### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # Claude How To
 
+[![Run in Smithery](https://smithery.ai/badge/skills/luongnv89)](https://smithery.ai/skills?ns=luongnv89&utm_source=github&utm_medium=badge)
+
+
 ## Contributors
 
 Thanks to everyone who has contributed to this project!


### PR DESCRIPTION
## Add skill discoverability badge

Your 3 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/luongnv89)](https://smithery.ai/skills?ns=luongnv89&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.