### PR TITLE
Add complete Vietnamese translation

### DIFF
--- a/01-slash-commands/README.vi.md
+++ b/01-slash-commands/README.vi.md
@@ -1,0 +1,579 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Slash Commands
+
+## Tổng quan
+
+Slash commands là các lệnh tắt để điều khiển hành vi của Claude trong một phiên làm việc. Chúng có một số loại:
+
+- **Lệnh tích hợp sẵn (Built-in)**: Do Claude Code cung cấp (`/help`, `/clear`, `/model`)
+- **Skills**: Lệnh do người dùng tự tạo dưới dạng file `SKILL.md` (`/optimize`, `/pr`)
+- **Lệnh từ Plugin**: Lệnh từ các plugin đã cài (`/frontend-design:frontend-design`)
+- **MCP prompts**: Lệnh từ MCP server (`/mcp__github__list_prs`)
+
+> **Ghi chú**: Custom slash commands đã được hợp nhất vào skills. Các file trong `.claude/commands/` vẫn hoạt động, nhưng skills (`.claude/skills/`) là cách tiếp cận được khuyến nghị hiện nay. Cả hai đều tạo ra lệnh `/tên-lệnh`. Xem [Hướng dẫn Skills](../03-skills/) để tham khảo đầy đủ.
+
+---
+
+## Tham khảo lệnh tích hợp sẵn
+
+Lệnh tích hợp sẵn là phím tắt cho các thao tác phổ biến. Hiện có **hơn 55 lệnh tích hợp** và **5 skill đi kèm**. Gõ `/` trong Claude Code để xem danh sách đầy đủ, hoặc gõ `/` kèm chữ cái để lọc.
+
+| Lệnh | Mục đích |
+|------|---------|
+| `/add-dir <đường-dẫn>` | Thêm thư mục làm việc |
+| `/agents` | Quản lý cấu hình agent |
+| `/branch [tên]` | Tách conversation sang phiên mới (bí danh: `/fork`). Lưu ý: `/fork` đổi tên thành `/branch` từ v2.1.77 |
+| `/btw <câu-hỏi>` | Đặt câu hỏi nhanh không lưu vào lịch sử |
+| `/chrome` | Cấu hình tích hợp Chrome browser |
+| `/clear` | Xóa conversation (bí danh: `/reset`, `/new`) |
+| `/color [màu\|default]` | Đặt màu thanh prompt |
+| `/compact [hướng-dẫn]` | Nén conversation với hướng dẫn tùy chọn |
+| `/config` | Mở Settings (bí danh: `/settings`) |
+| `/context` | Hiển thị mức sử dụng context dạng lưới màu |
+| `/copy [N]` | Copy phản hồi của assistant vào clipboard; `w` ghi ra file |
+| `/cost` | Hiện thống kê sử dụng token |
+| `/desktop` | Tiếp tục trong Desktop app (bí danh: `/app`) |
+| `/diff` | Xem diff tương tác cho các thay đổi chưa commit |
+| `/doctor` | Chẩn đoán tình trạng cài đặt |
+| `/effort [low\|medium\|high\|max\|auto]` | Đặt mức nỗ lực. `max` yêu cầu Opus 4.6 |
+| `/exit` | Thoát REPL (bí danh: `/quit`) |
+| `/export [tên-file]` | Xuất conversation hiện tại ra file hoặc clipboard |
+| `/extra-usage` | Cấu hình extra usage cho rate limits |
+| `/fast [on\|off]` | Bật/tắt fast mode |
+| `/feedback` | Gửi phản hồi (bí danh: `/bug`) |
+| `/help` | Hiển thị trợ giúp |
+| `/hooks` | Xem cấu hình hook |
+| `/ide` | Quản lý tích hợp IDE |
+| `/init` | Khởi tạo `CLAUDE.md`. Đặt `CLAUDE_CODE_NEW_INIT=true` để dùng luồng tương tác |
+| `/insights` | Tạo báo cáo phân tích phiên làm việc |
+| `/install-github-app` | Thiết lập GitHub Actions app |
+| `/install-slack-app` | Cài Slack app |
+| `/keybindings` | Mở cấu hình phím tắt |
+| `/login` | Chuyển tài khoản Anthropic |
+| `/logout` | Đăng xuất khỏi tài khoản Anthropic |
+| `/mcp` | Quản lý MCP server và OAuth |
+| `/memory` | Chỉnh sửa `CLAUDE.md`, bật/tắt auto-memory |
+| `/mobile` | QR code cho mobile app (bí danh: `/ios`, `/android`) |
+| `/model [model]` | Chọn model với mũi tên trái/phải để chỉnh effort |
+| `/passes` | Chia sẻ một tuần miễn phí Claude Code |
+| `/permissions` | Xem/cập nhật quyền (bí danh: `/allowed-tools`) |
+| `/plan [mô-tả]` | Vào planning mode |
+| `/plugin` | Quản lý plugin |
+| `/pr-comments [PR]` | Lấy comments của GitHub PR |
+| `/privacy-settings` | Cài đặt quyền riêng tư (chỉ Pro/Max) |
+| `/release-notes` | Xem changelog |
+| `/reload-plugins` | Tải lại các plugin đang hoạt động |
+| `/remote-control` | Điều khiển từ xa qua claude.ai (bí danh: `/rc`) |
+| `/remote-env` | Cấu hình môi trường remote mặc định |
+| `/rename [tên]` | Đổi tên phiên làm việc |
+| `/resume [phiên]` | Tiếp tục conversation (bí danh: `/continue`) |
+| `/review` | **Đã lỗi thời** — hãy cài plugin `code-review` thay thế |
+| `/rewind` | Tua lại conversation và/hoặc code (bí danh: `/checkpoint`) |
+| `/sandbox` | Bật/tắt sandbox mode |
+| `/schedule [mô-tả]` | Tạo/quản lý tác vụ theo lịch |
+| `/security-review` | Phân tích branch để tìm lỗ hổng bảo mật |
+| `/skills` | Liệt kê các skill đang có |
+| `/stats` | Trực quan hóa lượng dùng theo ngày, phiên, chuỗi ngày |
+| `/status` | Hiện phiên bản, model, tài khoản |
+| `/statusline` | Cấu hình thanh trạng thái |
+| `/tasks` | Liệt kê/quản lý background task |
+| `/terminal-setup` | Cấu hình phím tắt terminal |
+| `/theme` | Đổi theme màu sắc |
+| `/vim` | Bật/tắt chế độ Vim/Normal |
+| `/voice` | Bật/tắt voice dictation push-to-talk |
+
+### Skills đi kèm sẵn
+
+Các skill này đi kèm với Claude Code và được gọi như slash command:
+
+| Skill | Mục đích |
+|-------|---------|
+| `/batch <hướng-dẫn>` | Điều phối thay đổi song song quy mô lớn dùng worktrees |
+| `/claude-api` | Tải tham khảo Claude API cho ngôn ngữ dự án |
+| `/debug [mô-tả]` | Bật debug logging |
+| `/loop [khoảng-thời-gian] <prompt>` | Chạy prompt lặp lại theo khoảng thời gian |
+| `/simplify [trọng-tâm]` | Review các file đã thay đổi về chất lượng code |
+
+### Lệnh đã lỗi thời
+
+| Lệnh | Trạng thái |
+|------|-----------|
+| `/review` | Đã lỗi thời — thay bằng plugin `code-review` |
+| `/output-style` | Đã lỗi thời từ v2.1.73 |
+| `/fork` | Đổi tên thành `/branch` (bí danh vẫn hoạt động, v2.1.77) |
+
+### Thay đổi gần đây
+
+- `/fork` đổi tên thành `/branch`, `/fork` được giữ làm bí danh (v2.1.77)
+- `/output-style` đã lỗi thời (v2.1.73)
+- `/review` lỗi thời, thay bằng plugin `code-review`
+- Thêm lệnh `/effort` với level `max` yêu cầu Opus 4.6
+- Thêm lệnh `/voice` cho voice dictation push-to-talk
+- Thêm lệnh `/schedule` để tạo/quản lý tác vụ theo lịch
+- Thêm lệnh `/color` để tùy chỉnh màu thanh prompt
+- Bộ chọn `/model` hiện hiển thị nhãn dễ đọc (ví dụ: "Sonnet 4.6") thay vì model ID thô
+- `/resume` hỗ trợ bí danh `/continue`
+- MCP prompts có thể dùng dưới dạng lệnh `/mcp__<server>__<prompt>` (xem [MCP Prompts as Commands](#mcp-prompts-dưới-dạng-lệnh))
+
+---
+
+## Lệnh tùy chỉnh (nay là Skills)
+
+Custom slash commands đã được **hợp nhất vào skills**. Cả hai cách đều tạo lệnh có thể gọi bằng `/tên-lệnh`:
+
+| Cách | Vị trí | Trạng thái |
+|------|--------|-----------|
+| **Skills (Khuyến nghị)** | `.claude/skills/<tên>/SKILL.md` | Tiêu chuẩn hiện tại |
+| **Legacy Commands** | `.claude/commands/<tên>.md` | Vẫn hoạt động |
+
+Nếu một skill và một command có cùng tên, **skill được ưu tiên hơn**. Ví dụ: khi cả `.claude/commands/review.md` và `.claude/skills/review/SKILL.md` cùng tồn tại, phiên bản skill sẽ được dùng.
+
+### Lộ trình chuyển đổi
+
+Các file `.claude/commands/` hiện tại vẫn hoạt động bình thường. Để chuyển sang skills:
+
+**Trước (Command):**
+```
+.claude/commands/optimize.md
+```
+
+**Sau (Skill):**
+```
+.claude/skills/optimize/SKILL.md
+```
+
+### Tại sao dùng Skills?
+
+Skills có thêm nhiều tính năng so với legacy commands:
+
+- **Cấu trúc thư mục**: Đóng gói scripts, templates và file tham khảo
+- **Auto-invocation**: Claude có thể tự kích hoạt skill khi phù hợp (không cần gọi tay)
+- **Kiểm soát cách gọi**: Chọn ai được gọi — người dùng, Claude, hoặc cả hai
+- **Chạy trong subagent**: Chạy skill trong context riêng biệt với `context: fork`
+- **Tải thông tin dần**: Chỉ tải thêm file khi cần
+
+### Tạo lệnh tùy chỉnh dưới dạng Skill
+
+Tạo một thư mục với file `SKILL.md`:
+
+```bash
+mkdir -p .claude/skills/my-command
+```
+
+**File:** `.claude/skills/my-command/SKILL.md`
+
+```yaml
+---
+name: my-command
+description: Lệnh này làm gì và khi nào dùng
+---
+
+# My Command
+
+Hướng dẫn cho Claude thực hiện khi lệnh này được gọi.
+
+1. Bước đầu tiên
+2. Bước thứ hai
+3. Bước thứ ba
+```
+
+### Tham khảo Frontmatter
+
+> **Ghi chú**: Frontmatter là phần cấu hình ở đầu file, nằm giữa hai dấu `---`. Đây là nơi bạn định nghĩa tên lệnh, mô tả và các tùy chọn.
+
+| Trường | Mục đích | Mặc định |
+|--------|---------|---------|
+| `name` | Tên lệnh (thành `/tên`) | Tên thư mục |
+| `description` | Mô tả ngắn (giúp Claude biết khi nào nên dùng) | Đoạn văn đầu tiên |
+| `argument-hint` | Tham số dự kiến để auto-completion | Không có |
+| `allowed-tools` | Các tool lệnh được dùng không cần xin phép | Kế thừa |
+| `model` | Model cụ thể để dùng | Kế thừa |
+| `disable-model-invocation` | Nếu `true`, chỉ người dùng mới gọi được (Claude không tự gọi) | `false` |
+| `user-invocable` | Nếu `false`, ẩn khỏi menu `/` | `true` |
+| `context` | Đặt thành `fork` để chạy trong subagent riêng biệt | Không có |
+| `agent` | Loại agent khi dùng `context: fork` | `general-purpose` |
+| `hooks` | Hook riêng cho skill (PreToolUse, PostToolUse, Stop) | Không có |
+
+### Tham số (Arguments)
+
+Lệnh có thể nhận tham số truyền vào:
+
+**Tất cả tham số với `$ARGUMENTS`:**
+
+```yaml
+---
+name: fix-issue
+description: Sửa một GitHub issue theo số
+---
+
+Fix issue #$ARGUMENTS theo chuẩn code của chúng ta
+```
+
+Dùng: `/fix-issue 123` → `$ARGUMENTS` trở thành "123"
+
+**Từng tham số riêng lẻ với `$0`, `$1`, v.v.:**
+
+```yaml
+---
+name: review-pr
+description: Review một PR với mức độ ưu tiên
+---
+
+Review PR #$0 với mức ưu tiên $1
+```
+
+Dùng: `/review-pr 456 high` → `$0`="456", `$1`="high"
+
+### Ngữ cảnh động với Shell Commands
+
+Thực thi lệnh bash trước prompt bằng cách dùng `` !`lệnh` ``:
+
+```yaml
+---
+name: commit
+description: Tạo git commit với ngữ cảnh từ repository
+allowed-tools: Bash(git *)
+---
+
+## Ngữ cảnh hiện tại
+
+- Git status: !`git status`
+- Git diff: !`git diff HEAD`
+- Branch hiện tại: !`git branch --show-current`
+- Commit gần đây: !`git log --oneline -5`
+
+## Nhiệm vụ
+
+Dựa trên các thay đổi trên, tạo một git commit phù hợp.
+```
+
+> **Tại sao dùng `!`lệnh``?** Đây là cách để skill tự động lấy thông tin mới nhất từ hệ thống trước khi gửi cho Claude — thay vì phải tự nhập tay mỗi lần.
+
+### Tham chiếu file
+
+Đưa nội dung file vào prompt bằng `@`:
+
+```markdown
+Review cài đặt trong @src/utils/helpers.js
+So sánh @src/old-version.js với @src/new-version.js
+```
+
+---
+
+## Lệnh từ Plugin
+
+Plugin có thể cung cấp lệnh tùy chỉnh:
+
+```
+/tên-plugin:tên-lệnh
+```
+
+Hoặc chỉ `/tên-lệnh` khi không có xung đột tên.
+
+**Ví dụ:**
+```bash
+/frontend-design:frontend-design
+/commit-commands:commit
+```
+
+---
+
+## MCP Prompts dưới dạng lệnh
+
+MCP server có thể cung cấp prompts dưới dạng slash command:
+
+```
+/mcp__<tên-server>__<tên-prompt> [tham-số]
+```
+
+**Ví dụ:**
+```bash
+/mcp__github__list_prs
+/mcp__github__pr_review 456
+/mcp__jira__create_issue "Tiêu đề bug" high
+```
+
+### Cú pháp quyền MCP
+
+Kiểm soát quyền truy cập MCP server trong cài đặt permissions:
+
+- `mcp__github` — Truy cập toàn bộ GitHub MCP server
+- `mcp__github__*` — Truy cập wildcard tất cả tool
+- `mcp__github__get_issue` — Truy cập một tool cụ thể
+
+---
+
+## Kiến trúc lệnh
+
+```mermaid
+graph TD
+    A["Người dùng nhập: /tên-lệnh"] --> B{"Loại lệnh?"}
+    B -->|Built-in| C["Thực thi Built-in"]
+    B -->|Skill| D["Tải SKILL.md"]
+    B -->|Plugin| E["Tải Plugin Command"]
+    B -->|MCP| F["Thực thi MCP Prompt"]
+
+    D --> G["Phân tích Frontmatter"]
+    G --> H["Thay thế biến"]
+    H --> I["Chạy Shell Commands"]
+    I --> J["Gửi cho Claude"]
+    J --> K["Trả kết quả"]
+```
+
+## Vòng đời của lệnh
+
+```mermaid
+sequenceDiagram
+    participant User as Người dùng
+    participant Claude as Claude Code
+    participant FS as File System
+    participant CLI as Shell/Bash
+
+    User->>Claude: Gõ /optimize
+    Claude->>FS: Tìm trong .claude/skills/ và .claude/commands/
+    FS-->>Claude: Trả về optimize/SKILL.md
+    Claude->>Claude: Phân tích frontmatter
+    Claude->>CLI: Chạy các !`lệnh` để lấy ngữ cảnh động
+    CLI-->>Claude: Kết quả lệnh
+    Claude->>Claude: Thay thế $ARGUMENTS
+    Claude->>User: Xử lý prompt
+    Claude->>User: Trả kết quả
+```
+
+---
+
+## Các lệnh mẫu trong thư mục này
+
+Các lệnh mẫu dưới đây có thể được cài dưới dạng skill hoặc legacy command.
+
+### 1. `/optimize` — Tối ưu code
+
+Phân tích code để tìm vấn đề hiệu năng, memory leak và cơ hội tối ưu.
+
+**Cách dùng:**
+```
+/optimize
+[Dán code của bạn vào]
+```
+
+### 2. `/pr` — Chuẩn bị Pull Request
+
+Hướng dẫn qua checklist chuẩn bị PR bao gồm linting, testing và định dạng commit.
+
+**Cách dùng:**
+```
+/pr
+```
+
+### 3. `/generate-api-docs` — Tạo tài liệu API
+
+Tự động tạo tài liệu API đầy đủ từ source code.
+
+**Cách dùng:**
+```
+/generate-api-docs
+```
+
+### 4. `/commit` — Git commit với ngữ cảnh
+
+Tạo git commit với ngữ cảnh được lấy tự động từ repository.
+
+**Cách dùng:**
+```
+/commit [thông-điệp-tùy-chọn]
+```
+
+### 5. `/push-all` — Stage, Commit và Push
+
+Stage tất cả thay đổi, tạo commit và push lên remote với các kiểm tra an toàn.
+
+**Cách dùng:**
+```
+/push-all
+```
+
+**Kiểm tra an toàn tự động:**
+- Secrets: `.env*`, `*.key`, `*.pem`, `credentials.json`
+- API Keys: Phát hiện key thật so với placeholder
+- File lớn: `>10MB` mà không có Git LFS
+- Build artifacts: `node_modules/`, `dist/`, `__pycache__/`
+
+### 6. `/doc-refactor` — Tái cấu trúc tài liệu
+
+Tái cấu trúc tài liệu dự án cho rõ ràng và dễ tiếp cận hơn.
+
+**Cách dùng:**
+```
+/doc-refactor
+```
+
+### 7. `/setup-ci-cd` — Thiết lập CI/CD Pipeline
+
+Triển khai pre-commit hooks và GitHub Actions cho đảm bảo chất lượng.
+
+**Cách dùng:**
+```
+/setup-ci-cd
+```
+
+### 8. `/unit-test-expand` — Mở rộng test coverage
+
+Tăng test coverage bằng cách nhắm vào các nhánh chưa được test và edge case.
+
+**Cách dùng:**
+```
+/unit-test-expand
+```
+
+---
+
+## Cài đặt
+
+### Dưới dạng Skills (Khuyến nghị)
+
+Copy vào thư mục skills:
+
+```bash
+# Tạo thư mục skills
+mkdir -p .claude/skills
+
+# Với mỗi file lệnh, tạo thư mục skill tương ứng
+for cmd in optimize pr commit; do
+  mkdir -p .claude/skills/$cmd
+  cp 01-slash-commands/$cmd.md .claude/skills/$cmd/SKILL.md
+done
+```
+
+### Dưới dạng Legacy Commands
+
+Copy vào thư mục commands:
+
+```bash
+# Cho toàn dự án (cả team)
+mkdir -p .claude/commands
+cp 01-slash-commands/*.md .claude/commands/
+
+# Cho cá nhân
+mkdir -p ~/.claude/commands
+cp 01-slash-commands/*.md ~/.claude/commands/
+```
+
+---
+
+## Tự tạo lệnh của riêng bạn
+
+### Template Skill (Khuyến nghị)
+
+Tạo `.claude/skills/my-command/SKILL.md`:
+
+```yaml
+---
+name: my-command
+description: Lệnh này làm gì. Dùng khi [điều kiện kích hoạt].
+argument-hint: [tham-số-tùy-chọn]
+allowed-tools: Bash(npm *), Read, Grep
+---
+
+# Tiêu đề lệnh
+
+## Ngữ cảnh
+
+- Branch hiện tại: !`git branch --show-current`
+- File liên quan: @package.json
+
+## Hướng dẫn
+
+1. Bước đầu tiên
+2. Bước thứ hai với tham số: $ARGUMENTS
+3. Bước thứ ba
+
+## Định dạng output
+
+- Cách định dạng kết quả trả về
+- Cần bao gồm những gì
+```
+
+### Lệnh chỉ dành cho người dùng (Không tự kích hoạt)
+
+Dành cho lệnh có side effect mà Claude không nên tự kích hoạt:
+
+```yaml
+---
+name: deploy
+description: Deploy lên production
+disable-model-invocation: true
+allowed-tools: Bash(npm *), Bash(git *)
+---
+
+Deploy ứng dụng lên production:
+
+1. Chạy tests
+2. Build ứng dụng
+3. Push lên deployment target
+4. Xác nhận deployment thành công
+```
+
+---
+
+## Thực hành tốt nhất
+
+| Nên làm | Không nên làm |
+|---------|--------------|
+| Đặt tên rõ ràng, hướng hành động | Tạo lệnh cho tác vụ chỉ dùng một lần |
+| Viết `description` kèm điều kiện kích hoạt | Đưa logic phức tạp vào lệnh |
+| Giữ lệnh tập trung vào một nhiệm vụ | Hardcode thông tin nhạy cảm |
+| Dùng `disable-model-invocation` cho lệnh có side effect | Bỏ qua trường description |
+| Dùng `!` để lấy ngữ cảnh động | Giả định Claude đã biết trạng thái hiện tại |
+| Tổ chức file liên quan vào thư mục skill | Nhồi mọi thứ vào một file |
+
+---
+
+## Xử lý sự cố
+
+### Lệnh không tìm thấy
+
+**Giải pháp:**
+- Kiểm tra file có tại `.claude/skills/<tên>/SKILL.md` hoặc `.claude/commands/<tên>.md` không
+- Xác nhận trường `name` trong frontmatter khớp với tên lệnh mong đợi
+- Khởi động lại phiên Claude Code
+- Chạy `/help` để xem danh sách lệnh có sẵn
+
+### Lệnh không thực thi như mong đợi
+
+**Giải pháp:**
+- Thêm hướng dẫn cụ thể hơn
+- Đưa ví dụ vào file skill
+- Kiểm tra `allowed-tools` nếu dùng bash commands
+- Thử với input đơn giản trước
+
+### Xung đột Skill vs Command
+
+Nếu cả hai cùng tên, **skill được ưu tiên hơn**. Xóa một hoặc đổi tên.
+
+---
+
+## Hướng dẫn liên quan
+
+- **[Skills](../03-skills/)** — Tham khảo đầy đủ về skills (khả năng tự kích hoạt)
+- **[Memory](../02-memory/)** — Ngữ cảnh lâu dài với CLAUDE.md
+- **[Subagents](../04-subagents/)** — AI agent được ủy quyền
+- **[Plugins](../07-plugins/)** — Bộ lệnh đóng gói sẵn
+- **[Hooks](../06-hooks/)** — Tự động hóa theo sự kiện
+
+## Tài nguyên bổ sung
+
+- [Tài liệu Interactive Mode chính thức](https://code.claude.com/docs/en/interactive-mode) — Tham khảo lệnh tích hợp sẵn
+- [Tài liệu Skills chính thức](https://code.claude.com/docs/en/skills) — Tham khảo skills đầy đủ
+- [CLI Reference](https://code.claude.com/docs/en/cli-reference) — Tùy chọn command-line
+
+---
+
+*Thuộc chuỗi hướng dẫn [Claude How To](../)*
+
+---
+
+> **Ghi chú cho bản dịch tiếng Việt:** Bản gốc tiếng Anh luôn là nguồn chính xác nhất: [README.md](README.md).

--- a/02-memory/README.vi.md
+++ b/02-memory/README.vi.md
@@ -1,0 +1,880 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Hướng dẫn Memory
+
+Memory cho phép Claude lưu giữ ngữ cảnh giữa các phiên và cuộc hội thoại. Nó tồn tại dưới hai hình thức: tự động tổng hợp trong claude.ai, và dựa trên file CLAUDE.md trong Claude Code.
+
+---
+
+## Tổng quan
+
+Memory trong Claude Code cung cấp ngữ cảnh lâu dài được duy trì qua nhiều phiên và cuộc hội thoại. Khác với context window tạm thời, các file memory cho phép bạn:
+
+- Chia sẻ chuẩn dự án trong toàn team
+- Lưu trữ tùy chỉnh phát triển cá nhân
+- Duy trì quy tắc và cấu hình riêng cho từng thư mục
+- Import tài liệu bên ngoài vào ngữ cảnh
+- Quản lý phiên bản memory như một phần của dự án
+
+Hệ thống memory hoạt động theo nhiều cấp — từ tùy chỉnh cá nhân toàn cục xuống đến các thư mục con cụ thể — cho phép kiểm soát chi tiết những gì Claude nhớ và cách áp dụng kiến thức đó.
+
+---
+
+## Tham khảo nhanh lệnh Memory
+
+| Lệnh | Mục đích | Cách dùng | Khi nào dùng |
+|------|---------|-----------|-------------|
+| `/init` | Khởi tạo project memory | `/init` | Bắt đầu dự án mới, lần đầu tạo CLAUDE.md |
+| `/memory` | Chỉnh sửa file memory trong editor | `/memory` | Cập nhật lớn, tái tổ chức, xem nội dung |
+| Tiền tố `#` | Thêm nhanh một dòng vào memory | `# Quy tắc của bạn ở đây` | Thêm quy tắc nhanh trong lúc chat |
+| `# new rule into memory` | Thêm memory tường minh | `# new rule into memory`<br/>Quy tắc chi tiết | Thêm quy tắc nhiều dòng phức tạp |
+| `# remember this` | Memory bằng ngôn ngữ tự nhiên | `# remember this`<br/>Hướng dẫn | Cập nhật memory kiểu hội thoại |
+| `@path/to/file` | Import nội dung bên ngoài | `@README.md` hoặc `@docs/api.md` | Tham chiếu tài liệu đã có vào CLAUDE.md |
+
+---
+
+## Bắt đầu nhanh: Khởi tạo Memory
+
+### Lệnh `/init`
+
+Lệnh `/init` là cách nhanh nhất để thiết lập project memory trong Claude Code. Nó tạo file CLAUDE.md với tài liệu nền tảng của dự án.
+
+**Cách dùng:**
+
+```bash
+/init
+```
+
+**Nó làm gì:**
+
+- Tạo file CLAUDE.md mới trong dự án (thường tại `./CLAUDE.md` hoặc `./.claude/CLAUDE.md`)
+- Thiết lập quy ước và hướng dẫn dự án
+- Tạo nền tảng cho việc duy trì ngữ cảnh xuyên phiên
+- Cung cấp cấu trúc template để ghi lại chuẩn dự án
+
+**Chế độ tương tác nâng cao:** Đặt `CLAUDE_CODE_NEW_INIT=true` để bật luồng tương tác nhiều giai đoạn, hướng dẫn bạn từng bước thiết lập dự án:
+
+```bash
+CLAUDE_CODE_NEW_INIT=true claude
+/init
+```
+
+**Khi nào dùng `/init`:**
+
+- Bắt đầu dự án mới với Claude Code
+- Thiết lập chuẩn code và quy ước cho team
+- Tạo tài liệu về cấu trúc codebase
+- Thiết lập phân cấp memory cho phát triển cộng tác
+
+---
+
+### Cập nhật memory nhanh với `#`
+
+Bạn có thể thêm thông tin vào memory trong bất kỳ cuộc hội thoại nào bằng cách bắt đầu tin nhắn với `#`:
+
+**Cú pháp:**
+
+```markdown
+# Quy tắc hoặc hướng dẫn memory của bạn
+```
+
+**Ví dụ:**
+
+```markdown
+# Luôn dùng TypeScript strict mode trong dự án này
+
+# Ưu tiên async/await thay vì promise chains
+
+# Chạy npm test trước mỗi commit
+
+# Dùng kebab-case cho tên file
+```
+
+**Cách hoạt động:**
+
+1. Bắt đầu tin nhắn với `#` kèm quy tắc của bạn
+2. Claude nhận ra đây là yêu cầu cập nhật memory
+3. Claude hỏi bạn muốn cập nhật file memory nào (project hay personal)
+4. Quy tắc được thêm vào file CLAUDE.md phù hợp
+5. Các phiên sau tự động tải ngữ cảnh này
+
+**Các cách viết thay thế:**
+
+```markdown
+# new rule into memory
+Luôn validate user input với Zod schemas
+
+# remember this
+Dùng semantic versioning cho tất cả releases
+
+# add to memory
+Database migrations phải có thể hoàn tác
+```
+
+---
+
+### Lệnh `/memory`
+
+Lệnh `/memory` cho phép truy cập trực tiếp để chỉnh sửa các file CLAUDE.md trong phiên Claude Code. Nó mở file memory trong editor hệ thống để chỉnh sửa toàn diện.
+
+**Cách dùng:**
+
+```bash
+/memory
+```
+
+**Nó làm gì:**
+
+- Mở file memory trong editor mặc định của hệ thống
+- Cho phép thêm, sửa đổi và tái tổ chức nội dung lớn
+- Truy cập trực tiếp tất cả file memory trong phân cấp
+- Quản lý ngữ cảnh lâu dài xuyên phiên
+
+**Khi nào dùng `/memory`:**
+
+- Xem nội dung memory hiện tại
+- Cập nhật lớn cho chuẩn dự án
+- Tái tổ chức cấu trúc memory
+- Thêm tài liệu hoặc hướng dẫn chi tiết
+- Duy trì và cập nhật memory khi dự án phát triển
+
+**So sánh: `/memory` vs `/init`**
+
+| Khía cạnh | `/memory` | `/init` |
+|-----------|-----------|---------|
+| **Mục đích** | Chỉnh sửa file memory đã có | Khởi tạo CLAUDE.md mới |
+| **Khi nào dùng** | Cập nhật/chỉnh sửa ngữ cảnh | Bắt đầu dự án mới |
+| **Hành động** | Mở editor để thay đổi | Tạo template ban đầu |
+| **Workflow** | Bảo trì liên tục | Thiết lập một lần |
+
+**Ví dụ workflow:**
+
+```markdown
+# Mở memory để chỉnh sửa
+/memory
+
+# Claude hiển thị các lựa chọn:
+# 1. Managed Policy Memory
+# 2. Project Memory (./CLAUDE.md)
+# 3. User Memory (~/.claude/CLAUDE.md)
+# 4. Local Project Memory
+
+# Chọn tùy chọn 2 (Project Memory)
+# Editor mặc định mở với nội dung ./CLAUDE.md
+
+# Thực hiện thay đổi, lưu và đóng editor
+# Claude tự động tải lại memory đã cập nhật
+```
+
+**Dùng Memory Imports:**
+
+File CLAUDE.md hỗ trợ cú pháp `@path/to/file` để đưa nội dung bên ngoài vào:
+
+```markdown
+# Tài liệu dự án
+Xem @README.md để có tổng quan dự án
+Xem @package.json để biết các lệnh npm có sẵn
+Xem @docs/architecture.md để hiểu thiết kế hệ thống
+
+# Import từ thư mục home bằng đường dẫn tuyệt đối
+@~/.claude/my-project-instructions.md
+```
+
+**Tính năng import:**
+
+- Hỗ trợ cả đường dẫn tương đối và tuyệt đối
+- Import đệ quy được hỗ trợ với độ sâu tối đa 5 cấp
+- Import lần đầu từ vị trí bên ngoài sẽ hiện hộp thoại phê duyệt để bảo mật
+- Cú pháp `@` không được đánh giá bên trong code block (an toàn khi dùng làm ví dụ)
+- Giúp tránh trùng lặp bằng cách tham chiếu tài liệu đã có
+- Tự động đưa nội dung được tham chiếu vào ngữ cảnh của Claude
+
+---
+
+## Kiến trúc Memory
+
+Memory trong Claude Code theo hệ thống phân cấp, mỗi cấp phục vụ mục đích khác nhau:
+
+```mermaid
+graph TB
+    A["Phiên Claude"]
+    B["Input người dùng"]
+    C["Hệ thống Memory"]
+    D["Lưu trữ Memory"]
+
+    B -->|Người dùng cung cấp thông tin| C
+    C -->|Tổng hợp mỗi 24h| D
+    D -->|Tải tự động| A
+    A -->|Dùng ngữ cảnh| C
+```
+
+---
+
+## Phân cấp Memory trong Claude Code
+
+Claude Code dùng hệ thống memory phân cấp nhiều tầng. Các file memory được tải tự động khi Claude Code khởi động, file cấp cao hơn được ưu tiên hơn.
+
+**Phân cấp Memory đầy đủ (theo thứ tự ưu tiên):**
+
+1. **Managed Policy** — Hướng dẫn toàn tổ chức
+   - macOS: `/Library/Application Support/ClaudeCode/CLAUDE.md`
+   - Linux/WSL: `/etc/claude-code/CLAUDE.md`
+   - Windows: `C:\Program Files\ClaudeCode\CLAUDE.md`
+
+2. **Managed Drop-ins** — File policy ghép theo alphabet (v2.1.83+)
+   - Thư mục `managed-settings.d/` bên cạnh file CLAUDE.md chính sách
+   - Các file được ghép theo thứ tự alphabet để quản lý policy dạng module
+
+3. **Project Memory** — Ngữ cảnh chia sẻ cho team (có version control)
+   - `./.claude/CLAUDE.md` hoặc `./CLAUDE.md` (trong thư mục gốc repository)
+
+4. **Project Rules** — Quy tắc dự án theo chủ đề, dạng module
+   - `./.claude/rules/*.md`
+
+5. **User Memory** — Tùy chỉnh cá nhân (tất cả dự án)
+   - `~/.claude/CLAUDE.md`
+
+6. **User-Level Rules** — Quy tắc cá nhân (tất cả dự án)
+   - `~/.claude/rules/*.md`
+
+7. **Local Project Memory** — Tùy chỉnh cá nhân riêng cho dự án
+   - `./CLAUDE.local.md`
+
+> **Ghi chú**: `CLAUDE.local.md` không được đề cập trong [tài liệu chính thức](https://code.claude.com/docs/en/memory) tính đến tháng 3/2026. Nó vẫn có thể hoạt động như tính năng cũ. Với dự án mới, nên dùng `~/.claude/CLAUDE.md` (cấp người dùng) hoặc `.claude/rules/` (cấp dự án, phân vùng theo đường dẫn) thay thế.
+
+8. **Auto Memory** — Ghi chú và học hỏi tự động của Claude
+   - `~/.claude/projects/<project>/memory/`
+
+**Cách Claude tìm kiếm file Memory:**
+
+Claude tìm file memory theo thứ tự này, vị trí đầu tiên có ưu tiên cao hơn:
+
+```mermaid
+graph TD
+    A["Managed Policy<br/>/Library/.../ClaudeCode/CLAUDE.md"] -->|ưu tiên cao nhất| A2["Managed Drop-ins<br/>managed-settings.d/"]
+    A2 --> B["Project Memory<br/>./CLAUDE.md"]
+    B --> C["Project Rules<br/>./.claude/rules/*.md"]
+    C --> D["User Memory<br/>~/.claude/CLAUDE.md"]
+    D --> E["User Rules<br/>~/.claude/rules/*.md"]
+    E --> F["Local Project Memory<br/>./CLAUDE.local.md"]
+    F --> G["Auto Memory<br/>~/.claude/projects/.../memory/"]
+
+    B -->|imports| H["@docs/architecture.md"]
+    H -->|imports| I["@docs/api-standards.md"]
+
+    style A fill:#fce4ec,stroke:#333,color:#333
+    style A2 fill:#fce4ec,stroke:#333,color:#333
+    style B fill:#e1f5fe,stroke:#333,color:#333
+    style C fill:#e1f5fe,stroke:#333,color:#333
+    style D fill:#f3e5f5,stroke:#333,color:#333
+    style E fill:#f3e5f5,stroke:#333,color:#333
+    style F fill:#e8f5e9,stroke:#333,color:#333
+    style G fill:#fff3e0,stroke:#333,color:#333
+    style H fill:#e1f5fe,stroke:#333,color:#333
+    style I fill:#e1f5fe,stroke:#333,color:#333
+```
+
+---
+
+## Loại trừ CLAUDE.md với `claudeMdExcludes`
+
+Trong các monorepo lớn, một số file CLAUDE.md có thể không liên quan đến công việc hiện tại. Cài đặt `claudeMdExcludes` cho phép bỏ qua các file CLAUDE.md cụ thể để chúng không được tải vào ngữ cảnh:
+
+```jsonc
+// Trong ~/.claude/settings.json hoặc .claude/settings.json
+{
+  "claudeMdExcludes": [
+    "packages/legacy-app/CLAUDE.md",
+    "vendors/**/CLAUDE.md"
+  ]
+}
+```
+
+Pattern được so khớp với đường dẫn tương đối từ thư mục gốc dự án. Đặc biệt hữu ích cho:
+
+- Monorepo với nhiều sub-project, chỉ một số liên quan đến công việc hiện tại
+- Repository chứa file CLAUDE.md của thư viện hoặc bên thứ ba
+- Giảm nhiễu trong context window của Claude bằng cách loại trừ hướng dẫn cũ hoặc không liên quan
+
+---
+
+## Phân cấp File Settings
+
+Các cài đặt Claude Code (bao gồm `autoMemoryDirectory`, `claudeMdExcludes` và các cấu hình khác) được giải quyết từ phân cấp năm cấp, cấp cao hơn được ưu tiên hơn:
+
+| Cấp | Vị trí | Phạm vi |
+|-----|--------|---------|
+| 1 (Cao nhất) | Managed policy (cấp hệ thống) | Áp dụng bắt buộc toàn tổ chức |
+| 2 | `managed-settings.d/` (v2.1.83+) | Drop-in policy dạng module, ghép theo alphabet |
+| 3 | `~/.claude/settings.json` | Tùy chỉnh người dùng |
+| 4 | `.claude/settings.json` | Cấp dự án (commit vào git) |
+| 5 (Thấp nhất) | `.claude/settings.local.json` | Ghi đè cục bộ (git-ignored) |
+
+**Cấu hình theo nền tảng (v2.1.51+):**
+
+Cài đặt cũng có thể được cấu hình qua:
+- **macOS**: File Property list (plist)
+- **Windows**: Windows Registry
+
+Các cơ chế native này được đọc cùng với file JSON settings và tuân theo cùng quy tắc ưu tiên.
+
+---
+
+## Hệ thống Rules dạng Module
+
+Tạo rules có tổ chức, theo đường dẫn cụ thể bằng cấu trúc thư mục `.claude/rules/`. Rules có thể được định nghĩa ở cả cấp dự án và cấp người dùng:
+
+```
+your-project/
+├── .claude/
+│   ├── CLAUDE.md
+│   └── rules/
+│       ├── code-style.md
+│       ├── testing.md
+│       ├── security.md
+│       └── api/                  # Hỗ trợ thư mục con
+│           ├── conventions.md
+│           └── validation.md
+
+~/.claude/
+├── CLAUDE.md
+└── rules/                        # Rules cấp người dùng (tất cả dự án)
+    ├── personal-style.md
+    └── preferred-patterns.md
+```
+
+Rules được tìm kiếm đệ quy trong thư mục `rules/`, bao gồm cả thư mục con. Rules cấp người dùng tại `~/.claude/rules/` được tải trước rules cấp dự án, cho phép đặt mặc định cá nhân mà dự án có thể ghi đè.
+
+### Rules theo đường dẫn với YAML Frontmatter
+
+Định nghĩa rules chỉ áp dụng cho các đường dẫn file cụ thể:
+
+```markdown
+---
+paths: src/api/**/*.ts
+---
+
+# Quy tắc phát triển API
+
+- Tất cả API endpoint phải có validation input
+- Dùng Zod để validate schema
+- Ghi lại tất cả parameters và kiểu response
+- Bao gồm xử lý lỗi cho tất cả thao tác
+```
+
+**Ví dụ Glob Pattern:**
+
+- `**/*.ts` — Tất cả file TypeScript
+- `src/**/*` — Tất cả file trong src/
+- `src/**/*.{ts,tsx}` — Nhiều extension
+- `{src,lib}/**/*.ts, tests/**/*.test.ts` — Nhiều pattern
+
+### Thư mục con và Symlinks
+
+Rules trong `.claude/rules/` hỗ trợ hai tính năng tổ chức:
+
+- **Thư mục con**: Rules được tìm kiếm đệ quy, bạn có thể tổ chức theo chủ đề (ví dụ: `rules/api/`, `rules/testing/`, `rules/security/`)
+- **Symlinks**: Hỗ trợ symlink để chia sẻ rules giữa nhiều dự án. Ví dụ: bạn có thể symlink một file rule từ vị trí trung tâm vào thư mục `.claude/rules/` của từng dự án
+
+---
+
+## Bảng vị trí Memory
+
+| Vị trí | Phạm vi | Ưu tiên | Chia sẻ | Truy cập | Phù hợp nhất |
+|--------|---------|---------|---------|---------|-------------|
+| `/Library/Application Support/ClaudeCode/CLAUDE.md` (macOS) | Managed Policy | 1 (Cao nhất) | Tổ chức | Hệ thống | Chính sách toàn công ty |
+| `/etc/claude-code/CLAUDE.md` (Linux/WSL) | Managed Policy | 1 (Cao nhất) | Tổ chức | Hệ thống | Chuẩn tổ chức |
+| `C:\Program Files\ClaudeCode\CLAUDE.md` (Windows) | Managed Policy | 1 (Cao nhất) | Tổ chức | Hệ thống | Hướng dẫn doanh nghiệp |
+| `managed-settings.d/*.md` (cùng vị trí với policy) | Managed Drop-ins | 1.5 | Tổ chức | Hệ thống | File policy dạng module (v2.1.83+) |
+| `./CLAUDE.md` hoặc `./.claude/CLAUDE.md` | Project Memory | 2 | Team | Git | Chuẩn team, kiến trúc chung |
+| `./.claude/rules/*.md` | Project Rules | 3 | Team | Git | Rules theo đường dẫn, dạng module |
+| `~/.claude/CLAUDE.md` | User Memory | 4 | Cá nhân | Filesystem | Tùy chỉnh cá nhân (tất cả dự án) |
+| `~/.claude/rules/*.md` | User Rules | 5 | Cá nhân | Filesystem | Rules cá nhân (tất cả dự án) |
+| `./CLAUDE.local.md` | Project Local | 6 | Cá nhân | Git (ignored) | Tùy chỉnh cá nhân riêng cho dự án |
+| `~/.claude/projects/<project>/memory/` | Auto Memory | 7 (Thấp nhất) | Cá nhân | Filesystem | Ghi chú và học hỏi tự động của Claude |
+
+---
+
+## Vòng đời cập nhật Memory
+
+Đây là cách các cập nhật memory di chuyển qua các phiên Claude Code:
+
+```mermaid
+sequenceDiagram
+    participant User as Người dùng
+    participant Claude as Claude Code
+    participant Editor as File System
+    participant Memory as CLAUDE.md
+
+    User->>Claude: "Nhớ nhé: dùng async/await"
+    Claude->>User: "Lưu vào file memory nào?"
+    User->>Claude: "Project memory"
+    Claude->>Editor: Mở ~/.claude/settings.json
+    Claude->>Memory: Ghi vào ./CLAUDE.md
+    Memory-->>Claude: File đã lưu
+    Claude->>Claude: Tải lại memory đã cập nhật
+    Claude-->>User: "Đã lưu memory!"
+```
+
+---
+
+## Auto Memory
+
+Auto memory là thư mục lâu dài nơi Claude tự động ghi lại những gì học được, các pattern và insight trong quá trình làm việc với dự án. Khác với file CLAUDE.md do bạn viết và duy trì thủ công, auto memory được Claude tự ghi trong các phiên làm việc.
+
+> **Hiểu đơn giản**: CLAUDE.md là "notepad" bạn viết cho Claude đọc. Auto Memory là "nhật ký" Claude tự ghi lại những gì nó học được từ dự án của bạn.
+
+### Cách Auto Memory hoạt động
+
+- **Vị trí**: `~/.claude/projects/<project>/memory/`
+- **Điểm vào**: `MEMORY.md` là file chính trong thư mục auto memory
+- **File theo chủ đề**: Các file bổ sung tùy chọn cho chủ đề cụ thể (ví dụ: `debugging.md`, `api-conventions.md`)
+- **Cách tải**: 200 dòng đầu của `MEMORY.md` được tải vào system prompt khi bắt đầu phiên. File theo chủ đề được tải theo yêu cầu, không tải khi khởi động
+- **Đọc/ghi**: Claude đọc và ghi file memory trong phiên khi phát hiện pattern và kiến thức riêng của dự án
+
+### Kiến trúc Auto Memory
+
+```mermaid
+graph TD
+    A["Phiên Claude bắt đầu"] --> B["Tải MEMORY.md<br/>(200 dòng đầu)"]
+    B --> C["Phiên đang hoạt động"]
+    C --> D["Claude phát hiện<br/>pattern & insight"]
+    D --> E{"Ghi vào<br/>auto memory"}
+    E -->|Ghi chú chung| F["MEMORY.md"]
+    E -->|Theo chủ đề| G["debugging.md"]
+    E -->|Theo chủ đề| H["api-conventions.md"]
+    C --> I["Tải file chủ đề<br/>theo yêu cầu"]
+    I --> C
+
+    style A fill:#e1f5fe,stroke:#333,color:#333
+    style B fill:#e1f5fe,stroke:#333,color:#333
+    style C fill:#e8f5e9,stroke:#333,color:#333
+    style D fill:#f3e5f5,stroke:#333,color:#333
+    style E fill:#fff3e0,stroke:#333,color:#333
+    style F fill:#fce4ec,stroke:#333,color:#333
+    style G fill:#fce4ec,stroke:#333,color:#333
+    style H fill:#fce4ec,stroke:#333,color:#333
+    style I fill:#f3e5f5,stroke:#333,color:#333
+```
+
+### Cấu trúc thư mục Auto Memory
+
+```
+~/.claude/projects/<project>/memory/
+├── MEMORY.md              # Điểm vào (200 dòng đầu tải khi khởi động)
+├── debugging.md           # File chủ đề (tải theo yêu cầu)
+├── api-conventions.md     # File chủ đề (tải theo yêu cầu)
+└── testing-patterns.md    # File chủ đề (tải theo yêu cầu)
+```
+
+### Yêu cầu phiên bản
+
+Auto memory yêu cầu **Claude Code v2.1.59 trở lên**. Nếu đang dùng phiên bản cũ hơn, hãy nâng cấp trước:
+
+```bash
+npm install -g @anthropic-ai/claude-code@latest
+```
+
+### Thư mục Auto Memory tùy chỉnh
+
+Mặc định, auto memory được lưu tại `~/.claude/projects/<project>/memory/`. Bạn có thể đổi vị trí này bằng cài đặt `autoMemoryDirectory` (có từ **v2.1.74**):
+
+```jsonc
+// Trong ~/.claude/settings.json hoặc .claude/settings.local.json (chỉ settings người dùng/local)
+{
+  "autoMemoryDirectory": "/path/to/custom/memory/directory"
+}
+```
+
+> **Ghi chú**: `autoMemoryDirectory` chỉ có thể đặt trong settings cấp người dùng (`~/.claude/settings.json`) hoặc local (`.claude/settings.local.json`), không đặt trong settings dự án hoặc managed policy.
+
+Hữu ích khi bạn muốn:
+- Lưu auto memory ở vị trí chia sẻ hoặc đồng bộ
+- Tách auto memory khỏi thư mục cấu hình Claude mặc định
+- Dùng đường dẫn riêng cho dự án ngoài phân cấp mặc định
+
+### Chia sẻ Worktree và Repository
+
+Tất cả worktree và thư mục con trong cùng một git repository chia sẻ một thư mục auto memory duy nhất. Điều này nghĩa là chuyển đổi giữa các worktree hoặc làm việc trong các thư mục con khác nhau của cùng một repo đều đọc và ghi vào cùng một file memory.
+
+### Memory của Subagent
+
+Subagent (được tạo qua tool Task hoặc thực thi song song) có thể có ngữ cảnh memory riêng. Dùng trường `memory` trong frontmatter của định nghĩa subagent để chỉ định phạm vi memory nào cần tải:
+
+```yaml
+memory: user      # Chỉ tải memory cấp người dùng
+memory: project   # Chỉ tải memory cấp dự án
+memory: local     # Chỉ tải memory local
+```
+
+Điều này cho phép subagent hoạt động với ngữ cảnh tập trung thay vì kế thừa toàn bộ phân cấp memory.
+
+### Kiểm soát Auto Memory
+
+Auto memory có thể kiểm soát qua biến môi trường `CLAUDE_CODE_DISABLE_AUTO_MEMORY`:
+
+| Giá trị | Hành vi |
+|---------|---------|
+| `0` | Bật auto memory **bắt buộc** |
+| `1` | Tắt auto memory **bắt buộc** |
+| *(không đặt)* | Hành vi mặc định (auto memory được bật) |
+
+```bash
+# Tắt auto memory cho một phiên
+CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 claude
+
+# Bật auto memory rõ ràng
+CLAUDE_CODE_DISABLE_AUTO_MEMORY=0 claude
+```
+
+---
+
+## Thêm thư mục với `--add-dir`
+
+Flag `--add-dir` cho phép Claude Code tải file CLAUDE.md từ các thư mục bổ sung ngoài thư mục làm việc hiện tại. Hữu ích cho monorepo hoặc setup đa dự án khi ngữ cảnh từ thư mục khác cũng có liên quan.
+
+Để bật tính năng này, đặt biến môi trường:
+
+```bash
+CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1
+```
+
+Sau đó khởi động Claude Code với flag:
+
+```bash
+claude --add-dir /path/to/other/project
+```
+
+Claude sẽ tải CLAUDE.md từ thư mục bổ sung đó cùng với các file memory từ thư mục làm việc hiện tại.
+
+---
+
+## Ví dụ thực tế
+
+### Ví dụ 1: Cấu trúc Project Memory
+
+**File:** `./CLAUDE.md`
+
+```markdown
+# Cấu hình dự án
+
+## Tổng quan dự án
+- **Tên**: Nền tảng E-commerce
+- **Tech Stack**: Node.js, PostgreSQL, React 18, Docker
+- **Quy mô team**: 5 lập trình viên
+- **Deadline**: Q4 2025
+
+## Kiến trúc
+@docs/architecture.md
+@docs/api-standards.md
+@docs/database-schema.md
+
+## Chuẩn phát triển
+
+### Phong cách code
+- Dùng Prettier để format
+- Dùng ESLint với config airbnb
+- Độ dài dòng tối đa: 100 ký tự
+- Thụt lề 2 khoảng trắng
+
+### Quy ước đặt tên
+- **File**: kebab-case (user-controller.js)
+- **Class**: PascalCase (UserService)
+- **Hàm/Biến**: camelCase (getUserById)
+- **Hằng số**: UPPER_SNAKE_CASE (API_BASE_URL)
+- **Bảng Database**: snake_case (user_accounts)
+
+### Git Workflow
+- Tên branch: `feature/mô-tả` hoặc `fix/mô-tả`
+- Commit message: Theo conventional commits
+- Bắt buộc PR trước khi merge
+- Tất cả CI/CD checks phải pass
+- Tối thiểu 1 approval
+
+### Yêu cầu kiểm thử
+- Tối thiểu 80% code coverage
+- Tất cả luồng quan trọng phải có test
+- Dùng Jest cho unit test
+- Dùng Cypress cho E2E test
+- Tên file test: `*.test.ts` hoặc `*.spec.ts`
+```
+
+### Ví dụ 2: Memory theo thư mục
+
+**File:** `./src/api/CLAUDE.md`
+
+```markdown
+# Chuẩn Module API
+
+File này ghi đè root CLAUDE.md cho mọi thứ trong /src/api/
+
+## Chuẩn riêng cho API
+
+### Validation Request
+- Dùng Zod để validate schema
+- Luôn validate input
+- Trả về 400 kèm lỗi validation
+- Bao gồm chi tiết lỗi theo từng field
+
+### Xác thực
+- Tất cả endpoint yêu cầu JWT token
+- Token trong Authorization header
+- Token hết hạn sau 24 giờ
+- Triển khai cơ chế refresh token
+```
+
+### Ví dụ 3: Personal Memory
+
+**File:** `~/.claude/CLAUDE.md`
+
+```markdown
+# Tùy chỉnh phát triển của tôi
+
+## Về tôi
+- **Trình độ**: 8 năm kinh nghiệm full-stack
+- **Ngôn ngữ ưa thích**: TypeScript, Python
+- **Phong cách giao tiếp**: Trực tiếp, có ví dụ
+- **Cách học**: Sơ đồ trực quan kèm code
+
+## Tùy chỉnh code
+
+### Xử lý lỗi
+Tôi ưa thích xử lý lỗi rõ ràng với try-catch và thông báo lỗi có ý nghĩa.
+Tránh lỗi chung chung. Luôn log lỗi để debug.
+
+### Bình luận
+Dùng comment để giải thích TẠI SAO, không phải LÀM GÌ. Code phải tự giải thích được.
+
+### Kiểm thử
+Tôi ưa thích TDD (test-driven development).
+Viết test trước, sau đó mới implement.
+```
+
+### Ví dụ 4: Cập nhật Memory trong phiên làm việc
+
+Bạn có thể thêm quy tắc mới vào memory trong phiên Claude Code đang hoạt động:
+
+#### Cách 1: Yêu cầu trực tiếp
+
+```markdown
+Người dùng: Nhớ rằng tôi ưa dùng React hooks thay vì class components
+           cho tất cả component mới.
+
+Claude: Tôi đang thêm vào memory. Lưu vào file memory nào?
+        1. Project memory (./CLAUDE.md)
+        2. Personal memory (~/.claude/CLAUDE.md)
+
+Người dùng: Project memory
+
+Claude: ✅ Đã lưu memory!
+
+Đã thêm vào ./CLAUDE.md:
+---
+
+### Phát triển Component
+- Dùng functional components với React Hooks
+- Ưu tiên hooks hơn class components
+- Custom hooks cho logic tái sử dụng
+```
+
+#### Cách 2: Dùng pattern "# new rule into memory"
+
+```markdown
+Người dùng: # new rule into memory
+            Luôn validate user input với Zod schemas trước khi xử lý.
+
+Claude: Tôi đang lưu quy tắc này. Dùng file memory nào?
+        1. Project memory (./CLAUDE.md)
+        2. Personal memory (~/.claude/CLAUDE.md)
+
+Người dùng: Project memory
+
+Claude: ✅ Đã lưu memory!
+```
+
+#### Mẹo khi thêm Memory
+
+- Viết quy tắc cụ thể và có thể hành động được
+- Nhóm các quy tắc liên quan dưới cùng một tiêu đề section
+- Cập nhật section hiện có thay vì tạo nội dung trùng lặp
+- Chọn phạm vi memory phù hợp (project hay personal)
+
+---
+
+## So sánh tính năng Memory
+
+| Tính năng | Claude Web/Desktop | Claude Code (CLAUDE.md) |
+|-----------|-------------------|------------------------|
+| Tự động tổng hợp | ✅ Mỗi 24h | ❌ Thủ công |
+| Xuyên dự án | ✅ Dùng chung | ❌ Riêng từng dự án |
+| Truy cập team | ✅ Dự án chia sẻ | ✅ Theo dõi qua Git |
+| Tìm kiếm | ✅ Tích hợp sẵn | ✅ Qua `/memory` |
+| Chỉnh sửa được | ✅ Trong chat | ✅ Chỉnh sửa file trực tiếp |
+| Import/Export | ✅ Có | ✅ Copy/paste |
+| Lâu dài | ✅ 24h+ | ✅ Vô thời hạn |
+
+---
+
+## Thực hành tốt nhất
+
+### Nên làm — Những gì nên đưa vào
+
+- **Cụ thể và chi tiết**: Dùng hướng dẫn rõ ràng thay vì mơ hồ
+  - ✅ Tốt: "Dùng thụt lề 2 khoảng trắng cho tất cả file JavaScript"
+  - ❌ Tránh: "Tuân theo best practices"
+
+- **Có tổ chức**: Cấu trúc file memory với sections và tiêu đề markdown rõ ràng
+
+- **Dùng đúng cấp phân cấp**:
+  - **Managed policy**: Chính sách toàn công ty, chuẩn bảo mật, yêu cầu tuân thủ
+  - **Project memory**: Chuẩn team, kiến trúc, quy ước code (commit vào git)
+  - **User memory**: Tùy chỉnh cá nhân, phong cách giao tiếp, lựa chọn công cụ
+  - **Directory memory**: Quy tắc và ghi đè riêng cho module đó
+
+- **Tận dụng imports**: Dùng cú pháp `@path/to/file` để tham chiếu tài liệu đã có
+  - Hỗ trợ đến 5 cấp lồng nhau đệ quy
+  - Tránh trùng lặp giữa các file memory
+  - Ví dụ: `Xem @README.md để có tổng quan dự án`
+
+- **Ghi lại lệnh hay dùng**: Bao gồm các lệnh bạn dùng thường xuyên để tiết kiệm thời gian
+
+- **Version control project memory**: Commit file CLAUDE.md cấp dự án vào git để cả team cùng hưởng lợi
+
+- **Xem lại định kỳ**: Cập nhật memory thường xuyên khi dự án phát triển và yêu cầu thay đổi
+
+- **Cung cấp ví dụ cụ thể**: Bao gồm đoạn code và tình huống cụ thể
+
+### Không nên làm — Những gì cần tránh
+
+- **Không lưu secrets**: Không bao giờ đưa API key, mật khẩu, token hay thông tin đăng nhập vào
+
+- **Không đưa dữ liệu nhạy cảm**: Không có PII, thông tin riêng tư hay bí mật độc quyền
+
+- **Không trùng lặp nội dung**: Dùng import (`@path`) để tham chiếu tài liệu thay vì sao chép
+
+- **Không mơ hồ**: Tránh phát biểu chung chung như "tuân theo best practices" hay "viết code tốt"
+
+- **Không quá dài**: Giữ file memory riêng lẻ tập trung và dưới 500 dòng
+
+- **Không tổ chức quá mức**: Dùng phân cấp có chiến lược; không tạo quá nhiều ghi đè thư mục con
+
+- **Không quên cập nhật**: Memory cũ có thể gây nhầm lẫn và thực hành lỗi thời
+
+- **Không vượt giới hạn lồng nhau**: Import memory hỗ trợ tối đa 5 cấp lồng nhau
+
+---
+
+## Hướng dẫn cài đặt
+
+### Thiết lập Project Memory
+
+#### Cách 1: Dùng lệnh `/init` (Khuyến nghị)
+
+1. **Điều hướng đến thư mục dự án:**
+   ```bash
+   cd /path/to/your/project
+   ```
+
+2. **Chạy lệnh init trong Claude Code:**
+   ```bash
+   /init
+   ```
+
+3. **Claude tạo và điền vào CLAUDE.md** với cấu trúc template
+
+4. **Tùy chỉnh file đã tạo** cho phù hợp với dự án của bạn
+
+5. **Commit vào git:**
+   ```bash
+   git add CLAUDE.md
+   git commit -m "Initialize project memory with /init"
+   ```
+
+#### Cách 2: Tạo thủ công
+
+1. **Tạo CLAUDE.md trong thư mục gốc dự án:**
+   ```bash
+   cd /path/to/your/project
+   touch CLAUDE.md
+   ```
+
+2. **Thêm chuẩn dự án và commit:**
+   ```bash
+   git add CLAUDE.md
+   git commit -m "Add project memory configuration"
+   ```
+
+#### Cách 3: Cập nhật nhanh với `#`
+
+Khi CLAUDE.md đã tồn tại, thêm quy tắc nhanh trong lúc chat:
+
+```markdown
+# Dùng semantic versioning cho tất cả releases
+
+# Luôn chạy test trước khi commit
+
+# Ưa thích composition hơn inheritance
+```
+
+Claude sẽ hỏi bạn muốn cập nhật file memory nào.
+
+### Thiết lập Personal Memory
+
+```bash
+# Tạo thư mục .claude
+mkdir -p ~/.claude
+
+# Tạo personal CLAUDE.md
+touch ~/.claude/CLAUDE.md
+
+# Thêm tùy chỉnh của bạn vào file
+```
+
+### Thiết lập Memory theo thư mục
+
+```bash
+# Tạo memory cho thư mục cụ thể
+mkdir -p /path/to/directory/.claude
+touch /path/to/directory/CLAUDE.md
+
+# Commit vào version control
+git add /path/to/directory/CLAUDE.md
+git commit -m "Add [directory] memory configuration"
+```
+
+### Xác nhận thiết lập
+
+```bash
+# Kiểm tra vị trí memory
+ls -la ./CLAUDE.md           # Project memory
+ls -la ~/.claude/CLAUDE.md   # Personal memory
+```
+
+Claude Code sẽ tự động tải các file này khi bắt đầu phiên mới.
+
+---
+
+## Tài liệu chính thức
+
+- **[Memory Documentation](https://code.claude.com/docs/en/memory)** — Tham khảo đầy đủ hệ thống memory
+- **[Slash Commands Reference](https://code.claude.com/docs/en/interactive-mode)** — Tất cả lệnh tích hợp bao gồm `/init` và `/memory`
+- **[CLI Reference](https://code.claude.com/docs/en/cli-reference)** — Tài liệu command-line interface
+
+---
+
+## Điểm tích hợp liên quan
+
+- [MCP Protocol](../05-mcp/) — Truy cập dữ liệu thời gian thực bên cạnh memory
+- [Slash Commands](../01-slash-commands/) — Phím tắt riêng cho phiên
+- [Skills](../03-skills/) — Workflow tự động với ngữ cảnh memory
+
+---
+
+*Thuộc chuỗi hướng dẫn [Claude How To](../)*
+
+---
+
+> **Ghi chú cho bản dịch tiếng Việt:** Bản gốc tiếng Anh luôn là nguồn chính xác nhất: [README.md](README.md).

--- a/03-skills/README.vi.md
+++ b/03-skills/README.vi.md
@@ -372,7 +372,7 @@ Skill này cung cấp khả năng review code toàn diện tập trung vào:
    - Độ phức tạp Cyclomatic
    - Type safety
 
-## Template Review
+## Mẫu Review
 
 Với mỗi đoạn code được review, cung cấp:
 

--- a/03-skills/README.vi.md
+++ b/03-skills/README.vi.md
@@ -1,0 +1,796 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Hướng dẫn Agent Skills
+
+Agent Skills (kỹ năng tác nhân) là các khả năng có thể tái sử dụng, lưu trữ trên filesystem, giúp mở rộng chức năng của Claude. Chúng đóng gói chuyên môn theo lĩnh vực, quy trình làm việc và các thực hành tốt nhất thành các thành phần có thể khám phá tự động mà Claude tự nhận ra khi cần.
+
+## Tổng quan
+
+**Agent Skills** là các khả năng dạng module, biến đổi các tác nhân đa năng thành chuyên gia. Khác với prompts (hướng dẫn cấp hội thoại cho các tác vụ một lần), Skills được tải theo nhu cầu và loại bỏ việc phải cung cấp hướng dẫn lặp đi lặp lại qua nhiều cuộc hội thoại.
+
+### Lợi ích chính
+
+- **Chuyên môn hóa Claude**: Điều chỉnh khả năng cho các tác vụ theo lĩnh vực cụ thể
+- **Giảm lặp lại**: Tạo một lần, dùng tự động qua nhiều hội thoại
+- **Kết hợp khả năng**: Ghép nhiều Skills để xây dựng quy trình phức tạp
+- **Mở rộng quy mô**: Tái sử dụng skills qua nhiều dự án và nhóm
+- **Duy trì chất lượng**: Nhúng trực tiếp các thực hành tốt nhất vào quy trình làm việc
+
+Skills tuân theo tiêu chuẩn mở [Agent Skills](https://agentskills.io), hoạt động trên nhiều công cụ AI. Claude Code mở rộng tiêu chuẩn này với các tính năng bổ sung như kiểm soát gọi skill, thực thi subagent và chèn ngữ cảnh động.
+
+> **Lưu ý**: Slash commands tùy chỉnh đã được tích hợp vào skills. Các file `.claude/commands/` vẫn hoạt động và hỗ trợ các trường frontmatter tương tự. Skills được khuyến nghị cho việc phát triển mới. Khi cả hai tồn tại cùng đường dẫn (ví dụ: `.claude/commands/review.md` và `.claude/skills/review/SKILL.md`), skill sẽ được ưu tiên.
+
+## Cách Skills hoạt động: Tiết lộ dần dần (Progressive Disclosure)
+
+Skills sử dụng kiến trúc **tiết lộ dần dần** — Claude tải thông tin theo từng giai đoạn khi cần, thay vì tiêu thụ ngữ cảnh ngay từ đầu. Điều này cho phép quản lý ngữ cảnh hiệu quả trong khi vẫn duy trì khả năng mở rộng không giới hạn.
+
+### Ba cấp độ tải
+
+```mermaid
+graph TB
+    subgraph "Cấp 1: Metadata (Luôn tải)"
+        A["YAML Frontmatter"]
+        A1["~100 tokens mỗi skill"]
+        A2["name + description"]
+    end
+
+    subgraph "Cấp 2: Hướng dẫn (Khi được kích hoạt)"
+        B["Nội dung SKILL.md"]
+        B1["Dưới 5k tokens"]
+        B2["Quy trình & hướng dẫn"]
+    end
+
+    subgraph "Cấp 3: Tài nguyên (Khi cần)
+        C["File đi kèm"]
+        C1["Thực tế không giới hạn"]
+        C2["Scripts, templates, docs"]
+    end
+
+    A --> B
+    B --> C
+```
+
+| Cấp độ | Khi nào tải | Chi phí token | Nội dung |
+|--------|------------|--------------|---------|
+| **Cấp 1: Metadata** | Luôn luôn (lúc khởi động) | ~100 tokens mỗi Skill | `name` và `description` từ YAML frontmatter |
+| **Cấp 2: Hướng dẫn** | Khi Skill được kích hoạt | Dưới 5k tokens | Nội dung SKILL.md với hướng dẫn |
+| **Cấp 3+: Tài nguyên** | Khi cần | Thực tế không giới hạn | File đi kèm được thực thi qua bash mà không tải nội dung vào ngữ cảnh |
+
+Điều này có nghĩa bạn có thể cài nhiều Skills mà không tốn ngữ cảnh — Claude chỉ biết mỗi Skill tồn tại và khi nào dùng nó cho đến khi thực sự được kích hoạt.
+
+## Quy trình tải Skill
+
+```mermaid
+sequenceDiagram
+    participant User as Người dùng
+    participant Claude as Claude
+    participant System as Hệ thống
+    participant Skill as Skill
+
+    User->>Claude: "Review code này về bảo mật đi"
+    Claude->>System: Kiểm tra skills có sẵn (metadata)
+    System-->>Claude: Mô tả Skill đã tải lúc khởi động
+    Claude->>Claude: Khớp yêu cầu với mô tả skill
+    Claude->>Skill: bash: read code-review/SKILL.md
+    Skill-->>Claude: Hướng dẫn tải vào ngữ cảnh
+    Claude->>Claude: Xác định: Cần templates không?
+    Claude->>Skill: bash: read templates/checklist.md
+    Skill-->>Claude: Template đã tải
+    Claude->>Claude: Thực thi hướng dẫn skill
+    Claude->>User: Kết quả review code toàn diện
+```
+
+## Loại & Vị trí Skills
+
+| Loại | Vị trí | Phạm vi | Chia sẻ được | Tốt nhất cho |
+|------|--------|---------|-------------|------------|
+| **Enterprise** | Cài đặt quản lý | Tất cả user tổ chức | Có | Tiêu chuẩn toàn tổ chức |
+| **Cá nhân** | `~/.claude/skills/<tên-skill>/SKILL.md` | Cá nhân | Không | Quy trình cá nhân |
+| **Dự án** | `.claude/skills/<tên-skill>/SKILL.md` | Nhóm | Có (qua git) | Tiêu chuẩn nhóm |
+| **Plugin** | `<plugin>/skills/<tên-skill>/SKILL.md` | Nơi được bật | Tùy | Đi kèm với plugins |
+
+Khi skills có cùng tên ở nhiều cấp, vị trí ưu tiên cao hơn thắng: **enterprise > cá nhân > dự án**. Plugin skills dùng namespace `tên-plugin:tên-skill`, nên không thể xung đột.
+
+### Khám phá tự động
+
+**Thư mục lồng nhau**: Khi bạn làm việc với file trong thư mục con, Claude Code tự động khám phá skills từ các thư mục `.claude/skills/` lồng nhau. Ví dụ, nếu bạn đang chỉnh sửa file trong `packages/frontend/`, Claude Code cũng tìm skills trong `packages/frontend/.claude/skills/`. Hỗ trợ cấu trúc monorepo nơi các package có skills riêng.
+
+**Thư mục `--add-dir`**: Skills từ các thư mục được thêm qua `--add-dir` được tải tự động với phát hiện thay đổi trực tiếp. Mọi chỉnh sửa file skill trong các thư mục đó có hiệu lực ngay mà không cần khởi động lại Claude Code.
+
+**Ngân sách mô tả**: Mô tả Skill (metadata Cấp 1) bị giới hạn ở **2% cửa sổ ngữ cảnh** (dự phòng: **16.000 ký tự**). Nếu bạn cài nhiều skills, một số có thể bị loại trừ. Chạy `/context` để kiểm tra cảnh báo. Ghi đè ngân sách bằng biến môi trường `SLASH_COMMAND_TOOL_CHAR_BUDGET`.
+
+## Tạo Skills tùy chỉnh
+
+### Cấu trúc thư mục cơ bản
+
+```
+my-skill/
+├── SKILL.md           # Hướng dẫn chính (bắt buộc)
+├── template.md        # Template để Claude điền vào
+├── examples/
+│   └── sample.md      # Ví dụ output thể hiện định dạng mong đợi
+└── scripts/
+    └── validate.sh    # Script Claude có thể thực thi
+```
+
+### Định dạng SKILL.md
+
+```yaml
+---
+name: tên-skill-của-bạn
+description: Mô tả ngắn gọn Skill này làm gì và khi nào dùng
+---
+
+# Tên Skill của bạn
+
+## Hướng dẫn
+Cung cấp hướng dẫn rõ ràng, từng bước cho Claude.
+
+## Ví dụ
+Hiển thị các ví dụ cụ thể về cách dùng Skill này.
+```
+
+### Các trường bắt buộc
+
+- **name**: chỉ chữ thường, số, dấu gạch ngang (tối đa 64 ký tự). Không được chứa "anthropic" hoặc "claude".
+- **description**: Skill làm gì VÀ khi nào dùng (tối đa 1024 ký tự). Đây là yếu tố quan trọng để Claude biết khi nào kích hoạt skill.
+
+### Các trường frontmatter tùy chọn
+
+```yaml
+---
+name: my-skill
+description: Skill này làm gì và khi nào dùng
+argument-hint: "[tên-file] [định-dạng]"      # Gợi ý cho autocomplete
+disable-model-invocation: true              # Chỉ user mới có thể gọi
+user-invocable: false                       # Ẩn khỏi menu slash
+allowed-tools: Read, Grep, Glob             # Giới hạn quyền truy cập tool
+model: opus                                 # Model cụ thể để dùng
+effort: high                                # Ghi đè mức effort (low, medium, high, max)
+context: fork                               # Chạy trong subagent riêng biệt
+agent: Explore                              # Loại agent (với context: fork)
+shell: bash                                 # Shell cho lệnh: bash (mặc định) hoặc powershell
+hooks:                                      # Hooks theo phạm vi skill
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate.sh"
+---
+```
+
+| Trường | Mô tả |
+|--------|-------|
+| `name` | Chỉ chữ thường, số, dấu gạch ngang (tối đa 64 ký tự). Không được chứa "anthropic" hoặc "claude". |
+| `description` | Skill làm gì VÀ khi nào dùng (tối đa 1024 ký tự). Quan trọng cho việc tự khớp khi gọi tự động. |
+| `argument-hint` | Gợi ý hiển thị trong menu autocomplete `/` (ví dụ: `"[tên-file] [định-dạng]"`). |
+| `disable-model-invocation` | `true` = chỉ user có thể gọi qua `/tên`. Claude sẽ không bao giờ tự gọi. |
+| `user-invocable` | `false` = ẩn khỏi menu `/`. Chỉ Claude có thể tự động gọi. |
+| `allowed-tools` | Danh sách tools (cách nhau bằng dấu phẩy) mà skill có thể dùng mà không cần xin phép. |
+| `model` | Ghi đè model khi skill đang chạy (ví dụ: `opus`, `sonnet`). |
+| `effort` | Ghi đè mức effort khi skill chạy: `low`, `medium`, `high`, hoặc `max`. |
+| `context` | `fork` để chạy skill trong ngữ cảnh subagent riêng với cửa sổ ngữ cảnh của nó. |
+| `agent` | Loại subagent khi `context: fork` (ví dụ: `Explore`, `Plan`, `general-purpose`). |
+| `shell` | Shell dùng cho thay thế lệnh `` !`command` `` và scripts: `bash` (mặc định) hoặc `powershell`. |
+| `hooks` | Hooks theo phạm vi vòng đời skill này (cùng định dạng với hooks toàn cục). |
+
+## Loại nội dung Skill
+
+Skills có thể chứa hai loại nội dung, phù hợp với các mục đích khác nhau:
+
+### Nội dung tham chiếu (Reference Content)
+
+Thêm kiến thức Claude áp dụng vào công việc hiện tại — quy ước, pattern, hướng dẫn phong cách, kiến thức lĩnh vực. Chạy nội tuyến trong ngữ cảnh hội thoại.
+
+```yaml
+---
+name: api-conventions
+description: Các mẫu thiết kế API cho codebase này
+---
+
+Khi viết API endpoints:
+- Dùng quy ước đặt tên RESTful
+- Trả về định dạng lỗi nhất quán
+- Bao gồm xác thực request
+```
+
+### Nội dung tác vụ (Task Content)
+
+Hướng dẫn từng bước cho các hành động cụ thể. Thường được gọi trực tiếp với `/tên-skill`.
+
+```yaml
+---
+name: deploy
+description: Deploy ứng dụng lên production
+context: fork
+disable-model-invocation: true
+---
+
+Deploy ứng dụng:
+1. Chạy test suite
+2. Build ứng dụng
+3. Push lên deployment target
+```
+
+## Kiểm soát cách gọi Skill
+
+Mặc định, cả bạn và Claude đều có thể gọi bất kỳ skill nào. Hai trường frontmatter kiểm soát ba chế độ gọi:
+
+| Frontmatter | Bạn có thể gọi | Claude có thể gọi |
+|---|---|---|
+| (mặc định) | Có | Có |
+| `disable-model-invocation: true` | Có | Không |
+| `user-invocable: false` | Không | Có |
+
+**Dùng `disable-model-invocation: true`** cho các quy trình có tác dụng phụ: `/commit`, `/deploy`, `/send-slack-message`. Bạn không muốn Claude tự quyết định deploy chỉ vì code trông có vẻ sẵn sàng.
+
+**Dùng `user-invocable: false`** cho kiến thức nền không phải là lệnh có nghĩa. Skill `legacy-system-context` giải thích cách hoạt động của hệ thống cũ — hữu ích cho Claude, nhưng không phải hành động có nghĩa cho user.
+
+## Thay thế chuỗi (String Substitutions)
+
+Skills hỗ trợ các giá trị động được giải quyết trước khi nội dung skill đến Claude:
+
+| Biến | Mô tả |
+|------|-------|
+| `$ARGUMENTS` | Tất cả đối số truyền khi gọi skill |
+| `$ARGUMENTS[N]` hoặc `$N` | Truy cập đối số cụ thể theo chỉ số (bắt đầu từ 0) |
+| `${CLAUDE_SESSION_ID}` | ID phiên hiện tại |
+| `${CLAUDE_SKILL_DIR}` | Thư mục chứa file SKILL.md của skill |
+| `` !`lệnh` `` | Chèn ngữ cảnh động — chạy lệnh shell và đưa output vào nội tuyến |
+
+**Ví dụ:**
+
+```yaml
+---
+name: fix-issue
+description: Sửa một GitHub issue
+---
+
+Sửa GitHub issue $ARGUMENTS theo tiêu chuẩn coding của chúng ta.
+1. Đọc mô tả issue
+2. Triển khai bản sửa lỗi
+3. Viết tests
+4. Tạo commit
+```
+
+Chạy `/fix-issue 123` sẽ thay thế `$ARGUMENTS` bằng `123`.
+
+## Chèn ngữ cảnh động
+
+Cú pháp `` !`lệnh` `` chạy lệnh shell trước khi nội dung skill được gửi đến Claude:
+
+```yaml
+---
+name: pr-summary
+description: Tóm tắt các thay đổi trong một pull request
+context: fork
+agent: Explore
+---
+
+## Ngữ cảnh pull request
+- PR diff: !`gh pr diff`
+- PR comments: !`gh pr view --comments`
+- File đã thay đổi: !`gh pr diff --name-only`
+
+## Nhiệm vụ của bạn
+Tóm tắt pull request này...
+```
+
+Lệnh thực thi ngay lập tức; Claude chỉ thấy output cuối cùng. Mặc định, lệnh chạy trong `bash`. Đặt `shell: powershell` trong frontmatter để dùng PowerShell.
+
+## Chạy Skills trong Subagents
+
+Thêm `context: fork` để chạy skill trong ngữ cảnh subagent riêng biệt. Nội dung skill trở thành tác vụ cho một subagent chuyên dụng với cửa sổ ngữ cảnh riêng, giữ cho hội thoại chính gọn gàng.
+
+Trường `agent` chỉ định loại agent nào sẽ dùng:
+
+| Loại Agent | Tốt nhất cho |
+|---|---|
+| `Explore` | Nghiên cứu chỉ đọc, phân tích codebase |
+| `Plan` | Tạo kế hoạch triển khai |
+| `general-purpose` | Các tác vụ rộng cần tất cả tools |
+| Custom agents | Các agent chuyên biệt trong cấu hình của bạn |
+
+**Ví dụ frontmatter:**
+
+```yaml
+---
+context: fork
+agent: Explore
+---
+```
+
+**Ví dụ skill đầy đủ:**
+
+```yaml
+---
+name: deep-research
+description: Nghiên cứu một chủ đề kỹ lưỡng
+context: fork
+agent: Explore
+---
+
+Nghiên cứu $ARGUMENTS kỹ lưỡng:
+1. Tìm các file liên quan bằng Glob và Grep
+2. Đọc và phân tích code
+3. Tóm tắt kết quả với tham chiếu file cụ thể
+```
+
+## Ví dụ thực tế
+
+### Ví dụ 1: Skill Review Code
+
+**Cấu trúc thư mục:**
+
+```
+~/.claude/skills/code-review/
+├── SKILL.md
+├── templates/
+│   ├── review-checklist.md
+│   └── finding-template.md
+└── scripts/
+    ├── analyze-metrics.py
+    └── compare-complexity.py
+```
+
+**File:** `~/.claude/skills/code-review/SKILL.md`
+
+```yaml
+---
+name: code-review-specialist
+description: Review code toàn diện với phân tích bảo mật, hiệu năng và chất lượng. Dùng khi user yêu cầu review code, phân tích chất lượng code, đánh giá pull requests, hoặc đề cập đến code review, phân tích bảo mật, hoặc tối ưu hiệu năng.
+---
+
+# Skill Review Code
+
+Skill này cung cấp khả năng review code toàn diện tập trung vào:
+
+1. **Phân tích bảo mật**
+   - Vấn đề xác thực/ủy quyền
+   - Rủi ro lộ dữ liệu
+   - Lỗ hổng injection
+   - Điểm yếu mật mã
+
+2. **Review hiệu năng**
+   - Hiệu quả thuật toán (phân tích Big O)
+   - Tối ưu bộ nhớ
+   - Tối ưu truy vấn database
+   - Cơ hội caching
+
+3. **Chất lượng code**
+   - Nguyên tắc SOLID
+   - Design patterns
+   - Quy ước đặt tên
+   - Độ phủ test
+
+4. **Khả năng bảo trì**
+   - Khả năng đọc code
+   - Kích thước hàm (nên < 50 dòng)
+   - Độ phức tạp Cyclomatic
+   - Type safety
+
+## Template Review
+
+Với mỗi đoạn code được review, cung cấp:
+
+### Tóm tắt
+- Đánh giá chất lượng tổng thể (1-5)
+- Số lượng phát hiện chính
+- Các khu vực ưu tiên được đề xuất
+
+### Vấn đề nghiêm trọng (nếu có)
+- **Vấn đề**: Mô tả rõ ràng
+- **Vị trí**: File và số dòng
+- **Tác động**: Tại sao điều này quan trọng
+- **Mức độ**: Critical/High/Medium
+- **Cách sửa**: Ví dụ code
+
+Để xem checklist chi tiết, xem [templates/review-checklist.md](templates/review-checklist.md).
+```
+
+### Ví dụ 2: Skill Trực quan hóa Codebase
+
+Một skill tạo ra các visualization HTML tương tác:
+
+**Cấu trúc thư mục:**
+
+```
+~/.claude/skills/codebase-visualizer/
+├── SKILL.md
+└── scripts/
+    └── visualize.py
+```
+
+**File:** `~/.claude/skills/codebase-visualizer/SKILL.md`
+
+```yaml
+---
+name: codebase-visualizer
+description: Tạo visualization cây thư mục tương tác có thể thu gọn cho codebase của bạn. Dùng khi khám phá repo mới, tìm hiểu cấu trúc dự án, hoặc xác định file lớn.
+allowed-tools: Bash(python *)
+---
+
+# Codebase Visualizer
+
+Tạo cây HTML tương tác hiển thị cấu trúc file dự án.
+
+## Cách dùng
+
+Chạy script visualization từ thư mục gốc dự án:
+
+```bash
+python ~/.claude/skills/codebase-visualizer/scripts/visualize.py .
+```
+
+Lệnh này tạo `codebase-map.html` và mở trong trình duyệt mặc định.
+
+## Visualization hiển thị gì
+
+- **Thư mục có thể thu gọn**: Click vào folder để mở rộng/thu gọn
+- **Kích thước file**: Hiển thị bên cạnh mỗi file
+- **Màu sắc**: Màu khác nhau cho các loại file khác nhau
+- **Tổng kích thước thư mục**: Hiển thị kích thước tổng của mỗi folder
+```
+
+Script Python đi kèm xử lý phần nặng trong khi Claude quản lý việc điều phối.
+
+### Ví dụ 3: Skill Deploy (Chỉ User gọi)
+
+```yaml
+---
+name: deploy
+description: Deploy ứng dụng lên production
+disable-model-invocation: true
+allowed-tools: Bash(npm *), Bash(git *)
+---
+
+Deploy $ARGUMENTS lên production:
+
+1. Chạy test suite: `npm test`
+2. Build ứng dụng: `npm run build`
+3. Push lên deployment target
+4. Xác minh deployment thành công
+5. Báo cáo trạng thái deployment
+```
+
+### Ví dụ 4: Skill Giọng nói thương hiệu (Kiến thức nền)
+
+```yaml
+---
+name: brand-voice
+description: Đảm bảo tất cả giao tiếp phù hợp với hướng dẫn giọng nói và tông điệu thương hiệu. Dùng khi tạo nội dung marketing, giao tiếp khách hàng, hoặc nội dung công khai.
+user-invocable: false
+---
+
+## Tông điệu giọng nói
+- **Thân thiện nhưng chuyên nghiệp** - dễ tiếp cận mà không cần bình thường hóa
+- **Rõ ràng và súc tích** - tránh biệt ngữ
+- **Tự tin** - chúng ta biết mình đang làm gì
+- **Đồng cảm** - hiểu nhu cầu user
+
+## Hướng dẫn viết
+- Dùng "bạn" khi xưng hô với người đọc
+- Dùng giọng chủ động
+- Giữ câu dưới 20 từ
+- Bắt đầu bằng đề xuất giá trị
+
+Để xem templates, xem [templates/](templates/).
+```
+
+### Ví dụ 5: Skill Tạo CLAUDE.md
+
+```yaml
+---
+name: claude-md
+description: Tạo hoặc cập nhật file CLAUDE.md theo các thực hành tốt nhất để AI agent onboarding tối ưu. Dùng khi user đề cập đến CLAUDE.md, tài liệu dự án, hoặc AI onboarding.
+---
+
+## Nguyên tắc cốt lõi
+
+**LLMs không có trạng thái**: CLAUDE.md là file duy nhất được tự động đưa vào mọi hội thoại.
+
+### Quy tắc vàng
+
+1. **Ít hơn là tốt hơn**: Giữ dưới 300 dòng (tốt nhất dưới 100)
+2. **Áp dụng chung**: Chỉ bao gồm thông tin liên quan đến MỌI phiên
+3. **Đừng dùng Claude làm Linter**: Dùng các công cụ xác định thay thế
+4. **Không bao giờ tự động tạo**: Soạn thủ công với sự cân nhắc kỹ lưỡng
+
+## Các phần thiết yếu
+
+- **Tên dự án**: Mô tả ngắn một dòng
+- **Tech Stack**: Ngôn ngữ chính, frameworks, database
+- **Lệnh phát triển**: Install, test, build
+- **Quy ước quan trọng**: Chỉ các quy ước không hiển nhiên, có tác động cao
+- **Vấn đề đã biết / Bẫy**: Những thứ hay gây nhầm lẫn cho developer
+```
+
+### Ví dụ 6: Skill Tái cấu trúc với Scripts
+
+**Cấu trúc thư mục:**
+
+```
+refactor/
+├── SKILL.md
+├── references/
+│   ├── code-smells.md
+│   └── refactoring-catalog.md
+├── templates/
+│   └── refactoring-plan.md
+└── scripts/
+    ├── analyze-complexity.py
+    └── detect-smells.py
+```
+
+**File:** `refactor/SKILL.md`
+
+```yaml
+---
+name: code-refactor
+description: Tái cấu trúc code có hệ thống dựa trên phương pháp của Martin Fowler. Dùng khi user yêu cầu tái cấu trúc code, cải thiện cấu trúc code, giảm nợ kỹ thuật, hoặc loại bỏ code smells.
+---
+
+# Skill Tái cấu trúc Code
+
+Cách tiếp cận theo giai đoạn nhấn mạnh các thay đổi an toàn, tăng dần được backup bởi tests.
+
+## Quy trình
+
+Giai đoạn 1: Nghiên cứu & Phân tích → Giai đoạn 2: Đánh giá độ phủ Test →
+Giai đoạn 3: Xác định Code Smell → Giai đoạn 4: Tạo Kế hoạch Tái cấu trúc →
+Giai đoạn 5: Triển khai tăng dần → Giai đoạn 6: Review & Lặp lại
+
+## Nguyên tắc cốt lõi
+
+1. **Bảo toàn hành vi**: Hành vi bên ngoài phải không thay đổi
+2. **Bước nhỏ**: Thực hiện các thay đổi nhỏ, có thể kiểm tra
+3. **Hướng test**: Tests là lưới an toàn
+4. **Liên tục**: Tái cấu trúc là quá trình liên tục, không phải một lần
+
+Để xem catalog code smell, xem [references/code-smells.md](references/code-smells.md).
+Để xem kỹ thuật tái cấu trúc, xem [references/refactoring-catalog.md](references/refactoring-catalog.md).
+```
+
+## File hỗ trợ
+
+Skills có thể bao gồm nhiều file trong thư mục của chúng ngoài `SKILL.md`. Các file hỗ trợ này (templates, ví dụ, scripts, tài liệu tham chiếu) giúp file skill chính gọn gàng trong khi cung cấp cho Claude các tài nguyên bổ sung có thể tải khi cần.
+
+```
+my-skill/
+├── SKILL.md              # Hướng dẫn chính (bắt buộc, giữ dưới 500 dòng)
+├── templates/            # Templates để Claude điền vào
+│   └── output-format.md
+├── examples/             # Ví dụ output thể hiện định dạng mong đợi
+│   └── sample-output.md
+├── references/           # Kiến thức lĩnh vực và đặc tả
+│   └── api-spec.md
+└── scripts/              # Scripts Claude có thể thực thi
+    └── validate.sh
+```
+
+Hướng dẫn cho file hỗ trợ:
+
+- Giữ `SKILL.md` dưới **500 dòng**. Chuyển tài liệu tham chiếu chi tiết, ví dụ lớn và đặc tả sang file riêng.
+- Tham chiếu file bổ sung từ `SKILL.md` bằng **đường dẫn tương đối** (ví dụ: `[Tham chiếu API](references/api-spec.md)`).
+- File hỗ trợ được tải ở Cấp 3 (khi cần), nên chúng không tiêu thụ ngữ cảnh cho đến khi Claude thực sự đọc chúng.
+
+## Quản lý Skills
+
+### Xem Skills có sẵn
+
+Hỏi Claude trực tiếp:
+```
+Skills nào đang có sẵn?
+```
+
+Hoặc kiểm tra filesystem:
+```bash
+# Liệt kê Skills cá nhân
+ls ~/.claude/skills/
+
+# Liệt kê Skills dự án
+ls .claude/skills/
+```
+
+### Kiểm tra một Skill
+
+Hai cách kiểm tra:
+
+**Để Claude tự kích hoạt** bằng cách yêu cầu điều gì đó khớp với mô tả:
+```
+Bạn có thể review code này về vấn đề bảo mật không?
+```
+
+**Hoặc gọi trực tiếp** với tên skill:
+```
+/code-review src/auth/login.ts
+```
+
+### Cập nhật một Skill
+
+Chỉnh sửa file `SKILL.md` trực tiếp. Thay đổi có hiệu lực khi khởi động Claude Code tiếp theo.
+
+```bash
+# Skill cá nhân
+code ~/.claude/skills/my-skill/SKILL.md
+
+# Skill dự án
+code .claude/skills/my-skill/SKILL.md
+```
+
+### Giới hạn quyền truy cập Skill của Claude
+
+Ba cách kiểm soát skills nào Claude có thể gọi:
+
+**Tắt tất cả skills** trong `/permissions`:
+```
+# Thêm vào quy tắc từ chối:
+Skill
+```
+
+**Cho phép hoặc từ chối skills cụ thể**:
+```
+# Chỉ cho phép skills cụ thể
+Skill(commit)
+Skill(review-pr *)
+
+# Từ chối skills cụ thể
+Skill(deploy *)
+```
+
+**Ẩn skills riêng lẻ** bằng cách thêm `disable-model-invocation: true` vào frontmatter của chúng.
+
+## Thực hành tốt nhất
+
+### 1. Làm cho mô tả cụ thể
+
+- **Kém (mơ hồ)**: "Giúp với tài liệu"
+- **Tốt (cụ thể)**: "Trích xuất văn bản và bảng từ file PDF, điền form, ghép tài liệu. Dùng khi làm việc với file PDF hoặc khi user đề cập đến PDFs, forms, hoặc trích xuất tài liệu."
+
+### 2. Giữ Skills tập trung
+
+- Một Skill = một khả năng
+- ✅ "Điền form PDF"
+- ❌ "Xử lý tài liệu" (quá rộng)
+
+### 3. Bao gồm từ kích hoạt
+
+Thêm từ khóa trong mô tả khớp với yêu cầu user:
+```yaml
+description: Phân tích bảng tính Excel, tạo pivot tables, vẽ biểu đồ. Dùng khi làm việc với file Excel, bảng tính, hoặc file .xlsx.
+```
+
+### 4. Giữ SKILL.md dưới 500 dòng
+
+Chuyển tài liệu tham chiếu chi tiết sang file riêng mà Claude tải khi cần.
+
+### 5. Tham chiếu file hỗ trợ
+
+```markdown
+## Tài nguyên bổ sung
+
+- Để xem chi tiết API đầy đủ, xem [reference.md](reference.md)
+- Để xem ví dụ sử dụng, xem [examples.md](examples.md)
+```
+
+### Nên làm
+
+- Dùng tên rõ ràng, mô tả
+- Bao gồm hướng dẫn toàn diện
+- Thêm ví dụ cụ thể
+- Đóng gói scripts và templates liên quan
+- Kiểm tra với các tình huống thực tế
+- Ghi lại dependencies
+
+### Không nên làm
+
+- Đừng tạo skills cho tác vụ một lần
+- Đừng nhân đôi chức năng hiện có
+- Đừng làm skills quá rộng
+- Đừng bỏ qua trường description
+- Đừng cài skills từ nguồn không tin cậy mà không kiểm tra
+
+## Xử lý sự cố
+
+### Tham chiếu nhanh
+
+| Vấn đề | Giải pháp |
+|--------|---------|
+| Claude không dùng Skill | Làm mô tả cụ thể hơn với các từ kích hoạt |
+| File skill không tìm thấy | Kiểm tra đường dẫn: `~/.claude/skills/tên/SKILL.md` |
+| Lỗi YAML | Kiểm tra dấu `---`, thụt lề, không dùng tabs |
+| Skills xung đột | Dùng từ kích hoạt riêng biệt trong mô tả |
+| Scripts không chạy | Kiểm tra quyền: `chmod +x scripts/*.py` |
+| Claude không thấy tất cả skills | Quá nhiều skills; kiểm tra `/context` để xem cảnh báo |
+
+### Skill không kích hoạt
+
+Nếu Claude không dùng skill khi bạn mong đợi:
+
+1. Kiểm tra mô tả có bao gồm từ khóa user sẽ tự nhiên nói không
+2. Xác minh skill xuất hiện khi hỏi "Skills nào đang có sẵn?"
+3. Thử diễn đạt lại yêu cầu để khớp với mô tả
+4. Gọi trực tiếp với `/tên-skill` để kiểm tra
+
+### Skill kích hoạt quá thường xuyên
+
+Nếu Claude dùng skill khi bạn không muốn:
+
+1. Làm mô tả cụ thể hơn
+2. Thêm `disable-model-invocation: true` để chỉ gọi thủ công
+
+### Claude không thấy tất cả Skills
+
+Mô tả Skill được tải ở **2% cửa sổ ngữ cảnh** (dự phòng: **16.000 ký tự**). Chạy `/context` để kiểm tra cảnh báo về skills bị loại trừ. Ghi đè ngân sách bằng biến môi trường `SLASH_COMMAND_TOOL_CHAR_BUDGET`.
+
+## Cân nhắc bảo mật
+
+**Chỉ dùng Skills từ nguồn tin cậy.** Skills cung cấp cho Claude khả năng qua hướng dẫn và code — một Skill độc hại có thể hướng Claude gọi tools hoặc thực thi code theo cách có hại.
+
+**Cân nhắc bảo mật chính:**
+
+- **Kiểm tra kỹ**: Review tất cả file trong thư mục Skill
+- **Nguồn bên ngoài có rủi ro**: Skills lấy dữ liệu từ URL bên ngoài có thể bị xâm phạm
+- **Lạm dụng tool**: Skills độc hại có thể gọi tools theo cách có hại
+- **Xử lý như cài phần mềm**: Chỉ dùng Skills từ nguồn tin cậy
+
+## Skills vs Các tính năng khác
+
+| Tính năng | Cách gọi | Tốt nhất cho |
+|-----------|----------|------------|
+| **Skills** | Tự động hoặc `/tên` | Chuyên môn có thể tái sử dụng, quy trình |
+| **Slash Commands** | User gọi `/tên` | Phím tắt nhanh (đã tích hợp vào skills) |
+| **Subagents** | Tự động ủy quyền | Thực thi tác vụ riêng biệt |
+| **Memory (CLAUDE.md)** | Luôn tải | Ngữ cảnh dự án liên tục |
+| **MCP** | Thời gian thực | Truy cập dữ liệu/dịch vụ bên ngoài |
+| **Hooks** | Theo sự kiện | Tác dụng phụ tự động |
+
+## Skills đi kèm sẵn
+
+Claude Code đi kèm với một số skills tích hợp sẵn luôn có sẵn mà không cần cài đặt:
+
+| Skill | Mô tả |
+|-------|-------|
+| `/simplify` | Review các file đã thay đổi về tái sử dụng, chất lượng và hiệu quả; tạo 3 agent review song song |
+| `/batch <hướng dẫn>` | Điều phối các thay đổi song song quy mô lớn qua codebase dùng git worktrees |
+| `/debug [mô tả]` | Xử lý sự cố phiên hiện tại bằng cách đọc debug log |
+| `/loop [khoảng thời gian] <prompt>` | Chạy prompt lặp lại theo khoảng thời gian (ví dụ: `/loop 5m kiểm tra deploy`) |
+| `/claude-api` | Tải tài liệu tham chiếu Claude API/SDK; tự động kích hoạt khi import `anthropic`/`@anthropic-ai/sdk` |
+
+Các skills này có sẵn ngay và không cần cài đặt hay cấu hình. Chúng tuân theo cùng định dạng SKILL.md như skills tùy chỉnh.
+
+## Chia sẻ Skills
+
+### Skills dự án (Chia sẻ nhóm)
+
+1. Tạo Skill trong `.claude/skills/`
+2. Commit lên git
+3. Thành viên nhóm pull thay đổi — Skills có sẵn ngay
+
+### Skills cá nhân
+
+```bash
+# Sao chép vào thư mục cá nhân
+cp -r my-skill ~/.claude/skills/
+
+# Làm scripts có thể thực thi
+chmod +x ~/.claude/skills/my-skill/scripts/*.py
+```
+
+### Phân phối qua Plugin
+
+Đóng gói skills trong thư mục `skills/` của plugin để phân phối rộng hơn.
+
+## Tài nguyên bổ sung
+
+- [Tài liệu Skills chính thức](https://code.claude.com/docs/en/skills)
+- [Blog kiến trúc Agent Skills](https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills)
+- [Kho Skills](https://github.com/luongnv89/skills) - Bộ sưu tập skills sẵn dùng
+- [Hướng dẫn Slash Commands](../01-slash-commands/) - Phím tắt do user khởi động
+- [Hướng dẫn Subagents](../04-subagents/) - Các AI agent được ủy quyền
+- [Hướng dẫn Memory](../02-memory/) - Ngữ cảnh liên tục
+- [MCP (Model Context Protocol)](../05-mcp/) - Dữ liệu bên ngoài thời gian thực
+- [Hướng dẫn Hooks](../06-hooks/) - Tự động hóa theo sự kiện

--- a/03-skills/README.vi.md
+++ b/03-skills/README.vi.md
@@ -43,7 +43,7 @@ graph TB
         B2["Quy trình & hướng dẫn"]
     end
 
-    subgraph "Cấp 3: Tài nguyên (Khi cần)
+    subgraph "Cấp 3: Tài nguyên (Khi cần)"
         C["File đi kèm"]
         C1["Thực tế không giới hạn"]
         C2["Scripts, templates, docs"]

--- a/04-subagents/README.vi.md
+++ b/04-subagents/README.vi.md
@@ -1,0 +1,1141 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Subagents - Hướng dẫn tham chiếu đầy đủ
+
+Subagents (tác nhân phụ) là các trợ lý AI chuyên biệt mà Claude Code có thể ủy quyền tác vụ. Mỗi subagent có một mục đích cụ thể, dùng cửa sổ ngữ cảnh riêng tách biệt với hội thoại chính, và có thể được cấu hình với các công cụ cụ thể và system prompt tùy chỉnh.
+
+## Mục lục
+
+1. [Tổng quan](#tổng-quan)
+2. [Lợi ích chính](#lợi-ích-chính)
+3. [Vị trí file](#vị-trí-file)
+4. [Cấu hình](#cấu-hình)
+5. [Subagents tích hợp sẵn](#subagents-tích-hợp-sẵn)
+6. [Quản lý Subagents](#quản-lý-subagents)
+7. [Dùng Subagents](#dùng-subagents)
+8. [Agents có thể tiếp tục](#agents-có-thể-tiếp-tục)
+9. [Kết nối Subagents](#kết-nối-subagents)
+10. [Bộ nhớ liên tục cho Subagents](#bộ-nhớ-liên-tục-cho-subagents)
+11. [Subagents nền](#subagents-nền)
+12. [Cô lập Worktree](#cô-lập-worktree)
+13. [Giới hạn Subagents có thể tạo](#giới-hạn-subagents-có-thể-tạo)
+14. [Lệnh CLI `claude agents`](#lệnh-cli-claude-agents)
+15. [Nhóm Agent (Thử nghiệm)](#nhóm-agent-thử-nghiệm)
+16. [Bảo mật Subagent của Plugin](#bảo-mật-subagent-của-plugin)
+17. [Kiến trúc](#kiến-trúc)
+18. [Quản lý ngữ cảnh](#quản-lý-ngữ-cảnh)
+19. [Khi nào dùng Subagents](#khi-nào-dùng-subagents)
+20. [Thực hành tốt nhất](#thực-hành-tốt-nhất)
+21. [Ví dụ Subagents trong thư mục này](#ví-dụ-subagents-trong-thư-mục-này)
+22. [Hướng dẫn cài đặt](#hướng-dẫn-cài-đặt)
+23. [Khái niệm liên quan](#khái-niệm-liên-quan)
+
+---
+
+## Tổng quan
+
+Subagents cho phép thực thi tác vụ được ủy quyền trong Claude Code bằng cách:
+
+- Tạo các **trợ lý AI cô lập** với cửa sổ ngữ cảnh riêng
+- Cung cấp **system prompts tùy chỉnh** cho chuyên môn theo lĩnh vực
+- Áp đặt **kiểm soát truy cập tool** để giới hạn khả năng
+- Ngăn **ô nhiễm ngữ cảnh** từ các tác vụ phức tạp
+- Cho phép **thực thi song song** nhiều tác vụ chuyên biệt
+
+Mỗi subagent hoạt động độc lập với ngữ cảnh sạch, chỉ nhận ngữ cảnh cụ thể cần thiết cho tác vụ của chúng, sau đó trả kết quả về cho agent chính để tổng hợp.
+
+**Bắt đầu nhanh**: Dùng lệnh `/agents` để tạo, xem, chỉnh sửa và quản lý subagents một cách tương tác.
+
+---
+
+## Lợi ích chính
+
+| Lợi ích | Mô tả |
+|---------|-------|
+| **Bảo toàn ngữ cảnh** | Hoạt động trong ngữ cảnh riêng, ngăn ô nhiễm hội thoại chính |
+| **Chuyên môn hóa** | Được tinh chỉnh cho các lĩnh vực cụ thể với tỷ lệ thành công cao hơn |
+| **Có thể tái sử dụng** | Dùng qua các dự án khác nhau và chia sẻ với nhóm |
+| **Quyền linh hoạt** | Mức truy cập tool khác nhau cho các loại subagent khác nhau |
+| **Khả năng mở rộng** | Nhiều agent làm việc trên các khía cạnh khác nhau đồng thời |
+
+---
+
+## Vị trí file
+
+File subagent có thể lưu ở nhiều vị trí với các phạm vi khác nhau:
+
+| Ưu tiên | Loại | Vị trí | Phạm vi |
+|---------|------|--------|---------|
+| 1 (cao nhất) | **Định nghĩa qua CLI** | Qua cờ `--agents` (JSON) | Chỉ trong phiên |
+| 2 | **Subagents dự án** | `.claude/agents/` | Dự án hiện tại |
+| 3 | **Subagents người dùng** | `~/.claude/agents/` | Tất cả dự án |
+| 4 (thấp nhất) | **Plugin agents** | Thư mục `agents/` của plugin | Qua plugins |
+
+Khi có tên trùng lặp, nguồn có ưu tiên cao hơn sẽ thắng.
+
+---
+
+## Cấu hình
+
+### Định dạng file
+
+Subagents được định nghĩa trong YAML frontmatter theo sau là system prompt dạng markdown:
+
+```yaml
+---
+name: tên-sub-agent-của-bạn
+description: Mô tả khi nào subagent này nên được gọi
+tools: tool1, tool2, tool3  # Tùy chọn - kế thừa tất cả tools nếu bỏ qua
+disallowedTools: tool4  # Tùy chọn - tools bị từ chối rõ ràng
+model: sonnet  # Tùy chọn - sonnet, opus, haiku, hoặc inherit
+permissionMode: default  # Tùy chọn - chế độ quyền
+maxTurns: 20  # Tùy chọn - giới hạn số lượt agentic
+skills: skill1, skill2  # Tùy chọn - skills để tải trước vào ngữ cảnh
+mcpServers: server1  # Tùy chọn - MCP servers để cung cấp
+memory: user  # Tùy chọn - phạm vi bộ nhớ liên tục (user, project, local)
+background: false  # Tùy chọn - chạy như tác vụ nền
+effort: high  # Tùy chọn - mức effort lý luận (low, medium, high, max)
+isolation: worktree  # Tùy chọn - cô lập git worktree
+initialPrompt: "Bắt đầu bằng cách phân tích codebase"  # Tùy chọn - lượt đầu tiên tự động gửi
+hooks:  # Tùy chọn - hooks theo phạm vi component
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/security-check.sh"
+---
+
+System prompt của subagent ở đây. Có thể nhiều đoạn văn
+và nên định nghĩa rõ ràng vai trò, khả năng và cách tiếp cận
+của subagent khi giải quyết vấn đề.
+```
+
+### Các trường cấu hình
+
+| Trường | Bắt buộc | Mô tả |
+|--------|----------|-------|
+| `name` | Có | Định danh duy nhất (chữ thường và dấu gạch ngang) |
+| `description` | Có | Mô tả ngôn ngữ tự nhiên về mục đích. Bao gồm "use PROACTIVELY" để khuyến khích gọi tự động |
+| `tools` | Không | Danh sách tools cụ thể cách nhau bằng dấu phẩy. Bỏ qua để kế thừa tất cả tools. Hỗ trợ cú pháp `Agent(tên_agent)` để giới hạn subagents có thể tạo |
+| `disallowedTools` | Không | Danh sách tools mà subagent không được dùng |
+| `model` | Không | Model dùng: `sonnet`, `opus`, `haiku`, model ID đầy đủ, hoặc `inherit`. Mặc định theo model subagent đã cấu hình |
+| `permissionMode` | Không | `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan` |
+| `maxTurns` | Không | Số lượt agentic tối đa subagent có thể thực hiện |
+| `skills` | Không | Danh sách skills cách nhau bằng dấu phẩy để tải trước. Đưa nội dung skill đầy đủ vào ngữ cảnh subagent lúc khởi động |
+| `mcpServers` | Không | MCP servers cung cấp cho subagent |
+| `hooks` | Không | Hooks theo phạm vi component (PreToolUse, PostToolUse, Stop) |
+| `memory` | Không | Phạm vi thư mục bộ nhớ liên tục: `user`, `project`, hoặc `local` |
+| `background` | Không | Đặt `true` để luôn chạy subagent này như tác vụ nền |
+| `effort` | Không | Mức effort lý luận: `low`, `medium`, `high`, hoặc `max` |
+| `isolation` | Không | Đặt `worktree` để cho subagent git worktree riêng |
+| `initialPrompt` | Không | Lượt đầu tiên tự động gửi khi subagent chạy như agent chính |
+
+### Tùy chọn cấu hình Tool
+
+**Tùy chọn 1: Kế thừa tất cả Tools (bỏ qua trường)**
+```yaml
+---
+name: full-access-agent
+description: Agent với tất cả tools có sẵn
+---
+```
+
+**Tùy chọn 2: Chỉ định Tools cụ thể**
+```yaml
+---
+name: limited-agent
+description: Agent chỉ có tools cụ thể
+tools: Read, Grep, Glob, Bash
+---
+```
+
+**Tùy chọn 3: Truy cập Tool có điều kiện**
+```yaml
+---
+name: conditional-agent
+description: Agent với truy cập tool được lọc
+tools: Read, Bash(npm:*), Bash(test:*)
+---
+```
+
+### Cấu hình qua CLI
+
+Định nghĩa subagents cho một phiên dùng cờ `--agents` với định dạng JSON:
+
+```bash
+claude --agents '{
+  "code-reviewer": {
+    "description": "Chuyên gia review code. Dùng chủ động sau khi thay đổi code.",
+    "prompt": "Bạn là senior code reviewer. Tập trung vào chất lượng code, bảo mật và thực hành tốt nhất.",
+    "tools": ["Read", "Grep", "Glob", "Bash"],
+    "model": "sonnet"
+  }
+}'
+```
+
+**Định dạng JSON cho cờ `--agents`:**
+
+```json
+{
+  "tên-agent": {
+    "description": "Bắt buộc: khi nào gọi agent này",
+    "prompt": "Bắt buộc: system prompt cho agent",
+    "tools": ["Tùy", "chọn", "mảng", "tools"],
+    "model": "tùy chọn: sonnet|opus|haiku"
+  }
+}
+```
+
+**Thứ tự ưu tiên của định nghĩa Agent:**
+
+Định nghĩa agent được tải theo thứ tự ưu tiên này (khớp đầu tiên thắng):
+1. **Định nghĩa qua CLI** - Cờ `--agents` (chỉ phiên, JSON)
+2. **Cấp dự án** - `.claude/agents/` (dự án hiện tại)
+3. **Cấp người dùng** - `~/.claude/agents/` (tất cả dự án)
+4. **Cấp plugin** - Thư mục `agents/` của plugin
+
+Điều này cho phép định nghĩa CLI ghi đè tất cả nguồn khác cho một phiên.
+
+---
+
+## Subagents tích hợp sẵn
+
+Claude Code bao gồm một số subagent tích hợp luôn có sẵn:
+
+| Agent | Model | Mục đích |
+|-------|-------|---------|
+| **general-purpose** | Kế thừa | Tác vụ phức tạp, nhiều bước |
+| **Plan** | Kế thừa | Nghiên cứu cho chế độ plan |
+| **Explore** | Haiku | Khám phá codebase chỉ đọc (quick/medium/very thorough) |
+| **Bash** | Kế thừa | Lệnh terminal trong ngữ cảnh riêng |
+| **statusline-setup** | Sonnet | Cấu hình status line |
+| **Claude Code Guide** | Haiku | Trả lời câu hỏi về tính năng Claude Code |
+
+### Subagent General-Purpose
+
+| Thuộc tính | Giá trị |
+|-----------|---------|
+| **Model** | Kế thừa từ parent |
+| **Tools** | Tất cả tools |
+| **Mục đích** | Tác vụ nghiên cứu phức tạp, thao tác nhiều bước, sửa đổi code |
+
+**Khi dùng**: Tác vụ cần cả khám phá và sửa đổi với lý luận phức tạp.
+
+### Subagent Plan
+
+| Thuộc tính | Giá trị |
+|-----------|---------|
+| **Model** | Kế thừa từ parent |
+| **Tools** | Read, Glob, Grep, Bash |
+| **Mục đích** | Tự động dùng trong chế độ plan để nghiên cứu codebase |
+
+**Khi dùng**: Khi Claude cần hiểu codebase trước khi trình bày kế hoạch.
+
+### Subagent Explore
+
+| Thuộc tính | Giá trị |
+|-----------|---------|
+| **Model** | Haiku (nhanh, độ trễ thấp) |
+| **Chế độ** | Chỉ đọc nghiêm ngặt |
+| **Tools** | Glob, Grep, Read, Bash (chỉ lệnh đọc) |
+| **Mục đích** | Tìm kiếm và phân tích codebase nhanh |
+
+**Khi dùng**: Khi tìm kiếm/hiểu code mà không thực hiện thay đổi.
+
+**Mức độ kỹ lưỡng** — Chỉ định độ sâu khám phá:
+- **"quick"** — Tìm kiếm nhanh với khám phá tối thiểu, tốt để tìm pattern cụ thể
+- **"medium"** — Khám phá vừa phải, cân bằng tốc độ và kỹ lưỡng, cách tiếp cận mặc định
+- **"very thorough"** — Phân tích toàn diện qua nhiều vị trí và quy ước đặt tên, có thể mất lâu hơn
+
+### Subagent Bash
+
+| Thuộc tính | Giá trị |
+|-----------|---------|
+| **Model** | Kế thừa từ parent |
+| **Tools** | Bash |
+| **Mục đích** | Thực thi lệnh terminal trong cửa sổ ngữ cảnh riêng |
+
+**Khi dùng**: Khi chạy lệnh shell được hưởng lợi từ ngữ cảnh cô lập.
+
+### Subagent Statusline Setup
+
+| Thuộc tính | Giá trị |
+|-----------|---------|
+| **Model** | Sonnet |
+| **Tools** | Read, Write, Bash |
+| **Mục đích** | Cấu hình hiển thị status line của Claude Code |
+
+**Khi dùng**: Khi thiết lập hoặc tùy chỉnh status line.
+
+### Subagent Claude Code Guide
+
+| Thuộc tính | Giá trị |
+|-----------|---------|
+| **Model** | Haiku (nhanh, độ trễ thấp) |
+| **Tools** | Chỉ đọc |
+| **Mục đích** | Trả lời câu hỏi về tính năng và cách sử dụng Claude Code |
+
+**Khi dùng**: Khi người dùng hỏi về cách Claude Code hoạt động hoặc cách dùng các tính năng cụ thể.
+
+---
+
+## Quản lý Subagents
+
+### Dùng lệnh `/agents` (Khuyến nghị)
+
+```bash
+/agents
+```
+
+Cung cấp menu tương tác để:
+- Xem tất cả subagents có sẵn (tích hợp sẵn, người dùng và dự án)
+- Tạo subagents mới với hướng dẫn từng bước
+- Chỉnh sửa subagents tùy chỉnh hiện có và quyền truy cập tool
+- Xóa subagents tùy chỉnh
+- Xem subagents nào đang hoạt động khi có trùng lặp
+
+### Quản lý file trực tiếp
+
+```bash
+# Tạo subagent dự án
+mkdir -p .claude/agents
+cat > .claude/agents/test-runner.md << 'EOF'
+---
+name: test-runner
+description: Dùng chủ động để chạy tests và sửa lỗi
+---
+
+Bạn là chuyên gia tự động hóa test. Khi thấy thay đổi code, hãy chủ động
+chạy các tests phù hợp. Nếu tests thất bại, phân tích lỗi và sửa
+trong khi bảo toàn ý định test ban đầu.
+EOF
+
+# Tạo subagent người dùng (có sẵn trong tất cả dự án)
+mkdir -p ~/.claude/agents
+```
+
+---
+
+## Dùng Subagents
+
+### Ủy quyền tự động
+
+Claude chủ động ủy quyền tác vụ dựa trên:
+- Mô tả tác vụ trong yêu cầu của bạn
+- Trường `description` trong cấu hình subagent
+- Ngữ cảnh hiện tại và tools có sẵn
+
+Để khuyến khích dùng chủ động, bao gồm "use PROACTIVELY" hoặc "MUST BE USED" trong trường `description`:
+
+```yaml
+---
+name: code-reviewer
+description: Chuyên gia review code. Use PROACTIVELY sau khi viết hoặc sửa đổi code.
+---
+```
+
+### Gọi trực tiếp
+
+Bạn có thể yêu cầu subagent cụ thể:
+
+```
+> Dùng subagent test-runner để sửa các tests thất bại
+> Yêu cầu subagent code-reviewer xem xét các thay đổi gần đây của tôi
+> Nhờ subagent debugger điều tra lỗi này
+```
+
+### Gọi qua @-Mention
+
+Dùng tiền tố `@` để đảm bảo subagent cụ thể được gọi (bỏ qua các phương pháp ủy quyền tự động):
+
+```
+> @"code-reviewer (agent)" review module xác thực
+```
+
+### Agent cho toàn phiên
+
+Chạy toàn bộ phiên dùng agent cụ thể làm agent chính:
+
+```bash
+# Qua cờ CLI
+claude --agent code-reviewer
+
+# Qua settings.json
+{
+  "agent": "code-reviewer"
+}
+```
+
+### Liệt kê Agents có sẵn
+
+Dùng lệnh `claude agents` để liệt kê tất cả agents đã cấu hình từ tất cả nguồn:
+
+```bash
+claude agents
+```
+
+---
+
+## Agents có thể tiếp tục
+
+Subagents có thể tiếp tục hội thoại trước với toàn bộ ngữ cảnh được lưu giữ:
+
+```bash
+# Gọi lần đầu
+> Dùng agent code-analyzer để bắt đầu review module xác thực
+# Trả về agentId: "abc123"
+
+# Tiếp tục agent sau đó
+> Tiếp tục agent abc123 và phân tích thêm logic ủy quyền
+```
+
+**Trường hợp dùng**:
+- Nghiên cứu dài hạn qua nhiều phiên
+- Cải thiện lặp lại mà không mất ngữ cảnh
+- Quy trình nhiều bước duy trì ngữ cảnh
+
+---
+
+## Kết nối Subagents
+
+Thực thi nhiều subagent theo trình tự:
+
+```bash
+> Đầu tiên dùng subagent code-analyzer để tìm vấn đề hiệu năng,
+  sau đó dùng subagent optimizer để sửa chúng
+```
+
+Điều này cho phép các quy trình phức tạp trong đó đầu ra của một subagent được đưa vào subagent tiếp theo.
+
+---
+
+## Bộ nhớ liên tục cho Subagents
+
+Trường `memory` cung cấp cho subagents một thư mục liên tục tồn tại qua các hội thoại. Điều này cho phép subagents xây dựng kiến thức theo thời gian, lưu trữ ghi chú, phát hiện và ngữ cảnh tồn tại giữa các phiên.
+
+### Phạm vi bộ nhớ
+
+| Phạm vi | Thư mục | Trường hợp dùng |
+|---------|---------|----------------|
+| `user` | `~/.claude/agent-memory/<tên>/` | Ghi chú và tùy chọn cá nhân qua tất cả dự án |
+| `project` | `.claude/agent-memory/<tên>/` | Kiến thức theo dự án chia sẻ với nhóm |
+| `local` | `.claude/agent-memory-local/<tên>/` | Kiến thức dự án cục bộ không commit vào version control |
+
+### Cách hoạt động
+
+- 200 dòng đầu tiên của `MEMORY.md` trong thư mục bộ nhớ tự động được tải vào system prompt của subagent
+- Các tools `Read`, `Write` và `Edit` tự động được bật cho subagent để quản lý các file bộ nhớ
+- Subagent có thể tạo thêm file trong thư mục bộ nhớ khi cần
+
+### Ví dụ cấu hình
+
+```yaml
+---
+name: researcher
+memory: user
+---
+
+Bạn là trợ lý nghiên cứu. Dùng thư mục bộ nhớ để lưu phát hiện,
+theo dõi tiến độ qua các phiên và tích lũy kiến thức theo thời gian.
+
+Kiểm tra file MEMORY.md lúc bắt đầu mỗi phiên để nhớ lại ngữ cảnh trước.
+```
+
+```mermaid
+graph LR
+    A["Subagent<br/>Phiên 1"] -->|ghi| M["MEMORY.md<br/>(liên tục)"]
+    M -->|tải vào| B["Subagent<br/>Phiên 2"]
+    B -->|cập nhật| M
+    M -->|tải vào| C["Subagent<br/>Phiên 3"]
+
+    style A fill:#e1f5fe,stroke:#333,color:#333
+    style B fill:#e1f5fe,stroke:#333,color:#333
+    style C fill:#e1f5fe,stroke:#333,color:#333
+    style M fill:#f3e5f5,stroke:#333,color:#333
+```
+
+---
+
+## Subagents nền
+
+Subagents có thể chạy nền, giải phóng hội thoại chính cho các tác vụ khác.
+
+### Cấu hình
+
+Đặt `background: true` trong frontmatter để luôn chạy subagent như tác vụ nền:
+
+```yaml
+---
+name: long-runner
+background: true
+description: Thực hiện các tác vụ phân tích dài hạn ở nền
+---
+```
+
+### Phím tắt
+
+| Phím tắt | Hành động |
+|----------|----------|
+| `Ctrl+B` | Đưa tác vụ subagent đang chạy xuống nền |
+| `Ctrl+F` | Dừng tất cả agents nền (nhấn hai lần để xác nhận) |
+
+### Tắt tác vụ nền
+
+Đặt biến môi trường để tắt hoàn toàn hỗ trợ tác vụ nền:
+
+```bash
+export CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1
+```
+
+---
+
+## Cô lập Worktree
+
+Cài đặt `isolation: worktree` cung cấp cho subagent git worktree riêng, cho phép thực hiện thay đổi độc lập mà không ảnh hưởng đến cây làm việc chính.
+
+### Cấu hình
+
+```yaml
+---
+name: feature-builder
+isolation: worktree
+description: Triển khai tính năng trong git worktree cô lập
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+```
+
+### Cách hoạt động
+
+```mermaid
+graph TB
+    Main["Cây làm việc chính"] -->|tạo| Sub["Subagent với<br/>Worktree cô lập"]
+    Sub -->|thực hiện thay đổi trong| WT["Git Worktree<br/>riêng + Branch"]
+    WT -->|không có thay đổi| Clean["Tự động dọn dẹp"]
+    WT -->|có thay đổi| Return["Trả về đường dẫn<br/>worktree và branch"]
+
+    style Main fill:#e1f5fe,stroke:#333,color:#333
+    style Sub fill:#f3e5f5,stroke:#333,color:#333
+    style WT fill:#e8f5e9,stroke:#333,color:#333
+    style Clean fill:#fff3e0,stroke:#333,color:#333
+    style Return fill:#fff3e0,stroke:#333,color:#333
+```
+
+- Subagent hoạt động trong git worktree riêng trên branch riêng
+- Nếu subagent không thực hiện thay đổi, worktree tự động được dọn dẹp
+- Nếu có thay đổi, đường dẫn worktree và tên branch được trả về agent chính để review hoặc merge
+
+---
+
+## Giới hạn Subagents có thể tạo
+
+Bạn có thể kiểm soát subagents nào một subagent được phép tạo ra bằng cú pháp `Agent(loại_agent)` trong trường `tools`. Điều này cung cấp cách whitelist các subagents cụ thể cho việc ủy quyền.
+
+> **Lưu ý**: Trong v2.1.63, tool `Task` đã được đổi tên thành `Agent`. Các tham chiếu `Task(...)` hiện có vẫn hoạt động như aliases.
+
+### Ví dụ
+
+```yaml
+---
+name: coordinator
+description: Phối hợp công việc giữa các agents chuyên biệt
+tools: Agent(worker, researcher), Read, Bash
+---
+
+Bạn là agent điều phối. Bạn chỉ có thể ủy quyền công việc cho subagents "worker" và
+"researcher". Dùng Read và Bash cho việc khám phá của bạn.
+```
+
+Trong ví dụ này, subagent `coordinator` chỉ có thể tạo các subagents `worker` và `researcher`. Không thể tạo subagents khác, dù chúng được định nghĩa ở nơi khác.
+
+---
+
+## Lệnh CLI `claude agents`
+
+Lệnh `claude agents` liệt kê tất cả agents được cấu hình theo nhóm nguồn (tích hợp sẵn, cấp người dùng, cấp dự án):
+
+```bash
+claude agents
+```
+
+Lệnh này:
+- Hiển thị tất cả agents có sẵn từ tất cả nguồn
+- Nhóm agents theo vị trí nguồn
+- Chỉ ra **ghi đè** khi một agent ở cấp ưu tiên cao hơn che khuất agent ở cấp thấp hơn (ví dụ: agent cấp dự án có cùng tên với agent cấp người dùng)
+
+---
+
+## Nhóm Agent (Thử nghiệm)
+
+Agent Teams (Nhóm Agent) phối hợp nhiều instance Claude Code làm việc cùng nhau trên các tác vụ phức tạp. Khác với subagents (nhận tác vụ con được ủy quyền trả về kết quả), teammates làm việc độc lập với ngữ cảnh riêng và giao tiếp trực tiếp qua hệ thống mailbox chia sẻ.
+
+> **Lưu ý**: Agent Teams là tính năng thử nghiệm và yêu cầu Claude Code v2.1.32+. Bật trước khi dùng.
+
+### Subagents vs Agent Teams
+
+| Khía cạnh | Subagents | Agent Teams |
+|-----------|-----------|-------------|
+| **Mô hình ủy quyền** | Parent ủy quyền tác vụ con, chờ kết quả | Team lead giao việc, teammates thực hiện độc lập |
+| **Ngữ cảnh** | Ngữ cảnh sạch mỗi tác vụ, kết quả được chắt lọc về | Mỗi teammate duy trì ngữ cảnh liên tục riêng |
+| **Phối hợp** | Tuần tự hoặc song song, được parent quản lý | Danh sách tác vụ chia sẻ với quản lý dependency tự động |
+| **Giao tiếp** | Chỉ trả về giá trị | Nhắn tin giữa agent qua mailbox |
+| **Tiếp tục phiên** | Được hỗ trợ | Không hỗ trợ với teammates in-process |
+| **Tốt nhất cho** | Tác vụ con tập trung, được xác định rõ | Dự án đa file lớn cần công việc song song |
+
+### Bật Agent Teams
+
+Đặt biến môi trường hoặc thêm vào `settings.json`:
+
+```bash
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+```
+
+Hoặc trong `settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+### Bắt đầu một nhóm
+
+Khi đã bật, yêu cầu Claude làm việc với teammates trong prompt của bạn:
+
+```
+Người dùng: Xây dựng module xác thực. Dùng một nhóm — một teammate cho API endpoints,
+             một cho database schema, và một cho test suite.
+```
+
+Claude sẽ tạo nhóm, giao tác vụ và phối hợp công việc tự động.
+
+### Chế độ hiển thị
+
+Kiểm soát cách hoạt động của teammate được hiển thị:
+
+| Chế độ | Cờ | Mô tả |
+|--------|----|----|
+| **Auto** | `--teammate-mode auto` | Tự động chọn chế độ hiển thị tốt nhất cho terminal |
+| **In-process** | `--teammate-mode in-process` | Hiển thị đầu ra teammate nội tuyến trong terminal hiện tại (mặc định) |
+| **Split-panes** | `--teammate-mode tmux` | Mở mỗi teammate trong pane tmux hoặc iTerm2 riêng |
+
+```bash
+claude --teammate-mode tmux
+```
+
+Bạn cũng có thể đặt chế độ hiển thị trong `settings.json`:
+
+```json
+{
+  "teammateMode": "tmux"
+}
+```
+
+> **Lưu ý**: Chế độ split-pane yêu cầu tmux hoặc iTerm2. Không có sẵn trong VS Code terminal, Windows Terminal hoặc Ghostty.
+
+### Điều hướng
+
+Dùng `Shift+Down` để điều hướng giữa các teammates trong chế độ split-pane.
+
+### Cấu hình nhóm
+
+Cấu hình nhóm được lưu tại `~/.claude/teams/{tên-nhóm}/config.json`.
+
+### Kiến trúc
+
+```mermaid
+graph TB
+    Lead["Team Lead<br/>(Điều phối)"]
+    TaskList["Danh sách tác vụ<br/>(Dependencies)"]
+    Mailbox["Mailbox<br/>(Tin nhắn)"]
+    T1["Teammate 1<br/>(Ngữ cảnh riêng)"]
+    T2["Teammate 2<br/>(Ngữ cảnh riêng)"]
+    T3["Teammate 3<br/>(Ngữ cảnh riêng)"]
+
+    Lead -->|giao tác vụ| TaskList
+    Lead -->|gửi tin nhắn| Mailbox
+    TaskList -->|nhận công việc| T1
+    TaskList -->|nhận công việc| T2
+    TaskList -->|nhận công việc| T3
+    T1 -->|đọc/ghi| Mailbox
+    T2 -->|đọc/ghi| Mailbox
+    T3 -->|đọc/ghi| Mailbox
+    T1 -->|cập nhật trạng thái| TaskList
+    T2 -->|cập nhật trạng thái| TaskList
+    T3 -->|cập nhật trạng thái| TaskList
+
+    style Lead fill:#e1f5fe,stroke:#333,color:#333
+    style TaskList fill:#fff9c4,stroke:#333,color:#333
+    style Mailbox fill:#f3e5f5,stroke:#333,color:#333
+    style T1 fill:#e8f5e9,stroke:#333,color:#333
+    style T2 fill:#e8f5e9,stroke:#333,color:#333
+    style T3 fill:#e8f5e9,stroke:#333,color:#333
+```
+
+**Các thành phần chính**:
+
+- **Team Lead**: Phiên Claude Code chính tạo nhóm, giao tác vụ và điều phối
+- **Danh sách tác vụ chia sẻ**: Danh sách tác vụ đồng bộ với theo dõi dependency tự động
+- **Mailbox**: Hệ thống nhắn tin giữa agent cho teammates giao tiếp trạng thái và phối hợp
+- **Teammates**: Các instance Claude Code độc lập, mỗi cái có cửa sổ ngữ cảnh riêng
+
+### Giao việc và nhắn tin
+
+Team lead chia công việc thành tác vụ và giao cho teammates. Danh sách tác vụ chia sẻ xử lý:
+
+- **Quản lý dependency tự động** — tác vụ chờ các dependency hoàn thành
+- **Theo dõi trạng thái** — teammates cập nhật trạng thái tác vụ khi làm việc
+- **Nhắn tin giữa agent** — teammates gửi tin nhắn qua mailbox để phối hợp (ví dụ: "Schema database đã sẵn sàng, bạn có thể bắt đầu viết queries")
+
+### Quy trình phê duyệt kế hoạch
+
+Cho các tác vụ phức tạp, team lead tạo kế hoạch thực thi trước khi teammates bắt đầu làm việc. Người dùng review và phê duyệt kế hoạch, đảm bảo cách tiếp cận của nhóm phù hợp với kỳ vọng trước khi thực hiện bất kỳ thay đổi code nào.
+
+### Sự kiện Hook cho nhóm
+
+Agent Teams giới thiệu thêm hai [sự kiện hook](../06-hooks/):
+
+| Sự kiện | Kích hoạt khi | Trường hợp dùng |
+|---------|--------------|----------------|
+| `TeammateIdle` | Teammate hoàn thành tác vụ hiện tại và không có công việc đang chờ | Kích hoạt thông báo, giao tác vụ tiếp theo |
+| `TaskCompleted` | Tác vụ trong danh sách tác vụ chia sẻ được đánh dấu hoàn thành | Chạy xác thực, cập nhật dashboard, kết nối công việc phụ thuộc |
+
+### Thực hành tốt nhất
+
+- **Quy mô nhóm**: Giữ nhóm 3-5 teammates để phối hợp tối ưu
+- **Kích thước tác vụ**: Chia công việc thành tác vụ mỗi tác vụ mất 5-15 phút — đủ nhỏ để song song hóa, đủ lớn để có nghĩa
+- **Tránh xung đột file**: Giao các file hoặc thư mục khác nhau cho các teammates khác nhau để ngăn merge conflicts
+- **Bắt đầu đơn giản**: Dùng chế độ in-process cho nhóm đầu tiên; chuyển sang split-panes khi đã quen
+- **Mô tả tác vụ rõ ràng**: Cung cấp mô tả tác vụ cụ thể, có thể hành động để teammates có thể làm việc độc lập
+
+### Giới hạn
+
+- **Thử nghiệm**: Hành vi tính năng có thể thay đổi trong các bản phát hành tương lai
+- **Không tiếp tục phiên**: Teammates in-process không thể tiếp tục sau khi phiên kết thúc
+- **Một nhóm mỗi phiên**: Không thể tạo nhóm lồng nhau hoặc nhiều nhóm trong một phiên
+- **Leadership cố định**: Vai trò team lead không thể chuyển cho teammate
+- **Giới hạn split-pane**: Yêu cầu tmux/iTerm2; không có sẵn trong VS Code terminal, Windows Terminal hoặc Ghostty
+- **Không có nhóm xuyên phiên**: Teammates chỉ tồn tại trong phiên hiện tại
+
+> **Cảnh báo**: Agent Teams là tính năng thử nghiệm. Kiểm tra với công việc không quan trọng trước và giám sát phối hợp teammate cho hành vi không mong đợi.
+
+---
+
+## Bảo mật Subagent của Plugin
+
+Subagents do plugin cung cấp có khả năng frontmatter bị giới hạn vì lý do bảo mật. Các trường sau **không được phép** trong định nghĩa subagent plugin:
+
+- `hooks` — Không thể định nghĩa lifecycle hooks
+- `mcpServers` — Không thể cấu hình MCP servers
+- `permissionMode` — Không thể ghi đè cài đặt quyền
+
+Điều này ngăn plugins leo thang đặc quyền hoặc thực thi lệnh tùy ý qua subagent hooks.
+
+---
+
+## Kiến trúc
+
+### Kiến trúc tổng quan
+
+```mermaid
+graph TB
+    User["Người dùng"]
+    Main["Agent chính<br/>(Điều phối)"]
+    Reviewer["Subagent<br/>Review Code"]
+    Tester["Subagent<br/>Kỹ sư Test"]
+    Docs["Subagent<br/>Tài liệu"]
+
+    User -->|yêu cầu| Main
+    Main -->|ủy quyền| Reviewer
+    Main -->|ủy quyền| Tester
+    Main -->|ủy quyền| Docs
+    Reviewer -->|trả kết quả| Main
+    Tester -->|trả kết quả| Main
+    Docs -->|trả kết quả| Main
+    Main -->|tổng hợp| User
+```
+
+### Vòng đời Subagent
+
+```mermaid
+sequenceDiagram
+    participant User as Người dùng
+    participant MainAgent as Agent chính
+    participant CodeReviewer as Subagent<br/>Review Code
+    participant Context as Cửa sổ ngữ<br/>cảnh riêng
+
+    User->>MainAgent: "Xây dựng tính năng auth mới"
+    MainAgent->>MainAgent: Phân tích tác vụ
+    MainAgent->>CodeReviewer: "Review code này"
+    CodeReviewer->>Context: Khởi tạo ngữ cảnh sạch
+    Context->>CodeReviewer: Tải hướng dẫn reviewer
+    CodeReviewer->>CodeReviewer: Thực hiện review
+    CodeReviewer-->>MainAgent: Trả về phát hiện
+    MainAgent->>MainAgent: Tích hợp kết quả
+    MainAgent-->>User: Cung cấp tổng hợp
+```
+
+---
+
+## Quản lý ngữ cảnh
+
+```mermaid
+graph TB
+    A["Ngữ cảnh Agent chính<br/>50.000 tokens"]
+    B["Ngữ cảnh Subagent 1<br/>20.000 tokens"]
+    C["Ngữ cảnh Subagent 2<br/>20.000 tokens"]
+    D["Ngữ cảnh Subagent 3<br/>20.000 tokens"]
+
+    A -->|Ngữ cảnh sạch| B
+    A -->|Ngữ cảnh sạch| C
+    A -->|Ngữ cảnh sạch| D
+
+    B -->|Chỉ kết quả| A
+    C -->|Chỉ kết quả| A
+    D -->|Chỉ kết quả| A
+
+    style A fill:#e1f5fe
+    style B fill:#fff9c4
+    style C fill:#fff9c4
+    style D fill:#fff9c4
+```
+
+### Điểm chính
+
+- Mỗi subagent nhận một **cửa sổ ngữ cảnh sạch** mà không có lịch sử hội thoại chính
+- Chỉ **ngữ cảnh liên quan** được truyền cho subagent cho tác vụ cụ thể của chúng
+- Kết quả được **chắt lọc** về agent chính
+- Điều này ngăn **cạn kiệt token ngữ cảnh** trên các dự án dài
+
+### Cân nhắc hiệu năng
+
+- **Hiệu quả ngữ cảnh** — Agents bảo toàn ngữ cảnh chính, cho phép phiên dài hơn
+- **Độ trễ** — Subagents bắt đầu với ngữ cảnh sạch và có thể thêm độ trễ khi thu thập ngữ cảnh ban đầu
+
+### Hành vi chính
+
+- **Không tạo lồng nhau** — Subagents không thể tạo subagents khác
+- **Quyền nền** — Subagents nền tự động từ chối mọi quyền chưa được phê duyệt trước
+- **Đưa xuống nền** — Nhấn `Ctrl+B` để đưa tác vụ đang chạy xuống nền
+- **Transcripts** — Transcripts subagent lưu tại `~/.claude/projects/{dự_án}/{sessionId}/subagents/agent-{agentId}.jsonl`
+- **Auto-compaction** — Ngữ cảnh subagent tự động compact ở ~95% dung lượng (ghi đè bằng biến môi trường `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`)
+
+---
+
+## Khi nào dùng Subagents
+
+| Tình huống | Dùng Subagent | Lý do |
+|-----------|--------------|-------|
+| Tính năng phức tạp với nhiều bước | Có | Tách biệt quan tâm, ngăn ô nhiễm ngữ cảnh |
+| Review code nhanh | Không | Chi phí không cần thiết |
+| Thực thi tác vụ song song | Có | Mỗi subagent có ngữ cảnh riêng |
+| Cần chuyên môn chuyên biệt | Có | System prompts tùy chỉnh |
+| Phân tích dài hạn | Có | Ngăn cạn kiệt ngữ cảnh chính |
+| Tác vụ đơn lẻ | Không | Thêm độ trễ không cần thiết |
+
+---
+
+## Thực hành tốt nhất
+
+### Nguyên tắc thiết kế
+
+**Nên làm:**
+- Bắt đầu với agents do Claude tạo — Tạo subagent ban đầu với Claude, sau đó lặp lại để tùy chỉnh
+- Thiết kế subagents tập trung — Trách nhiệm đơn, rõ ràng thay vì một làm tất cả
+- Viết prompts chi tiết — Bao gồm hướng dẫn cụ thể, ví dụ và ràng buộc
+- Giới hạn quyền truy cập tool — Chỉ cấp tools cần thiết cho mục đích của subagent
+- Kiểm soát phiên bản — Commit subagents dự án vào version control để cộng tác nhóm
+
+**Không nên làm:**
+- Tạo subagents trùng lặp với cùng vai trò
+- Cấp quyền truy cập tool không cần thiết cho subagents
+- Dùng subagents cho tác vụ đơn giản, một bước
+- Trộn lẫn nhiều quan tâm trong prompt của một subagent
+- Quên truyền ngữ cảnh cần thiết
+
+### Thực hành tốt nhất cho System Prompt
+
+1. **Cụ thể về Vai trò**
+   ```
+   Bạn là chuyên gia code reviewer chuyên về [lĩnh vực cụ thể]
+   ```
+
+2. **Định nghĩa Ưu tiên rõ ràng**
+   ```
+   Ưu tiên review (theo thứ tự):
+   1. Vấn đề bảo mật
+   2. Vấn đề hiệu năng
+   3. Chất lượng code
+   ```
+
+3. **Chỉ định Định dạng đầu ra**
+   ```
+   Với mỗi vấn đề cung cấp: Mức độ, Danh mục, Vị trí, Mô tả, Cách sửa, Tác động
+   ```
+
+4. **Bao gồm Các bước hành động**
+   ```
+   Khi được gọi:
+   1. Chạy git diff để xem các thay đổi gần đây
+   2. Tập trung vào các file đã sửa đổi
+   3. Bắt đầu review ngay
+   ```
+
+### Chiến lược truy cập Tool
+
+1. **Bắt đầu hạn chế**: Bắt đầu chỉ với tools thiết yếu
+2. **Mở rộng chỉ khi cần**: Thêm tools khi yêu cầu đòi hỏi
+3. **Chỉ đọc khi có thể**: Dùng Read/Grep cho agents phân tích
+4. **Thực thi trong sandbox**: Giới hạn lệnh Bash theo pattern cụ thể
+
+---
+
+## Ví dụ Subagents trong thư mục này
+
+Thư mục này chứa các subagent ví dụ sẵn dùng:
+
+### 1. Code Reviewer (`code-reviewer.md`)
+
+**Mục đích**: Phân tích chất lượng code và khả năng bảo trì toàn diện
+
+**Tools**: Read, Grep, Glob, Bash
+
+**Chuyên môn**:
+- Phát hiện lỗ hổng bảo mật
+- Xác định cơ hội tối ưu hiệu năng
+- Đánh giá khả năng bảo trì code
+- Phân tích độ phủ test
+
+**Dùng khi**: Bạn cần review code tự động tập trung vào chất lượng và bảo mật
+
+---
+
+### 2. Test Engineer (`test-engineer.md`)
+
+**Mục đích**: Chiến lược test, phân tích độ phủ và test tự động
+
+**Tools**: Read, Write, Bash, Grep
+
+**Chuyên môn**:
+- Tạo unit test
+- Thiết kế integration test
+- Xác định edge case
+- Phân tích độ phủ (mục tiêu >80%)
+
+**Dùng khi**: Bạn cần tạo test suite toàn diện hoặc phân tích độ phủ
+
+---
+
+### 3. Documentation Writer (`documentation-writer.md`)
+
+**Mục đích**: Tài liệu kỹ thuật, tài liệu API và hướng dẫn người dùng
+
+**Tools**: Read, Write, Grep
+
+**Chuyên môn**:
+- Tài liệu API endpoint
+- Tạo hướng dẫn người dùng
+- Tài liệu kiến trúc
+- Cải thiện comment code
+
+**Dùng khi**: Bạn cần tạo hoặc cập nhật tài liệu dự án
+
+---
+
+### 4. Secure Reviewer (`secure-reviewer.md`)
+
+**Mục đích**: Review code tập trung bảo mật với quyền tối thiểu
+
+**Tools**: Read, Grep
+
+**Chuyên môn**:
+- Phát hiện lỗ hổng bảo mật
+- Vấn đề xác thực/ủy quyền
+- Rủi ro lộ dữ liệu
+- Xác định tấn công injection
+
+**Dùng khi**: Bạn cần kiểm tra bảo mật mà không có khả năng sửa đổi
+
+---
+
+### 5. Implementation Agent (`implementation-agent.md`)
+
+**Mục đích**: Khả năng triển khai đầy đủ cho phát triển tính năng
+
+**Tools**: Read, Write, Edit, Bash, Grep, Glob
+
+**Chuyên môn**:
+- Triển khai tính năng
+- Tạo code
+- Thực thi build và test
+- Sửa đổi codebase
+
+**Dùng khi**: Bạn cần subagent triển khai tính năng từ đầu đến cuối
+
+---
+
+### 6. Debugger (`debugger.md`)
+
+**Mục đích**: Chuyên gia debug cho lỗi, test thất bại và hành vi không mong đợi
+
+**Tools**: Read, Edit, Bash, Grep, Glob
+
+**Chuyên môn**:
+- Phân tích nguyên nhân gốc rễ
+- Điều tra lỗi
+- Giải quyết test thất bại
+- Triển khai bản sửa lỗi tối thiểu
+
+**Dùng khi**: Bạn gặp bugs, lỗi hoặc hành vi không mong đợi
+
+---
+
+### 7. Data Scientist (`data-scientist.md`)
+
+**Mục đích**: Chuyên gia phân tích dữ liệu cho truy vấn SQL và thông tin dữ liệu
+
+**Tools**: Bash, Read, Write
+
+**Chuyên môn**:
+- Tối ưu truy vấn SQL
+- Thao tác BigQuery
+- Phân tích và trực quan hóa dữ liệu
+- Thông tin thống kê
+
+**Dùng khi**: Bạn cần phân tích dữ liệu, truy vấn SQL hoặc thao tác BigQuery
+
+---
+
+## Hướng dẫn cài đặt
+
+### Phương pháp 1: Dùng lệnh /agents (Khuyến nghị)
+
+```bash
+/agents
+```
+
+Sau đó:
+1. Chọn 'Create New Agent'
+2. Chọn cấp project hoặc cấp user
+3. Mô tả subagent của bạn chi tiết
+4. Chọn tools để cấp quyền (hoặc để trống để kế thừa tất cả)
+5. Lưu và dùng
+
+### Phương pháp 2: Sao chép vào dự án
+
+Sao chép file agent vào thư mục `.claude/agents/` của dự án:
+
+```bash
+# Điều hướng đến dự án của bạn
+cd /path/to/your/project
+
+# Tạo thư mục agents nếu chưa có
+mkdir -p .claude/agents
+
+# Sao chép tất cả file agent từ thư mục này
+cp /path/to/04-subagents/*.md .claude/agents/
+
+# Xóa README (không cần trong .claude/agents)
+rm .claude/agents/README.md
+```
+
+### Phương pháp 3: Sao chép vào thư mục người dùng
+
+Cho agents có sẵn trong tất cả dự án:
+
+```bash
+# Tạo thư mục user agents
+mkdir -p ~/.claude/agents
+
+# Sao chép agents
+cp /path/to/04-subagents/code-reviewer.md ~/.claude/agents/
+cp /path/to/04-subagents/debugger.md ~/.claude/agents/
+# ... sao chép các agents khác khi cần
+```
+
+### Xác minh
+
+Sau khi cài đặt, xác minh agents được nhận diện:
+
+```bash
+/agents
+```
+
+Bạn sẽ thấy các agents đã cài đặt được liệt kê cùng với các agents tích hợp sẵn.
+
+---
+
+## Cấu trúc file
+
+```
+project/
+├── .claude/
+│   └── agents/
+│       ├── code-reviewer.md
+│       ├── test-engineer.md
+│       ├── documentation-writer.md
+│       ├── secure-reviewer.md
+│       ├── implementation-agent.md
+│       ├── debugger.md
+│       └── data-scientist.md
+└── ...
+```
+
+---
+
+## Khái niệm liên quan
+
+### Các tính năng liên quan
+
+- **[Slash Commands](../01-slash-commands/)** - Phím tắt nhanh do người dùng gọi
+- **[Memory](../02-memory/)** - Ngữ cảnh liên tục xuyên phiên
+- **[Skills](../03-skills/)** - Khả năng tự chủ có thể tái sử dụng
+- **[MCP Protocol](../05-mcp/)** - Truy cập dữ liệu bên ngoài thời gian thực
+- **[Hooks](../06-hooks/)** - Tự động hóa lệnh shell theo sự kiện
+- **[Plugins](../07-plugins/)** - Gói mở rộng tích hợp sẵn
+
+### So sánh với các tính năng khác
+
+| Tính năng | User gọi | Tự động gọi | Liên tục | Truy cập ngoài | Ngữ cảnh cô lập |
+|-----------|----------|-------------|---------|----------------|----------------|
+| **Slash Commands** | Có | Không | Không | Không | Không |
+| **Subagents** | Có | Có | Không | Không | Có |
+| **Memory** | Tự động | Tự động | Có | Không | Không |
+| **MCP** | Tự động | Có | Không | Có | Không |
+| **Skills** | Có | Có | Không | Không | Không |
+
+### Pattern tích hợp
+
+```mermaid
+graph TD
+    User["Yêu cầu người dùng"] --> Main["Agent chính"]
+    Main -->|Dùng| Memory["Memory<br/>(Ngữ cảnh)"]
+    Main -->|Truy vấn| MCP["MCP<br/>(Dữ liệu trực tiếp)"]
+    Main -->|Gọi| Skills["Skills<br/>(Tools tự động)"]
+    Main -->|Ủy quyền| Subagents["Subagents<br/>(Chuyên gia)"]
+
+    Subagents -->|Dùng| Memory
+    Subagents -->|Truy vấn| MCP
+    Subagents -->|Cô lập| Context["Cửa sổ ngữ<br/>cảnh sạch"]
+```
+
+---
+
+## Tài nguyên bổ sung
+
+- [Tài liệu Subagents chính thức](https://code.claude.com/docs/en/sub-agents)
+- [Tài liệu tham chiếu CLI](https://code.claude.com/docs/en/cli-reference) - Cờ `--agents` và các tùy chọn CLI khác
+- [Hướng dẫn Plugins](../07-plugins/) - Để đóng gói agents với các tính năng khác
+- [Hướng dẫn Skills](../03-skills/) - Cho các khả năng tự động gọi
+- [Hướng dẫn Memory](../02-memory/) - Cho ngữ cảnh liên tục
+- [Hướng dẫn Hooks](../06-hooks/) - Cho tự động hóa theo sự kiện
+
+---
+
+*Cập nhật lần cuối: Tháng 3 năm 2026*
+
+*Hướng dẫn này bao gồm cấu hình subagent đầy đủ, các pattern ủy quyền và thực hành tốt nhất cho Claude Code.*

--- a/05-mcp/README.vi.md
+++ b/05-mcp/README.vi.md
@@ -1,0 +1,1112 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# MCP (Model Context Protocol)
+
+Thư mục này chứa tài liệu toàn diện và các ví dụ về cấu hình và cách sử dụng MCP server với Claude Code.
+
+## Tổng quan
+
+MCP (Model Context Protocol — Giao thức Ngữ cảnh Mô hình) là một cách tiêu chuẩn hóa để Claude truy cập các công cụ bên ngoài, API và nguồn dữ liệu thời gian thực. Khác với Memory, MCP cung cấp truy cập trực tiếp vào dữ liệu thay đổi liên tục.
+
+Đặc điểm chính:
+- Truy cập thời gian thực vào các dịch vụ bên ngoài
+- Đồng bộ dữ liệu trực tiếp
+- Kiến trúc có thể mở rộng
+- Xác thực bảo mật
+- Tương tác dựa trên công cụ
+
+## Kiến trúc MCP
+
+```mermaid
+graph TB
+    A["Claude"]
+    B["MCP Server"]
+    C["Dịch vụ bên ngoài"]
+
+    A -->|Yêu cầu: list_issues| B
+    B -->|Truy vấn| C
+    C -->|Dữ liệu| B
+    B -->|Phản hồi| A
+
+    A -->|Yêu cầu: create_issue| B
+    B -->|Hành động| C
+    C -->|Kết quả| B
+    B -->|Phản hồi| A
+
+    style A fill:#e1f5fe,stroke:#333,color:#333
+    style B fill:#f3e5f5,stroke:#333,color:#333
+    style C fill:#e8f5e9,stroke:#333,color:#333
+```
+
+## Hệ sinh thái MCP
+
+```mermaid
+graph TB
+    A["Claude"] -->|MCP| B["Filesystem<br/>MCP Server"]
+    A -->|MCP| C["GitHub<br/>MCP Server"]
+    A -->|MCP| D["Database<br/>MCP Server"]
+    A -->|MCP| E["Slack<br/>MCP Server"]
+    A -->|MCP| F["Google Docs<br/>MCP Server"]
+
+    B -->|File I/O| G["File cục bộ"]
+    C -->|API| H["GitHub Repos"]
+    D -->|Query| I["PostgreSQL/MySQL"]
+    E -->|Tin nhắn| J["Slack Workspace"]
+    F -->|Tài liệu| K["Google Drive"]
+
+    style A fill:#e1f5fe,stroke:#333,color:#333
+    style B fill:#f3e5f5,stroke:#333,color:#333
+    style C fill:#f3e5f5,stroke:#333,color:#333
+    style D fill:#f3e5f5,stroke:#333,color:#333
+    style E fill:#f3e5f5,stroke:#333,color:#333
+    style F fill:#f3e5f5,stroke:#333,color:#333
+    style G fill:#e8f5e9,stroke:#333,color:#333
+    style H fill:#e8f5e9,stroke:#333,color:#333
+    style I fill:#e8f5e9,stroke:#333,color:#333
+    style J fill:#e8f5e9,stroke:#333,color:#333
+    style K fill:#e8f5e9,stroke:#333,color:#333
+```
+
+## Phương thức cài đặt MCP
+
+Claude Code hỗ trợ nhiều giao thức vận chuyển cho kết nối MCP server:
+
+### HTTP Transport (Khuyến nghị)
+
+```bash
+# Kết nối HTTP cơ bản
+claude mcp add --transport http notion https://mcp.notion.com/mcp
+
+# HTTP với header xác thực
+claude mcp add --transport http secure-api https://api.example.com/mcp \
+  --header "Authorization: Bearer your-token"
+```
+
+### Stdio Transport (Cục bộ)
+
+Cho các MCP server chạy cục bộ:
+
+```bash
+# Server Node.js cục bộ
+claude mcp add --transport stdio myserver -- npx @myorg/mcp-server
+
+# Với biến môi trường
+claude mcp add --transport stdio myserver --env KEY=value -- npx server
+```
+
+### SSE Transport (Đã lỗi thời)
+
+Giao thức Server-Sent Events đã lỗi thời, thay bằng `http` nhưng vẫn được hỗ trợ:
+
+```bash
+claude mcp add --transport sse legacy-server https://example.com/sse
+```
+
+### WebSocket Transport
+
+WebSocket transport cho kết nối hai chiều liên tục:
+
+```bash
+claude mcp add --transport ws realtime-server wss://example.com/mcp
+```
+
+### Lưu ý cho Windows
+
+Trên Windows gốc (không phải WSL), dùng `cmd /c` cho các lệnh npx:
+
+```bash
+claude mcp add --transport stdio my-server -- cmd /c npx -y @some/package
+```
+
+### Xác thực OAuth 2.0
+
+Claude Code hỗ trợ OAuth 2.0 cho các MCP server yêu cầu nó. Khi kết nối với server hỗ trợ OAuth, Claude Code xử lý toàn bộ quy trình xác thực:
+
+```bash
+# Kết nối với MCP server hỗ trợ OAuth (quy trình tương tác)
+claude mcp add --transport http my-service https://my-service.example.com/mcp
+
+# Cấu hình trước OAuth credentials cho thiết lập không tương tác
+claude mcp add --transport http my-service https://my-service.example.com/mcp \
+  --client-id "your-client-id" \
+  --client-secret "your-client-secret" \
+  --callback-port 8080
+```
+
+| Tính năng | Mô tả |
+|-----------|-------|
+| **OAuth tương tác** | Dùng `/mcp` để kích hoạt quy trình OAuth dựa trên trình duyệt |
+| **OAuth clients có sẵn** | OAuth clients tích hợp sẵn cho các dịch vụ phổ biến như Notion, Stripe và các dịch vụ khác (v2.1.30+) |
+| **Credentials được cấu hình trước** | Cờ `--client-id`, `--client-secret`, `--callback-port` để thiết lập tự động |
+| **Lưu trữ token** | Token được lưu trữ bảo mật trong keychain hệ thống |
+| **Step-up auth** | Hỗ trợ xác thực step-up cho các thao tác đặc quyền |
+| **Discovery caching** | Metadata OAuth discovery được cache để kết nối lại nhanh hơn |
+| **Ghi đè Metadata** | `oauth.authServerMetadataUrl` trong `.mcp.json` để ghi đè OAuth metadata discovery mặc định |
+
+#### Ghi đè OAuth Metadata Discovery
+
+Nếu MCP server của bạn trả về lỗi tại endpoint OAuth metadata tiêu chuẩn (`/.well-known/oauth-authorization-server`) nhưng có endpoint OIDC hoạt động, bạn có thể yêu cầu Claude Code lấy OAuth metadata từ URL cụ thể. Đặt `authServerMetadataUrl` trong object `oauth` của cấu hình server:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "authServerMetadataUrl": "https://auth.example.com/.well-known/openid-configuration"
+      }
+    }
+  }
+}
+```
+
+URL phải dùng `https://`. Tùy chọn này yêu cầu Claude Code v2.1.64 trở lên.
+
+### Claude.ai MCP Connectors
+
+Các MCP server được cấu hình trong tài khoản Claude.ai của bạn tự động có sẵn trong Claude Code. Điều này có nghĩa các kết nối MCP bạn thiết lập qua giao diện web Claude.ai sẽ có thể truy cập mà không cần cấu hình thêm.
+
+Claude.ai MCP connectors cũng có sẵn trong chế độ `--print` (v2.1.83+), cho phép sử dụng không tương tác và theo script.
+
+Để tắt MCP servers của Claude.ai trong Claude Code, đặt biến môi trường `ENABLE_CLAUDEAI_MCP_SERVERS` thành `false`:
+
+```bash
+ENABLE_CLAUDEAI_MCP_SERVERS=false claude
+```
+
+> **Lưu ý:** Tính năng này chỉ có cho người dùng đăng nhập bằng tài khoản Claude.ai.
+
+## Quy trình thiết lập MCP
+
+```mermaid
+sequenceDiagram
+    participant User as Người dùng
+    participant Claude as Claude Code
+    participant Config as File cấu hình
+    participant Service as Dịch vụ bên ngoài
+
+    User->>Claude: Gõ /mcp
+    Claude->>Claude: Liệt kê các MCP server có sẵn
+    Claude->>User: Hiển thị tùy chọn
+    User->>Claude: Chọn GitHub MCP
+    Claude->>Config: Cập nhật cấu hình
+    Config->>Claude: Kích hoạt kết nối
+    Claude->>Service: Kiểm tra kết nối
+    Service-->>Claude: Xác thực thành công
+    Claude->>User: ✅ MCP đã kết nối!
+```
+
+## Tìm kiếm Tool MCP
+
+Khi mô tả tool MCP vượt quá 10% cửa sổ ngữ cảnh, Claude Code tự động bật tìm kiếm tool để chọn đúng công cụ mà không làm quá tải ngữ cảnh.
+
+| Cài đặt | Giá trị | Mô tả |
+|---------|---------|-------|
+| `ENABLE_TOOL_SEARCH` | `auto` (mặc định) | Tự động bật khi mô tả tool vượt quá 10% ngữ cảnh |
+| `ENABLE_TOOL_SEARCH` | `auto:<N>` | Tự động bật tại ngưỡng `N` tools tùy chỉnh |
+| `ENABLE_TOOL_SEARCH` | `true` | Luôn bật bất kể số lượng tool |
+| `ENABLE_TOOL_SEARCH` | `false` | Tắt; tất cả mô tả tool được gửi đầy đủ |
+
+> **Lưu ý:** Tìm kiếm tool yêu cầu Sonnet 4 trở lên, hoặc Opus 4 trở lên. Các model Haiku không hỗ trợ tìm kiếm tool.
+
+## Cập nhật Tool động
+
+Claude Code hỗ trợ thông báo `list_changed` của MCP. Khi MCP server tự động thêm, xóa hoặc sửa đổi các tool có sẵn, Claude Code nhận cập nhật và điều chỉnh danh sách tool của mình tự động — không cần kết nối lại hoặc khởi động lại.
+
+## MCP Elicitation (Yêu cầu thông tin)
+
+Các MCP server có thể yêu cầu đầu vào có cấu trúc từ người dùng qua các hộp thoại tương tác (v2.1.49+). Điều này cho phép MCP server yêu cầu thông tin bổ sung trong quá trình làm việc — ví dụ: nhắc xác nhận, chọn từ danh sách tùy chọn, hoặc điền các trường bắt buộc — thêm tính tương tác vào các tương tác MCP server.
+
+## Giới hạn mô tả và hướng dẫn Tool
+
+Từ v2.1.84, Claude Code áp đặt giới hạn **2 KB** cho mô tả tool và hướng dẫn mỗi MCP server. Điều này ngăn các server riêng lẻ tiêu thụ quá nhiều ngữ cảnh với định nghĩa tool quá dài, giảm phình ngữ cảnh và giữ cho các tương tác hiệu quả.
+
+## MCP Prompts dưới dạng Slash Commands
+
+Các MCP server có thể expose prompts xuất hiện dưới dạng slash commands trong Claude Code. Prompts có thể truy cập bằng quy ước đặt tên:
+
+```
+/mcp__<server>__<prompt>
+```
+
+Ví dụ, nếu server tên `github` expose một prompt tên `review`, bạn có thể gọi nó bằng `/mcp__github__review`.
+
+## Loại trùng lặp Server
+
+Khi cùng một MCP server được định nghĩa ở nhiều phạm vi (local, project, user), cấu hình local được ưu tiên. Điều này cho phép bạn ghi đè cài đặt MCP cấp project hoặc cấp user bằng tùy chỉnh cục bộ mà không xung đột.
+
+## Tài nguyên MCP qua @ Mentions
+
+Bạn có thể tham chiếu các tài nguyên MCP trực tiếp trong prompts của mình bằng cú pháp `@`:
+
+```
+@tên-server:protocol://resource/path
+```
+
+Ví dụ, để tham chiếu tài nguyên database cụ thể:
+
+```
+@database:postgres://mydb/users
+```
+
+Điều này cho phép Claude lấy và bao gồm nội dung tài nguyên MCP nội tuyến như một phần của ngữ cảnh hội thoại.
+
+## Các phạm vi MCP
+
+Cấu hình MCP có thể lưu trữ ở các phạm vi khác nhau với mức độ chia sẻ khác nhau:
+
+| Phạm vi | Vị trí | Mô tả | Chia sẻ với | Cần phê duyệt |
+|---------|--------|-------|------------|--------------|
+| **Local** (mặc định) | `~/.claude.json` (theo đường dẫn dự án) | Riêng tư cho người dùng hiện tại, chỉ dự án hiện tại (trước gọi là `project`) | Chỉ bạn | Không |
+| **Project** | `.mcp.json` | Được commit vào git repository | Thành viên nhóm | Có (lần đầu dùng) |
+| **User** | `~/.claude.json` | Có sẵn qua tất cả dự án (trước gọi là `global`) | Chỉ bạn | Không |
+
+### Dùng phạm vi Project
+
+Lưu cấu hình MCP theo dự án trong `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.github.com/mcp"
+    }
+  }
+}
+```
+
+Thành viên nhóm sẽ thấy prompt phê duyệt khi lần đầu dùng project MCPs.
+
+## Quản lý cấu hình MCP
+
+### Thêm MCP Servers
+
+```bash
+# Thêm server HTTP-based
+claude mcp add --transport http github https://api.github.com/mcp
+
+# Thêm server stdio cục bộ
+claude mcp add --transport stdio database -- npx @company/db-server
+
+# Liệt kê tất cả MCP server
+claude mcp list
+
+# Xem chi tiết server cụ thể
+claude mcp get github
+
+# Xóa MCP server
+claude mcp remove github
+
+# Đặt lại lựa chọn phê duyệt theo dự án
+claude mcp reset-project-choices
+
+# Import từ Claude Desktop
+claude mcp add-from-claude-desktop
+```
+
+## Bảng các MCP Server có sẵn
+
+| MCP Server | Mục đích | Tools phổ biến | Xác thực | Thời gian thực |
+|-----------|---------|---------------|---------|--------------|
+| **Filesystem** | Thao tác file | read, write, delete | Quyền OS | ✅ Có |
+| **GitHub** | Quản lý repository | list_prs, create_issue, push | OAuth | ✅ Có |
+| **Slack** | Giao tiếp nhóm | send_message, list_channels | Token | ✅ Có |
+| **Database** | Truy vấn SQL | query, insert, update | Credentials | ✅ Có |
+| **Google Docs** | Truy cập tài liệu | read, write, share | OAuth | ✅ Có |
+| **Asana** | Quản lý dự án | create_task, update_status | API Key | ✅ Có |
+| **Stripe** | Dữ liệu thanh toán | list_charges, create_invoice | API Key | ✅ Có |
+| **Memory** | Bộ nhớ liên tục | store, retrieve, delete | Cục bộ | ❌ Không |
+
+## Ví dụ thực tế
+
+### Ví dụ 1: Cấu hình GitHub MCP
+
+**File:** `.mcp.json` (thư mục gốc dự án)
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+**Các GitHub MCP Tools có sẵn:**
+
+#### Quản lý Pull Request
+- `list_prs` - Liệt kê tất cả PRs trong repository
+- `get_pr` - Lấy chi tiết PR bao gồm diff
+- `create_pr` - Tạo PR mới
+- `update_pr` - Cập nhật mô tả/tiêu đề PR
+- `merge_pr` - Merge PR vào nhánh main
+- `review_pr` - Thêm comment review
+
+**Ví dụ yêu cầu:**
+```
+/mcp__github__get_pr 456
+
+# Trả về:
+Title: Thêm hỗ trợ dark mode
+Author: @alice
+Description: Triển khai dark theme dùng CSS variables
+Status: OPEN
+Reviewers: @bob, @charlie
+```
+
+#### Quản lý Issue
+- `list_issues` - Liệt kê tất cả issues
+- `get_issue` - Lấy chi tiết issue
+- `create_issue` - Tạo issue mới
+- `close_issue` - Đóng issue
+- `add_comment` - Thêm comment vào issue
+
+#### Thông tin Repository
+- `get_repo_info` - Chi tiết repository
+- `list_files` - Cấu trúc cây file
+- `get_file_content` - Đọc nội dung file
+- `search_code` - Tìm kiếm trong codebase
+
+#### Thao tác Commit
+- `list_commits` - Lịch sử commit
+- `get_commit` - Chi tiết commit cụ thể
+- `create_commit` - Tạo commit mới
+
+**Thiết lập**:
+```bash
+export GITHUB_TOKEN="your_github_token"
+# Hoặc dùng CLI để thêm trực tiếp:
+claude mcp add --transport stdio github -- npx @modelcontextprotocol/server-github
+```
+
+### Mở rộng biến môi trường trong cấu hình
+
+Cấu hình MCP hỗ trợ mở rộng biến môi trường với giá trị mặc định dự phòng. Cú pháp `${VAR}` và `${VAR:-default}` hoạt động trong các trường sau: `command`, `args`, `env`, `url` và `headers`.
+
+```json
+{
+  "mcpServers": {
+    "api-server": {
+      "type": "http",
+      "url": "${API_BASE_URL:-https://api.example.com}/mcp",
+      "headers": {
+        "Authorization": "Bearer ${API_KEY}",
+        "X-Custom-Header": "${CUSTOM_HEADER:-default-value}"
+      }
+    },
+    "local-server": {
+      "command": "${MCP_BIN_PATH:-npx}",
+      "args": ["${MCP_PACKAGE:-@company/mcp-server}"],
+      "env": {
+        "DB_URL": "${DATABASE_URL:-postgresql://localhost/dev}"
+      }
+    }
+  }
+}
+```
+
+Biến được mở rộng lúc chạy:
+- `${VAR}` - Dùng biến môi trường, lỗi nếu chưa đặt
+- `${VAR:-default}` - Dùng biến môi trường, dùng giá trị mặc định nếu chưa đặt
+
+### Ví dụ 2: Thiết lập Database MCP
+
+**Cấu hình:**
+
+```json
+{
+  "mcpServers": {
+    "database": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-database"],
+      "env": {
+        "DATABASE_URL": "postgresql://user:pass@localhost/mydb"
+      }
+    }
+  }
+}
+```
+
+**Ví dụ sử dụng:**
+
+```markdown
+Người dùng: Lấy tất cả users có hơn 10 đơn hàng
+
+Claude: Tôi sẽ truy vấn database để tìm thông tin đó.
+
+# Dùng MCP database tool:
+SELECT u.*, COUNT(o.id) as order_count
+FROM users u
+LEFT JOIN orders o ON u.id = o.user_id
+GROUP BY u.id
+HAVING COUNT(o.id) > 10
+ORDER BY order_count DESC;
+
+# Kết quả:
+- Alice: 15 đơn hàng
+- Bob: 12 đơn hàng
+- Charlie: 11 đơn hàng
+```
+
+**Thiết lập**:
+```bash
+export DATABASE_URL="postgresql://user:pass@localhost/mydb"
+# Hoặc dùng CLI để thêm trực tiếp:
+claude mcp add --transport stdio database -- npx @modelcontextprotocol/server-database
+```
+
+### Ví dụ 3: Quy trình đa MCP
+
+**Tình huống: Tạo báo cáo hàng ngày**
+
+```markdown
+# Quy trình báo cáo hàng ngày dùng nhiều MCPs
+
+## Thiết lập
+1. GitHub MCP - lấy chỉ số PR
+2. Database MCP - truy vấn dữ liệu bán hàng
+3. Slack MCP - đăng báo cáo
+4. Filesystem MCP - lưu báo cáo
+
+## Quy trình
+
+### Bước 1: Lấy dữ liệu GitHub
+/mcp__github__list_prs completed:true last:7days
+
+Kết quả:
+- Tổng PRs: 42
+- Thời gian merge trung bình: 2.3 giờ
+- Thời gian review: 1.1 giờ
+
+### Bước 2: Truy vấn Database
+SELECT COUNT(*) as sales, SUM(amount) as revenue
+FROM orders
+WHERE created_at > NOW() - INTERVAL '1 day'
+
+Kết quả:
+- Doanh số: 247
+- Doanh thu: $12,450
+
+### Bước 3: Tạo báo cáo
+Kết hợp dữ liệu thành báo cáo HTML
+
+### Bước 4: Lưu vào Filesystem
+Ghi report.html vào /reports/
+
+### Bước 5: Đăng lên Slack
+Gửi tóm tắt vào kênh #daily-reports
+
+Kết quả cuối:
+✅ Báo cáo đã tạo và đăng
+📊 47 PRs được merge tuần này
+💰 $12,450 doanh thu ngày
+```
+
+**Thiết lập**:
+```bash
+export GITHUB_TOKEN="your_github_token"
+export DATABASE_URL="postgresql://user:pass@localhost/mydb"
+export SLACK_TOKEN="your_slack_token"
+# Thêm mỗi MCP server qua CLI hoặc cấu hình trong .mcp.json
+```
+
+### Ví dụ 4: Filesystem MCP Operations
+
+**Cấu hình:**
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-filesystem", "/home/user/projects"]
+    }
+  }
+}
+```
+
+**Các thao tác có sẵn:**
+
+| Thao tác | Lệnh | Mục đích |
+|----------|------|---------|
+| Liệt kê file | `ls ~/projects` | Hiển thị nội dung thư mục |
+| Đọc file | `cat src/main.ts` | Đọc nội dung file |
+| Ghi file | `create docs/api.md` | Tạo file mới |
+| Sửa file | `edit src/app.ts` | Chỉnh sửa file |
+| Tìm kiếm | `grep "async function"` | Tìm trong file |
+| Xóa | `rm old-file.js` | Xóa file |
+
+**Thiết lập**:
+```bash
+# Dùng CLI để thêm trực tiếp:
+claude mcp add --transport stdio filesystem -- npx @modelcontextprotocol/server-filesystem /home/user/projects
+```
+
+## Ma trận quyết định MCP vs Memory
+
+```mermaid
+graph TD
+    A["Cần dữ liệu bên ngoài?"]
+    A -->|Không| B["Dùng Memory"]
+    A -->|Có| C["Dữ liệu có thay đổi thường xuyên không?"]
+    C -->|Không/Hiếm| B
+    C -->|Có/Thường| D["Dùng MCP"]
+
+    B -->|Lưu trữ| E["Tùy chọn<br/>Ngữ cảnh<br/>Lịch sử"]
+    D -->|Truy cập| F["APIs trực tiếp<br/>Database<br/>Dịch vụ"]
+
+    style A fill:#fff3e0,stroke:#333,color:#333
+    style B fill:#e1f5fe,stroke:#333,color:#333
+    style C fill:#fff3e0,stroke:#333,color:#333
+    style D fill:#f3e5f5,stroke:#333,color:#333
+    style E fill:#e8f5e9,stroke:#333,color:#333
+    style F fill:#e8f5e9,stroke:#333,color:#333
+```
+
+## Pattern Yêu cầu/Phản hồi
+
+```mermaid
+sequenceDiagram
+    participant App as Claude
+    participant MCP as MCP Server
+    participant DB as Database
+
+    App->>MCP: Yêu cầu: "SELECT * FROM users WHERE id=1"
+    MCP->>DB: Thực thi truy vấn
+    DB-->>MCP: Tập kết quả
+    MCP-->>App: Trả về dữ liệu đã phân tích
+    App->>App: Xử lý kết quả
+    App->>App: Tiếp tục tác vụ
+
+    Note over MCP,DB: Truy cập thời gian thực<br/>Không cache
+```
+
+## Biến môi trường
+
+Lưu thông tin xác thực nhạy cảm trong biến môi trường:
+
+```bash
+# ~/.bashrc hoặc ~/.zshrc
+export GITHUB_TOKEN="ghp_xxxxxxxxxxxxx"
+export DATABASE_URL="postgresql://user:pass@localhost/mydb"
+export SLACK_TOKEN="xoxb-xxxxxxxxxxxxx"
+```
+
+Sau đó tham chiếu trong cấu hình MCP:
+
+```json
+{
+  "env": {
+    "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+  }
+}
+```
+
+## Claude làm MCP Server (`claude mcp serve`)
+
+Bản thân Claude Code có thể hoạt động như một MCP server cho các ứng dụng khác. Điều này cho phép các công cụ bên ngoài, editor và hệ thống tự động tận dụng khả năng của Claude qua giao thức MCP tiêu chuẩn.
+
+```bash
+# Khởi động Claude Code làm MCP server trên stdio
+claude mcp serve
+```
+
+Các ứng dụng khác có thể kết nối với server này như với bất kỳ MCP server dựa trên stdio nào. Ví dụ, để thêm Claude Code làm MCP server trong một instance Claude Code khác:
+
+```bash
+claude mcp add --transport stdio claude-agent -- claude mcp serve
+```
+
+Hữu ích khi xây dựng quy trình đa agent trong đó một instance Claude điều phối instance khác.
+
+## Cấu hình MCP Quản lý (Enterprise)
+
+Cho các triển khai doanh nghiệp, quản trị viên IT có thể áp đặt chính sách MCP server qua file cấu hình `managed-mcp.json`. File này cung cấp quyền kiểm soát duy nhất về các MCP server nào được phép hoặc bị chặn trên toàn tổ chức.
+
+**Vị trí:**
+- macOS: `/Library/Application Support/ClaudeCode/managed-mcp.json`
+- Linux: `~/.config/ClaudeCode/managed-mcp.json`
+- Windows: `%APPDATA%\ClaudeCode\managed-mcp.json`
+
+**Tính năng:**
+- `allowedMcpServers` -- danh sách trắng các server được phép
+- `deniedMcpServers` -- danh sách đen các server bị cấm
+- Hỗ trợ khớp theo tên server, lệnh và URL patterns
+- Chính sách MCP toàn tổ chức được áp dụng trước cấu hình người dùng
+- Ngăn kết nối server trái phép
+
+**Ví dụ cấu hình:**
+
+```json
+{
+  "allowedMcpServers": [
+    {
+      "serverName": "github",
+      "serverUrl": "https://api.github.com/mcp"
+    },
+    {
+      "serverName": "company-internal",
+      "serverCommand": "company-mcp-server"
+    }
+  ],
+  "deniedMcpServers": [
+    {
+      "serverName": "untrusted-*"
+    },
+    {
+      "serverUrl": "http://*"
+    }
+  ]
+}
+```
+
+> **Lưu ý:** Khi cả `allowedMcpServers` và `deniedMcpServers` khớp một server, quy tắc deny được ưu tiên.
+
+## MCP Servers do Plugin cung cấp
+
+Plugins có thể đi kèm các MCP server riêng, tự động có sẵn khi plugin được cài đặt. MCP servers do plugin cung cấp có thể được định nghĩa theo hai cách:
+
+1. **`.mcp.json` độc lập** -- Đặt file `.mcp.json` trong thư mục gốc plugin
+2. **Nội tuyến trong `plugin.json`** -- Định nghĩa MCP servers trực tiếp trong manifest plugin
+
+Dùng biến `${CLAUDE_PLUGIN_ROOT}` để tham chiếu đường dẫn tương đối với thư mục cài đặt plugin:
+
+```json
+{
+  "mcpServers": {
+    "plugin-tools": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.js"],
+      "env": {
+        "CONFIG_PATH": "${CLAUDE_PLUGIN_ROOT}/config.json"
+      }
+    }
+  }
+}
+```
+
+## MCP theo phạm vi Subagent
+
+Các MCP server có thể được định nghĩa nội tuyến trong frontmatter agent bằng khóa `mcpServers:`, giới hạn phạm vi cho subagent cụ thể thay vì toàn bộ dự án. Hữu ích khi một agent cần truy cập MCP server cụ thể mà các agent khác trong quy trình không cần.
+
+```yaml
+---
+mcpServers:
+  my-tool:
+    type: http
+    url: https://my-tool.example.com/mcp
+---
+
+Bạn là agent có quyền truy cập my-tool cho các thao tác chuyên biệt.
+```
+
+Các MCP server theo phạm vi subagent chỉ có sẵn trong ngữ cảnh thực thi của agent đó và không được chia sẻ với agent cha hoặc agent anh em.
+
+## Giới hạn đầu ra MCP
+
+Claude Code áp đặt giới hạn đầu ra tool MCP để ngăn tràn ngữ cảnh:
+
+| Giới hạn | Ngưỡng | Hành vi |
+|---------|--------|---------|
+| **Cảnh báo** | 10.000 tokens | Hiển thị cảnh báo rằng đầu ra lớn |
+| **Tối đa mặc định** | 25.000 tokens | Đầu ra bị cắt ngắn sau giới hạn này |
+| **Lưu vào đĩa** | 50.000 ký tự | Kết quả tool vượt quá 50K ký tự được lưu xuống đĩa |
+
+Giới hạn đầu ra tối đa có thể cấu hình qua biến môi trường `MAX_MCP_OUTPUT_TOKENS`:
+
+```bash
+# Tăng đầu ra tối đa lên 50.000 tokens
+export MAX_MCP_OUTPUT_TOKENS=50000
+```
+
+## Giải quyết phình ngữ cảnh bằng thực thi code
+
+Khi MCP được áp dụng rộng rãi, kết nối hàng chục server với hàng trăm hoặc hàng nghìn tools tạo ra thách thức lớn: **phình ngữ cảnh** (context bloat). Đây là vấn đề lớn nhất với MCP ở quy mô, và nhóm kỹ thuật Anthropic đề xuất giải pháp tinh tế — dùng thực thi code thay vì gọi tool trực tiếp.
+
+> **Nguồn**: [Code Execution with MCP: Building More Efficient Agents](https://www.anthropic.com/engineering/code-execution-with-mcp) — Blog Kỹ thuật Anthropic
+
+### Vấn đề: Hai nguồn lãng phí token
+
+**1. Định nghĩa tool làm quá tải cửa sổ ngữ cảnh**
+
+Hầu hết MCP client tải tất cả định nghĩa tool ngay từ đầu. Khi kết nối với hàng nghìn tool, model phải xử lý hàng trăm nghìn token trước khi đọc yêu cầu người dùng.
+
+**2. Kết quả trung gian tiêu thụ thêm token**
+
+Mọi kết quả tool trung gian đều đi qua ngữ cảnh của model. Hãy xem xét việc chuyển một transcript cuộc họp từ Google Drive sang Salesforce — transcript đầy đủ chạy qua ngữ cảnh **hai lần**: một lần khi đọc, và một lần nữa khi ghi vào đích. Một transcript cuộc họp 2 giờ có thể tốn hơn 50.000 token thêm.
+
+```mermaid
+graph LR
+    A["Model"] -->|"Tool Call: getDocument"| B["MCP Server"]
+    B -->|"Toàn bộ transcript (50K tokens)"| A
+    A -->|"Tool Call: updateRecord<br/>(gửi lại toàn bộ transcript)"| B
+    B -->|"Xác nhận"| A
+
+    style A fill:#ffcdd2,stroke:#333,color:#333
+    style B fill:#f3e5f5,stroke:#333,color:#333
+```
+
+### Giải pháp: MCP Tools dưới dạng Code APIs
+
+Thay vì đưa định nghĩa tool và kết quả qua cửa sổ ngữ cảnh, agent **viết code** gọi MCP tools như APIs. Code chạy trong môi trường thực thi được sandbox, và chỉ kết quả cuối cùng trả về model.
+
+```mermaid
+graph LR
+    A["Model"] -->|"Viết code"| B["Môi trường<br/>thực thi code"]
+    B -->|"Gọi tools trực tiếp"| C["MCP Servers"]
+    C -->|"Dữ liệu ở trong<br/>môi trường thực thi"| B
+    B -->|"Chỉ kết quả cuối<br/>(tối thiểu tokens)"| A
+
+    style A fill:#c8e6c9,stroke:#333,color:#333
+    style B fill:#e1f5fe,stroke:#333,color:#333
+    style C fill:#f3e5f5,stroke:#333,color:#333
+```
+
+#### Cách hoạt động
+
+Các MCP tool được trình bày như cây file của các hàm có kiểu:
+
+```
+servers/
+├── google-drive/
+│   ├── getDocument.ts
+│   └── index.ts
+├── salesforce/
+│   ├── updateRecord.ts
+│   └── index.ts
+└── ...
+```
+
+Mỗi file tool chứa một wrapper có kiểu:
+
+```typescript
+// ./servers/google-drive/getDocument.ts
+import { callMCPTool } from "../../../client.js";
+
+interface GetDocumentInput {
+  documentId: string;
+}
+
+interface GetDocumentResponse {
+  content: string;
+}
+
+export async function getDocument(
+  input: GetDocumentInput
+): Promise<GetDocumentResponse> {
+  return callMCPTool<GetDocumentResponse>(
+    'google_drive__get_document', input
+  );
+}
+```
+
+Agent sau đó viết code để điều phối các tool:
+
+```typescript
+import * as gdrive from './servers/google-drive';
+import * as salesforce from './servers/salesforce';
+
+// Dữ liệu chạy trực tiếp giữa các tool — không qua model
+const transcript = (
+  await gdrive.getDocument({ documentId: 'abc123' })
+).content;
+
+await salesforce.updateRecord({
+  objectType: 'SalesMeeting',
+  recordId: '00Q5f000001abcXYZ',
+  data: { Notes: transcript }
+});
+```
+
+**Kết quả: Sử dụng token giảm từ ~150.000 xuống ~2.000 — giảm 98,7%.**
+
+### Lợi ích chính
+
+| Lợi ích | Mô tả |
+|---------|-------|
+| **Tiết lộ dần dần** | Agent duyệt filesystem để chỉ tải định nghĩa tool cần thiết, thay vì tất cả tools ngay từ đầu |
+| **Kết quả tiết kiệm ngữ cảnh** | Dữ liệu được lọc/biến đổi trong môi trường thực thi trước khi trả về model |
+| **Luồng điều khiển mạnh mẽ** | Vòng lặp, điều kiện và xử lý lỗi chạy trong code mà không cần round-trip qua model |
+| **Bảo vệ quyền riêng tư** | Dữ liệu trung gian (PII, hồ sơ nhạy cảm) ở trong môi trường thực thi; không bao giờ vào ngữ cảnh model |
+| **Lưu trữ trạng thái** | Agent có thể lưu kết quả trung gian vào file và xây dựng các hàm skill tái sử dụng |
+
+#### Ví dụ: Lọc tập dữ liệu lớn
+
+```typescript
+// Không có code execution — tất cả 10.000 hàng qua ngữ cảnh
+// TOOL CALL: gdrive.getSheet(sheetId: 'abc123')
+//   -> trả về 10.000 hàng trong ngữ cảnh
+
+// Với code execution — lọc trong môi trường thực thi
+const allRows = await gdrive.getSheet({ sheetId: 'abc123' });
+const pendingOrders = allRows.filter(
+  row => row["Status"] === 'pending'
+);
+console.log(`Tìm thấy ${pendingOrders.length} đơn hàng pending`);
+console.log(pendingOrders.slice(0, 5)); // Chỉ 5 hàng đến model
+```
+
+#### Ví dụ: Vòng lặp không cần round-trip
+
+```typescript
+// Poll thông báo deployment — chạy hoàn toàn trong code
+let found = false;
+while (!found) {
+  const messages = await slack.getChannelHistory({
+    channel: 'C123456'
+  });
+  found = messages.some(
+    m => m.text.includes('deployment complete')
+  );
+  if (!found) await new Promise(r => setTimeout(r, 5000));
+}
+console.log('Đã nhận thông báo deployment');
+```
+
+### Đánh đổi cần xem xét
+
+Thực thi code tạo ra sự phức tạp riêng. Chạy code do agent tạo ra yêu cầu:
+
+- **Môi trường thực thi sandbox an toàn** với giới hạn tài nguyên phù hợp
+- **Giám sát và ghi log** code được thực thi
+- **Chi phí hạ tầng** cao hơn so với gọi tool trực tiếp
+
+Lợi ích — giảm chi phí token, độ trễ thấp hơn, kết hợp tool tốt hơn — cần được đánh giá so với chi phí triển khai. Với các agent chỉ có vài MCP server, gọi tool trực tiếp có thể đơn giản hơn. Với các agent ở quy mô (hàng chục server, hàng trăm tool), thực thi code là cải thiện đáng kể.
+
+### MCPorter: Runtime cho MCP Tool Composition
+
+[MCPorter](https://github.com/steipete/mcporter) là runtime TypeScript và bộ CLI giúp gọi MCP server thực tế mà không cần boilerplate — và giảm phình ngữ cảnh qua việc expose tool có chọn lọc và các wrapper có kiểu.
+
+**Vấn đề nó giải quyết:** Thay vì tải tất cả định nghĩa tool từ tất cả MCP server ngay từ đầu, MCPorter cho phép bạn khám phá, kiểm tra và gọi các tool cụ thể theo nhu cầu — giữ cho ngữ cảnh gọn gàng.
+
+**Tính năng chính:**
+
+| Tính năng | Mô tả |
+|-----------|-------|
+| **Khám phá không cần cấu hình** | Tự động khám phá MCP server từ Cursor, Claude, Codex hoặc cấu hình cục bộ |
+| **Tool clients có kiểu** | `mcporter emit-ts` tạo interfaces `.d.ts` và wrappers sẵn chạy |
+| **API có thể kết hợp** | `createServerProxy()` expose tools như các phương thức camelCase với helpers `.text()`, `.json()`, `.markdown()` |
+| **Tạo CLI** | `mcporter generate-cli` chuyển đổi bất kỳ MCP server nào thành CLI độc lập với lọc `--include-tools` / `--exclude-tools` |
+| **Ẩn tham số** | Tham số tùy chọn bị ẩn mặc định, giảm độ dài schema |
+
+**Cài đặt:**
+
+```bash
+npx mcporter list          # Không cần cài — khám phá server ngay
+pnpm add mcporter          # Thêm vào dự án
+brew install steipete/tap/mcporter  # macOS qua Homebrew
+```
+
+**Ví dụ — kết hợp tools trong TypeScript:**
+
+```typescript
+import { createRuntime, createServerProxy } from "mcporter";
+
+const runtime = await createRuntime();
+const gdrive = createServerProxy(runtime, "google-drive");
+const salesforce = createServerProxy(runtime, "salesforce");
+
+// Dữ liệu chạy giữa các tool mà không đi qua ngữ cảnh model
+const doc = await gdrive.getDocument({ documentId: "abc123" });
+await salesforce.updateRecord({
+  objectType: "SalesMeeting",
+  recordId: "00Q5f000001abcXYZ",
+  data: { Notes: doc.text() }
+});
+```
+
+**Ví dụ — gọi tool qua CLI:**
+
+```bash
+# Gọi tool cụ thể trực tiếp
+npx mcporter call linear.create_comment issueId:ENG-123 body:'Trông ổn!'
+
+# Liệt kê các server và tool có sẵn
+npx mcporter list
+```
+
+MCPorter bổ trợ cho cách tiếp cận thực thi code được mô tả ở trên bằng cách cung cấp runtime infrastructure để gọi MCP tools như typed APIs — giúp dễ dàng giữ dữ liệu trung gian ra khỏi ngữ cảnh model.
+
+## Thực hành tốt nhất
+
+### Cân nhắc bảo mật
+
+#### Nên làm ✅
+- Dùng biến môi trường cho tất cả thông tin xác thực
+- Xoay vòng tokens và API keys thường xuyên (khuyến nghị hàng tháng)
+- Dùng tokens chỉ đọc khi có thể
+- Giới hạn phạm vi truy cập MCP server ở mức tối thiểu cần thiết
+- Giám sát sử dụng và log truy cập MCP server
+- Dùng OAuth cho dịch vụ bên ngoài khi có thể
+- Triển khai rate limiting cho MCP requests
+- Kiểm tra kết nối MCP trước khi dùng production
+- Ghi lại tất cả kết nối MCP đang hoạt động
+- Cập nhật các gói MCP server
+
+#### Không nên làm ❌
+- Đừng hardcode thông tin xác thực trong file cấu hình
+- Đừng commit tokens hoặc secrets lên git
+- Đừng chia sẻ tokens trong chat nhóm hoặc email
+- Đừng dùng tokens cá nhân cho dự án nhóm
+- Đừng cấp quyền không cần thiết
+- Đừng bỏ qua lỗi xác thực
+- Đừng expose MCP endpoints công khai
+- Đừng chạy MCP server với quyền root/admin
+- Đừng cache dữ liệu nhạy cảm trong logs
+- Đừng tắt cơ chế xác thực
+
+### Thực hành tốt nhất về cấu hình
+
+1. **Kiểm soát phiên bản**: Giữ `.mcp.json` trong git nhưng dùng biến môi trường cho secrets
+2. **Quyền tối thiểu**: Cấp quyền tối thiểu cần thiết cho mỗi MCP server
+3. **Cô lập**: Chạy các MCP server khác nhau trong tiến trình riêng khi có thể
+4. **Giám sát**: Ghi log tất cả MCP requests và lỗi để kiểm tra
+5. **Kiểm tra**: Kiểm tra tất cả cấu hình MCP trước khi deploy production
+
+### Mẹo hiệu năng
+
+- Cache dữ liệu truy cập thường xuyên ở tầng ứng dụng
+- Dùng MCP queries cụ thể để giảm truyền dữ liệu
+- Giám sát thời gian phản hồi của các thao tác MCP
+- Xem xét rate limiting cho các API bên ngoài
+- Dùng batching khi thực hiện nhiều thao tác
+
+## Hướng dẫn cài đặt
+
+### Yêu cầu tiên quyết
+- Node.js và npm đã cài đặt
+- Claude Code CLI đã cài đặt
+- API tokens/credentials cho các dịch vụ bên ngoài
+
+### Thiết lập từng bước
+
+1. **Thêm MCP server đầu tiên** qua CLI (ví dụ: GitHub):
+```bash
+claude mcp add --transport stdio github -- npx @modelcontextprotocol/server-github
+```
+
+Hoặc tạo file `.mcp.json` trong thư mục gốc dự án:
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+2. **Đặt biến môi trường:**
+```bash
+export GITHUB_TOKEN="your_github_personal_access_token"
+```
+
+3. **Kiểm tra kết nối:**
+```bash
+claude /mcp
+```
+
+4. **Dùng MCP tools:**
+```bash
+/mcp__github__list_prs
+/mcp__github__create_issue "Tiêu đề" "Mô tả"
+```
+
+### Cài đặt cho các dịch vụ cụ thể
+
+**GitHub MCP:**
+```bash
+npm install -g @modelcontextprotocol/server-github
+```
+
+**Database MCP:**
+```bash
+npm install -g @modelcontextprotocol/server-database
+```
+
+**Filesystem MCP:**
+```bash
+npm install -g @modelcontextprotocol/server-filesystem
+```
+
+**Slack MCP:**
+```bash
+npm install -g @modelcontextprotocol/server-slack
+```
+
+## Xử lý sự cố
+
+### MCP Server không tìm thấy
+```bash
+# Kiểm tra MCP server đã cài đặt chưa
+npm list -g @modelcontextprotocol/server-github
+
+# Cài đặt nếu thiếu
+npm install -g @modelcontextprotocol/server-github
+```
+
+### Xác thực thất bại
+```bash
+# Kiểm tra biến môi trường đã đặt chưa
+echo $GITHUB_TOKEN
+
+# Re-export nếu cần
+export GITHUB_TOKEN="your_token"
+
+# Kiểm tra token có đúng quyền không
+# Xem GitHub token scopes tại: https://github.com/settings/tokens
+```
+
+### Kết nối timeout
+- Kiểm tra kết nối mạng: `ping api.github.com`
+- Xác minh API endpoint có thể truy cập
+- Kiểm tra rate limits trên API
+- Thử tăng timeout trong cấu hình
+- Kiểm tra firewall hoặc proxy
+
+### MCP Server bị crash
+- Kiểm tra log MCP server: `~/.claude/logs/`
+- Xác minh tất cả biến môi trường đã đặt
+- Đảm bảo quyền file đúng
+- Thử cài lại gói MCP server
+- Kiểm tra các tiến trình xung đột trên cùng port
+
+## Khái niệm liên quan
+
+### Memory vs MCP
+- **Memory**: Lưu trữ dữ liệu liên tục, không thay đổi (tùy chọn, ngữ cảnh, lịch sử)
+- **MCP**: Truy cập dữ liệu trực tiếp, thay đổi (APIs, databases, dịch vụ thời gian thực)
+
+### Khi nào dùng cái nào
+- **Dùng Memory** cho: Tùy chọn người dùng, lịch sử hội thoại, ngữ cảnh đã học
+- **Dùng MCP** cho: GitHub issues hiện tại, truy vấn database trực tiếp, dữ liệu thời gian thực
+
+### Tích hợp với các tính năng Claude khác
+- Kết hợp MCP với Memory để có ngữ cảnh phong phú
+- Dùng MCP tools trong prompts để lý luận tốt hơn
+- Tận dụng nhiều MCPs cho các quy trình phức tạp
+
+## Tài nguyên bổ sung
+
+- [Tài liệu MCP chính thức](https://code.claude.com/docs/en/mcp)
+- [Đặc tả giao thức MCP](https://modelcontextprotocol.io/specification)
+- [GitHub Repository MCP](https://github.com/modelcontextprotocol/servers)
+- [Các MCP Server có sẵn](https://github.com/modelcontextprotocol/servers)
+- [MCPorter](https://github.com/steipete/mcporter) — Runtime TypeScript & CLI để gọi MCP server không cần boilerplate
+- [Code Execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp) — Blog kỹ thuật Anthropic về giải quyết phình ngữ cảnh
+- [Tài liệu tham chiếu Claude Code CLI](https://code.claude.com/docs/en/cli-reference)
+- [Tài liệu Claude API](https://docs.anthropic.com)

--- a/06-hooks/README.vi.md
+++ b/06-hooks/README.vi.md
@@ -1,0 +1,1285 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Hooks
+
+Hooks là các script tự động chạy khi phản ứng với các sự kiện cụ thể trong phiên Claude Code. Chúng cho phép tự động hóa, xác thực, quản lý quyền và các quy trình làm việc tùy chỉnh.
+
+## Tổng quan
+
+Hooks là các hành động tự động (lệnh shell, HTTP webhooks, LLM prompts hoặc đánh giá subagent) chạy tự động khi các sự kiện cụ thể xảy ra trong Claude Code. Chúng nhận đầu vào JSON và giao tiếp kết quả qua exit codes và đầu ra JSON.
+
+**Tính năng chính:**
+- Tự động hóa theo sự kiện
+- Đầu vào/đầu ra dạng JSON
+- Hỗ trợ hook loại command, prompt, HTTP và agent
+- Khớp pattern cho hooks theo tool cụ thể
+
+## Cấu hình
+
+Hooks được cấu hình trong các file settings với cấu trúc cụ thể:
+
+- `~/.claude/settings.json` - Cài đặt người dùng (tất cả dự án)
+- `.claude/settings.json` - Cài đặt dự án (có thể chia sẻ, commit được)
+- `.claude/settings.local.json` - Cài đặt dự án cục bộ (không commit)
+- Managed policy - Cài đặt toàn tổ chức
+- Plugin `hooks/hooks.json` - Hooks theo phạm vi plugin
+- Frontmatter Skill/Agent - Hooks theo vòng đời component
+
+### Cấu trúc cơ bản
+
+```json
+{
+  "hooks": {
+    "TênSựKiện": [
+      {
+        "matcher": "PatternTool",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "lệnh-của-bạn",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Các trường chính:**
+
+| Trường | Mô tả | Ví dụ |
+|--------|-------|-------|
+| `matcher` | Pattern khớp tên tool (phân biệt chữ hoa/thường) | `"Write"`, `"Edit\|Write"`, `"*"` |
+| `hooks` | Mảng định nghĩa hook | `[{ "type": "command", ... }]` |
+| `type` | Loại hook: `"command"` (bash), `"prompt"` (LLM), `"http"` (webhook), hoặc `"agent"` (subagent) | `"command"` |
+| `command` | Lệnh shell cần thực thi | `"$CLAUDE_PROJECT_DIR/.claude/hooks/format.sh"` |
+| `timeout` | Timeout tùy chọn tính bằng giây (mặc định 60) | `30` |
+| `once` | Nếu `true`, chỉ chạy hook một lần mỗi phiên | `true` |
+
+### Patterns cho Matcher
+
+| Pattern | Mô tả | Ví dụ |
+|---------|-------|-------|
+| Chuỗi chính xác | Khớp tool cụ thể | `"Write"` |
+| Regex pattern | Khớp nhiều tools | `"Edit\|Write"` |
+| Ký tự đại diện | Khớp tất cả tools | `"*"` hoặc `""` |
+| MCP tools | Pattern server và tool | `"mcp__memory__.*"` |
+
+## Các loại Hook
+
+Claude Code hỗ trợ bốn loại hook:
+
+### Command Hooks
+
+Loại hook mặc định. Thực thi một lệnh shell và giao tiếp qua JSON stdin/stdout và exit codes.
+
+```json
+{
+  "type": "command",
+  "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/validate.py\"",
+  "timeout": 60
+}
+```
+
+### HTTP Hooks
+
+> Thêm vào từ v2.1.63.
+
+Các endpoint webhook từ xa nhận cùng đầu vào JSON như command hooks. HTTP hooks POST JSON đến URL và nhận phản hồi JSON. HTTP hooks được định tuyến qua sandbox khi bật sandboxing. Nội suy biến môi trường trong URL yêu cầu danh sách `allowedEnvVars` rõ ràng vì lý do bảo mật.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "type": "http",
+      "url": "https://my-webhook.example.com/hook",
+      "matcher": "Write"
+    }]
+  }
+}
+```
+
+**Thuộc tính chính:**
+- `"type": "http"` -- xác định đây là HTTP hook
+- `"url"` -- URL endpoint webhook
+- Định tuyến qua sandbox khi sandbox được bật
+- Yêu cầu danh sách `allowedEnvVars` rõ ràng cho bất kỳ nội suy biến môi trường nào trong URL
+
+### Prompt Hooks
+
+Các prompts được LLM đánh giá, trong đó nội dung hook là một prompt mà Claude đánh giá. Chủ yếu dùng với sự kiện `Stop` và `SubagentStop` để kiểm tra hoàn thành tác vụ thông minh.
+
+```json
+{
+  "type": "prompt",
+  "prompt": "Đánh giá xem Claude có hoàn thành tất cả tác vụ được yêu cầu không.",
+  "timeout": 30
+}
+```
+
+LLM đánh giá prompt và trả về quyết định có cấu trúc (xem [Hooks dựa trên Prompt](#hooks-dựa-trên-prompt) để biết chi tiết).
+
+### Agent Hooks
+
+Hooks xác minh dựa trên subagent — tạo ra một agent chuyên dụng để đánh giá điều kiện hoặc thực hiện kiểm tra phức tạp. Không giống prompt hooks (đánh giá LLM một lượt), agent hooks có thể dùng tools và thực hiện lý luận nhiều bước.
+
+```json
+{
+  "type": "agent",
+  "prompt": "Xác minh các thay đổi code tuân theo hướng dẫn kiến trúc. Kiểm tra tài liệu thiết kế liên quan và so sánh.",
+  "timeout": 120
+}
+```
+
+**Thuộc tính chính:**
+- `"type": "agent"` -- xác định đây là agent hook
+- `"prompt"` -- mô tả tác vụ cho subagent
+- Agent có thể dùng tools (Read, Grep, Bash, v.v.) để thực hiện đánh giá
+- Trả về quyết định có cấu trúc tương tự prompt hooks
+
+## Các sự kiện Hook
+
+Claude Code hỗ trợ **25 sự kiện hook**:
+
+| Sự kiện | Khi nào kích hoạt | Đầu vào Matcher | Có thể chặn | Dùng phổ biến |
+|---------|------------------|-----------------|-------------|--------------|
+| **SessionStart** | Phiên bắt đầu/tiếp tục/xóa/compact | startup/resume/clear/compact | Không | Thiết lập môi trường |
+| **InstructionsLoaded** | Sau khi tải CLAUDE.md hoặc file quy tắc | (không có) | Không | Sửa/lọc hướng dẫn |
+| **UserPromptSubmit** | Người dùng gửi prompt | (không có) | Có | Xác thực prompts |
+| **PreToolUse** | Trước khi thực thi tool | Tên tool | Có (allow/deny/ask) | Xác thực, sửa đầu vào |
+| **PermissionRequest** | Hộp thoại quyền hiển thị | Tên tool | Có | Tự động chấp nhận/từ chối |
+| **PostToolUse** | Sau khi tool thành công | Tên tool | Không | Thêm ngữ cảnh, phản hồi |
+| **PostToolUseFailure** | Thực thi tool thất bại | Tên tool | Không | Xử lý lỗi, ghi log |
+| **Notification** | Thông báo được gửi | Loại thông báo | Không | Thông báo tùy chỉnh |
+| **SubagentStart** | Subagent được tạo | Tên loại agent | Không | Thiết lập subagent |
+| **SubagentStop** | Subagent hoàn thành | Tên loại agent | Có | Xác thực subagent |
+| **Stop** | Claude hoàn thành phản hồi | (không có) | Có | Kiểm tra hoàn thành tác vụ |
+| **StopFailure** | Lỗi API kết thúc lượt | (không có) | Không | Phục hồi lỗi, ghi log |
+| **TeammateIdle** | Thành viên nhóm agent nhàn rỗi | (không có) | Có | Phối hợp thành viên |
+| **TaskCompleted** | Tác vụ được đánh dấu hoàn thành | (không có) | Có | Hành động sau tác vụ |
+| **TaskCreated** | Tác vụ được tạo qua TaskCreate | (không có) | Không | Theo dõi tác vụ, ghi log |
+| **ConfigChange** | File cấu hình thay đổi | (không có) | Có (trừ policy) | Phản ứng cập nhật cấu hình |
+| **CwdChanged** | Thư mục làm việc thay đổi | (không có) | Không | Thiết lập theo thư mục |
+| **FileChanged** | File được theo dõi thay đổi | (không có) | Không | Giám sát file, rebuild |
+| **PreCompact** | Trước khi compact ngữ cảnh | manual/auto | Không | Hành động trước compact |
+| **PostCompact** | Sau khi compact hoàn thành | (không có) | Không | Hành động sau compact |
+| **WorktreeCreate** | Worktree đang được tạo | (không có) | Có (trả về path) | Khởi tạo worktree |
+| **WorktreeRemove** | Worktree đang bị xóa | (không có) | Không | Dọn dẹp worktree |
+| **Elicitation** | MCP server yêu cầu đầu vào người dùng | (không có) | Có | Xác thực đầu vào |
+| **ElicitationResult** | Người dùng phản hồi elicitation | (không có) | Có | Xử lý phản hồi |
+| **SessionEnd** | Phiên kết thúc | (không có) | Không | Dọn dẹp, ghi log cuối |
+
+### PreToolUse
+
+Chạy sau khi Claude tạo tham số tool và trước khi xử lý. Dùng để xác thực hoặc sửa đầu vào tool.
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Matchers phổ biến:** `Task`, `Bash`, `Glob`, `Grep`, `Read`, `Edit`, `Write`, `WebFetch`, `WebSearch`
+
+**Kiểm soát đầu ra:**
+- `permissionDecision`: `"allow"`, `"deny"`, hoặc `"ask"`
+- `permissionDecisionReason`: Giải thích cho quyết định
+- `updatedInput`: Tham số đầu vào tool đã được sửa
+
+### PostToolUse
+
+Chạy ngay sau khi tool hoàn thành. Dùng để xác minh, ghi log, hoặc cung cấp ngữ cảnh lại cho Claude.
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/security-scan.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Kiểm soát đầu ra:**
+- Quyết định `"block"` nhắc Claude với phản hồi
+- `additionalContext`: Ngữ cảnh thêm cho Claude
+
+### UserPromptSubmit
+
+Chạy khi người dùng gửi prompt, trước khi Claude xử lý.
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-prompt.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Kiểm soát đầu ra:**
+- `decision`: `"block"` để ngăn xử lý
+- `reason`: Giải thích nếu bị chặn
+- `additionalContext`: Ngữ cảnh thêm vào prompt
+
+### Stop và SubagentStop
+
+Chạy khi Claude hoàn thành phản hồi (Stop) hoặc subagent hoàn thành (SubagentStop). Hỗ trợ đánh giá dựa trên prompt để kiểm tra hoàn thành tác vụ thông minh.
+
+**Trường đầu vào bổ sung:** Cả hai hook `Stop` và `SubagentStop` nhận trường `last_assistant_message` trong đầu vào JSON, chứa tin nhắn cuối cùng từ Claude hoặc subagent trước khi dừng. Hữu ích để đánh giá hoàn thành tác vụ.
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Đánh giá xem Claude có hoàn thành tất cả tác vụ được yêu cầu không.",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### SubagentStart
+
+Chạy khi subagent bắt đầu thực thi. Đầu vào matcher là tên loại agent, cho phép hooks nhắm mục tiêu các loại subagent cụ thể.
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "SubagentStart": [
+      {
+        "matcher": "code-review",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/subagent-init.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### SessionStart
+
+Chạy khi phiên bắt đầu hoặc tiếp tục. Có thể duy trì biến môi trường.
+
+**Matchers:** `startup`, `resume`, `clear`, `compact`
+
+**Tính năng đặc biệt:** Dùng `CLAUDE_ENV_FILE` để duy trì biến môi trường (cũng có sẵn trong hooks `CwdChanged` và `FileChanged`):
+
+```bash
+#!/bin/bash
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+  echo 'export NODE_ENV=development' >> "$CLAUDE_ENV_FILE"
+fi
+exit 0
+```
+
+### SessionEnd
+
+Chạy khi phiên kết thúc để dọn dẹp hoặc ghi log cuối. Không thể chặn quá trình kết thúc.
+
+**Giá trị trường reason:**
+- `clear` - Người dùng xóa phiên
+- `logout` - Người dùng đăng xuất
+- `prompt_input_exit` - Người dùng thoát qua prompt input
+- `other` - Lý do khác
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/session-cleanup.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Sự kiện Notification
+
+Các matchers cập nhật cho sự kiện thông báo:
+- `permission_prompt` - Thông báo yêu cầu quyền
+- `idle_prompt` - Thông báo trạng thái nhàn rỗi
+- `auth_success` - Xác thực thành công
+- `elicitation_dialog` - Hộp thoại hiển thị cho người dùng
+
+## Hooks theo phạm vi Component
+
+Hooks có thể gắn vào các component cụ thể (skills, agents, commands) trong frontmatter của chúng:
+
+**Trong SKILL.md, agent.md, hoặc command.md:**
+
+```yaml
+---
+name: secure-operations
+description: Thực hiện các thao tác với kiểm tra bảo mật
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/check.sh"
+          once: true  # Chỉ chạy một lần mỗi phiên
+---
+```
+
+**Các sự kiện được hỗ trợ cho component hooks:** `PreToolUse`, `PostToolUse`, `Stop`
+
+Điều này cho phép định nghĩa hooks trực tiếp trong component sử dụng chúng, giữ code liên quan ở cùng nơi.
+
+### Hooks trong Frontmatter Subagent
+
+Khi hook `Stop` được định nghĩa trong frontmatter của subagent, nó tự động được chuyển đổi thành hook `SubagentStop` có phạm vi theo subagent đó. Điều này đảm bảo hook stop chỉ kích hoạt khi subagent cụ thể đó hoàn thành, không phải khi phiên chính dừng.
+
+```yaml
+---
+name: code-review-agent
+description: Subagent review code tự động
+hooks:
+  Stop:
+    - hooks:
+        - type: prompt
+          prompt: "Xác minh review code đã đầy đủ và hoàn chỉnh."
+  # Hook Stop ở trên tự động chuyển thành SubagentStop cho subagent này
+---
+```
+
+## Sự kiện PermissionRequest
+
+Xử lý yêu cầu quyền với định dạng đầu ra tùy chỉnh:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow|deny",
+      "updatedInput": {},
+      "message": "Tin nhắn tùy chỉnh",
+      "interrupt": false
+    }
+  }
+}
+```
+
+## Đầu vào và Đầu ra của Hook
+
+### Đầu vào JSON (qua stdin)
+
+Tất cả hooks nhận đầu vào JSON qua stdin:
+
+```json
+{
+  "session_id": "abc123",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/current/working/directory",
+  "permission_mode": "default",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "/path/to/file.js",
+    "content": "..."
+  },
+  "tool_use_id": "toolu_01ABC123...",
+  "agent_id": "agent-abc123",
+  "agent_type": "main",
+  "worktree": "/path/to/worktree"
+}
+```
+
+**Các trường phổ biến:**
+
+| Trường | Mô tả |
+|--------|-------|
+| `session_id` | Định danh phiên duy nhất |
+| `transcript_path` | Đường dẫn đến file transcript hội thoại |
+| `cwd` | Thư mục làm việc hiện tại |
+| `hook_event_name` | Tên sự kiện đã kích hoạt hook |
+| `agent_id` | Định danh agent đang chạy hook này |
+| `agent_type` | Loại agent (`"main"`, tên loại subagent, v.v.) |
+| `worktree` | Đường dẫn đến git worktree, nếu agent đang chạy trong đó |
+
+### Exit Codes
+
+| Exit Code | Ý nghĩa | Hành vi |
+|-----------|---------|---------|
+| **0** | Thành công | Tiếp tục, phân tích JSON stdout |
+| **2** | Lỗi chặn | Chặn thao tác, stderr hiển thị như lỗi |
+| **Khác** | Lỗi không chặn | Tiếp tục, stderr hiển thị ở chế độ verbose |
+
+### Đầu ra JSON (stdout, exit code 0)
+
+```json
+{
+  "continue": true,
+  "stopReason": "Tin nhắn tùy chọn nếu dừng",
+  "suppressOutput": false,
+  "systemMessage": "Tin nhắn cảnh báo tùy chọn",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "permissionDecisionReason": "File ở trong thư mục được phép",
+    "updatedInput": {
+      "file_path": "/modified/path.js"
+    }
+  }
+}
+```
+
+## Biến môi trường
+
+| Biến | Phạm vi | Mô tả |
+|------|---------|-------|
+| `CLAUDE_PROJECT_DIR` | Tất cả hooks | Đường dẫn tuyệt đối đến thư mục gốc dự án |
+| `CLAUDE_ENV_FILE` | SessionStart, CwdChanged, FileChanged | Đường dẫn file để duy trì biến môi trường |
+| `CLAUDE_CODE_REMOTE` | Tất cả hooks | `"true"` nếu đang chạy trong môi trường remote |
+| `${CLAUDE_PLUGIN_ROOT}` | Plugin hooks | Đường dẫn đến thư mục plugin |
+| `${CLAUDE_PLUGIN_DATA}` | Plugin hooks | Đường dẫn đến thư mục data của plugin |
+| `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` | SessionEnd hooks | Timeout có thể cấu hình tính bằng milliseconds cho SessionEnd hooks (ghi đè mặc định) |
+
+## Hooks dựa trên Prompt
+
+Với sự kiện `Stop` và `SubagentStop`, bạn có thể dùng đánh giá dựa trên LLM:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Review xem tất cả tác vụ đã hoàn thành chưa. Trả về quyết định của bạn.",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Schema phản hồi LLM:**
+```json
+{
+  "decision": "approve",
+  "reason": "Tất cả tác vụ đã hoàn thành thành công",
+  "continue": false,
+  "stopReason": "Tác vụ hoàn thành"
+}
+```
+
+## Ví dụ
+
+### Ví dụ 1: Trình xác thực lệnh Bash (PreToolUse)
+
+**File:** `.claude/hooks/validate-bash.py`
+
+```python
+#!/usr/bin/env python3
+import json
+import sys
+import re
+
+BLOCKED_PATTERNS = [
+    (r"\brm\s+-rf\s+/", "Chặn lệnh nguy hiểm rm -rf /"),
+    (r"\bsudo\s+rm", "Chặn lệnh sudo rm"),
+]
+
+def main():
+    input_data = json.load(sys.stdin)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    for pattern, message in BLOCKED_PATTERNS:
+        if re.search(pattern, command):
+            print(message, file=sys.stderr)
+            sys.exit(2)  # Exit 2 = lỗi chặn
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+```
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-bash.py\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Ví dụ 2: Quét bảo mật (PostToolUse)
+
+**File:** `.claude/hooks/security-scan.py`
+
+```python
+#!/usr/bin/env python3
+import json
+import sys
+import re
+
+SECRET_PATTERNS = [
+    (r"password\s*=\s*['\"][^'\"]+['\"]", "Có thể có password hardcoded"),
+    (r"api[_-]?key\s*=\s*['\"][^'\"]+['\"]", "Có thể có API key hardcoded"),
+]
+
+def main():
+    input_data = json.load(sys.stdin)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name not in ["Write", "Edit"]:
+        sys.exit(0)
+
+    tool_input = input_data.get("tool_input", {})
+    content = tool_input.get("content", "") or tool_input.get("new_string", "")
+    file_path = tool_input.get("file_path", "")
+
+    warnings = []
+    for pattern, message in SECRET_PATTERNS:
+        if re.search(pattern, content, re.IGNORECASE):
+            warnings.append(message)
+
+    if warnings:
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": f"Cảnh báo bảo mật cho {file_path}: " + "; ".join(warnings)
+            }
+        }
+        print(json.dumps(output))
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+```
+
+### Ví dụ 3: Tự động format code (PostToolUse)
+
+**File:** `.claude/hooks/format-code.sh`
+
+```bash
+#!/bin/bash
+
+# Đọc JSON từ stdin
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import sys, json; print(json.load(sys.stdin).get('tool_name', ''))")
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys, json; print(json.load(sys.stdin).get('tool_input', {}).get('file_path', ''))")
+
+if [ "$TOOL_NAME" != "Write" ] && [ "$TOOL_NAME" != "Edit" ]; then
+    exit 0
+fi
+
+# Format theo phần mở rộng file
+case "$FILE_PATH" in
+    *.js|*.jsx|*.ts|*.tsx|*.json)
+        command -v prettier &>/dev/null && prettier --write "$FILE_PATH" 2>/dev/null
+        ;;
+    *.py)
+        command -v black &>/dev/null && black "$FILE_PATH" 2>/dev/null
+        ;;
+    *.go)
+        command -v gofmt &>/dev/null && gofmt -w "$FILE_PATH" 2>/dev/null
+        ;;
+esac
+
+exit 0
+```
+
+### Ví dụ 4: Xác thực Prompt (UserPromptSubmit)
+
+**File:** `.claude/hooks/validate-prompt.py`
+
+```python
+#!/usr/bin/env python3
+import json
+import sys
+import re
+
+BLOCKED_PATTERNS = [
+    (r"delete\s+(all\s+)?database", "Nguy hiểm: xóa database"),
+    (r"rm\s+-rf\s+/", "Nguy hiểm: xóa root"),
+]
+
+def main():
+    input_data = json.load(sys.stdin)
+    prompt = input_data.get("user_prompt", "") or input_data.get("prompt", "")
+
+    for pattern, message in BLOCKED_PATTERNS:
+        if re.search(pattern, prompt, re.IGNORECASE):
+            output = {
+                "decision": "block",
+                "reason": f"Bị chặn: {message}"
+            }
+            print(json.dumps(output))
+            sys.exit(0)
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+```
+
+### Ví dụ 5: Hook Stop thông minh (Dựa trên Prompt)
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Review xem Claude đã hoàn thành tất cả tác vụ được yêu cầu chưa. Kiểm tra: 1) Tất cả file đã được tạo/sửa chưa? 2) Có lỗi chưa giải quyết không? Nếu chưa hoàn thành, giải thích còn thiếu gì.",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Ví dụ 6: Theo dõi sử dụng Context (Cặp Hooks)
+
+Theo dõi mức tiêu thụ token mỗi request bằng cách dùng hooks `UserPromptSubmit` (trước tin nhắn) và `Stop` (sau phản hồi) cùng nhau.
+
+**File:** `.claude/hooks/context-tracker.py`
+
+```python
+#!/usr/bin/env python3
+"""
+Context Usage Tracker - Theo dõi tiêu thụ token mỗi request.
+
+Dùng UserPromptSubmit làm hook "pre-message" và Stop làm hook "post-response"
+để tính delta sử dụng token cho mỗi request.
+
+Phương pháp đếm Token:
+1. Ước tính ký tự (mặc định): ~4 ký tự mỗi token, không cần dependency
+2. tiktoken (tùy chọn): Chính xác hơn (~90-95%), yêu cầu: pip install tiktoken
+"""
+import json
+import os
+import sys
+import tempfile
+
+# Cấu hình
+CONTEXT_LIMIT = 128000  # Cửa sổ ngữ cảnh của Claude (điều chỉnh theo model)
+USE_TIKTOKEN = False    # Đặt True nếu tiktoken được cài để có độ chính xác tốt hơn
+
+
+def get_state_file(session_id: str) -> str:
+    """Lấy đường dẫn file tạm để lưu số token trước tin nhắn, cô lập theo phiên."""
+    return os.path.join(tempfile.gettempdir(), f"claude-context-{session_id}.json")
+
+
+def count_tokens(text: str) -> int:
+    """
+    Đếm token trong văn bản.
+
+    Dùng tiktoken với mã hóa p50k_base nếu có (~90-95% chính xác),
+    ngược lại dùng ước tính ký tự (~80-90% chính xác).
+    """
+    if USE_TIKTOKEN:
+        try:
+            import tiktoken
+            enc = tiktoken.get_encoding("p50k_base")
+            return len(enc.encode(text))
+        except ImportError:
+            pass  # Dùng ước tính thay thế
+
+    # Ước tính dựa trên ký tự: ~4 ký tự mỗi token cho tiếng Anh
+    return len(text) // 4
+
+
+def read_transcript(transcript_path: str) -> str:
+    """Đọc và nối tất cả nội dung từ file transcript."""
+    if not transcript_path or not os.path.exists(transcript_path):
+        return ""
+
+    content = []
+    with open(transcript_path, "r") as f:
+        for line in f:
+            try:
+                entry = json.loads(line.strip())
+                if "message" in entry:
+                    msg = entry["message"]
+                    if isinstance(msg.get("content"), str):
+                        content.append(msg["content"])
+                    elif isinstance(msg.get("content"), list):
+                        for block in msg["content"]:
+                            if isinstance(block, dict) and block.get("type") == "text":
+                                content.append(block.get("text", ""))
+            except json.JSONDecodeError:
+                continue
+
+    return "\n".join(content)
+
+
+def handle_user_prompt_submit(data: dict) -> None:
+    """Hook trước tin nhắn: Lưu số token hiện tại trước request."""
+    session_id = data.get("session_id", "unknown")
+    transcript_path = data.get("transcript_path", "")
+
+    transcript_content = read_transcript(transcript_path)
+    current_tokens = count_tokens(transcript_content)
+
+    state_file = get_state_file(session_id)
+    with open(state_file, "w") as f:
+        json.dump({"pre_tokens": current_tokens}, f)
+
+
+def handle_stop(data: dict) -> None:
+    """Hook sau phản hồi: Tính và báo cáo delta token."""
+    session_id = data.get("session_id", "unknown")
+    transcript_path = data.get("transcript_path", "")
+
+    transcript_content = read_transcript(transcript_path)
+    current_tokens = count_tokens(transcript_content)
+
+    state_file = get_state_file(session_id)
+    pre_tokens = 0
+    if os.path.exists(state_file):
+        try:
+            with open(state_file, "r") as f:
+                state = json.load(f)
+                pre_tokens = state.get("pre_tokens", 0)
+        except (json.JSONDecodeError, IOError):
+            pass
+
+    delta_tokens = current_tokens - pre_tokens
+    remaining = CONTEXT_LIMIT - current_tokens
+    percentage = (current_tokens / CONTEXT_LIMIT) * 100
+
+    method = "tiktoken" if USE_TIKTOKEN else "ước tính"
+    print(f"Context ({method}): ~{current_tokens:,} tokens ({percentage:.1f}% đã dùng, ~{remaining:,} còn lại)", file=sys.stderr)
+    if delta_tokens > 0:
+        print(f"Request này: ~{delta_tokens:,} tokens", file=sys.stderr)
+
+
+def main():
+    data = json.load(sys.stdin)
+    event = data.get("hook_event_name", "")
+
+    if event == "UserPromptSubmit":
+        handle_user_prompt_submit(data)
+    elif event == "Stop":
+        handle_stop(data)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/context-tracker.py\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/context-tracker.py\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Cách hoạt động:**
+1. `UserPromptSubmit` kích hoạt trước khi prompt của bạn được xử lý — lưu số token hiện tại
+2. `Stop` kích hoạt sau khi Claude phản hồi — tính delta và báo cáo mức sử dụng
+3. Mỗi phiên được cô lập qua `session_id` trong tên file tạm
+
+**Phương pháp đếm Token:**
+
+| Phương pháp | Độ chính xác | Dependency | Tốc độ |
+|-------------|-------------|-----------|--------|
+| Ước tính ký tự | ~80-90% | Không có | <1ms |
+| tiktoken (p50k_base) | ~90-95% | `pip install tiktoken` | <10ms |
+
+> **Lưu ý:** Anthropic chưa phát hành tokenizer offline chính thức. Cả hai phương pháp đều là xấp xỉ. Transcript bao gồm prompts người dùng, phản hồi của Claude và đầu ra tool, nhưng KHÔNG bao gồm system prompts hoặc ngữ cảnh nội bộ.
+
+### Ví dụ 7: Chế độ Tự động Thích nghi (PostToolUse)
+
+Tự động học từ các lần bạn chấp nhận tool và cập nhật quyền trong `~/.claude/settings.json`. Mỗi khi bạn chấp nhận thực thi tool, hook tổng quát hóa lệnh thành một quy tắc quyền có thể tái sử dụng — để bạn không bao giờ phải chấp nhận cùng loại lệnh hai lần. Các lệnh nguy hiểm/không thể hoàn tác **không bao giờ** được ghi nhớ.
+
+Khi chạy lần đầu, nó gieo cấu hình ban đầu với các quyền nền tương đương auto-mode (đọc/ghi file, git, package managers, CLI tools phổ biến).
+
+**File:** `.claude/hooks/auto-adapt-mode.py`
+
+```python
+#!/usr/bin/env python3
+"""
+auto-adapt-mode: Học từ các lần user chấp nhận tool và cập nhật cấu hình Claude.
+
+Loại Hook: PostToolUse
+Sự kiện: Kích hoạt sau khi tool được thực thi thành công (nghĩa là user đã chấp nhận)
+"""
+
+import json
+import os
+import sys
+import re
+from pathlib import Path
+
+SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+LOG_PATH = Path.home() / ".claude" / "auto-adapt-mode.log"
+
+# Nền tảng auto-mode: các thao tác an toàn, cục bộ, có thể hoàn tác
+AUTO_MODE_BASELINE = [
+    "Read(*)", "Edit(*)", "Write(*)", "Glob(*)", "Grep(*)",
+    "Bash(git status:*)", "Bash(git log:*)", "Bash(git diff:*)",
+    "Bash(git add:*)", "Bash(git commit:*)", "Bash(git checkout:*)",
+    "Bash(npm install:*)", "Bash(npm test:*)", "Bash(npm run:*)",
+    "Bash(pip install:*)", "Bash(pytest:*)",
+    "Bash(ls:*)", "Bash(cat:*)", "Bash(find:*)", "Bash(mkdir:*)",
+    "Bash(cp:*)", "Bash(mv:*)", "Bash(chmod:*)",
+    "Bash(gh pr view:*)", "Bash(gh issue list:*)",
+    "Agent(*)", "Skill(*)", "WebSearch(*)", "WebFetch(*)",
+    # ... (danh sách đầy đủ bao gồm 70+ pattern an toàn)
+]
+
+# Các lệnh KHÔNG BAO GIỜ được tự động ghi nhớ
+DANGEROUS_PATTERNS = [
+    r"rm\s+(-[a-zA-Z]*r[a-zA-Z]*|--recursive)",   # rm -rf
+    r"git\s+push\s+(-[a-zA-Z]*f|--force)",          # force push
+    r"git\s+reset\s+--hard",                         # hard reset
+    r"DROP\s+(TABLE|DATABASE)",                       # SQL phá hủy
+    r"curl\s+.*\|\s*(bash|sh)",                       # pipe to shell
+    r"sudo\b",                                        # leo thang đặc quyền
+    r"docker\s+(rm|rmi|system\s+prune)",              # container phá hủy
+    r"kubectl\s+delete",                              # k8s phá hủy
+    r"terraform\s+destroy",                           # hạ tầng phá hủy
+    r"npm\s+publish",                                 # publish không thể hoàn tác
+    r"deploy\s+.*prod",                               # deploy production
+    # ... (danh sách đầy đủ bao gồm 25+ pattern)
+]
+
+
+def is_dangerous_command(command: str) -> bool:
+    """Kiểm tra xem lệnh bash có khớp với pattern nguy hiểm không."""
+    return any(re.search(p, command, re.IGNORECASE) for p in DANGEROUS_PATTERNS)
+
+
+def generalize_tool_permission(tool_name: str, tool_input: dict) -> str | None:
+    """Chuyển đổi một lần gọi tool cụ thể thành quy tắc quyền tổng quát."""
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if not command or is_dangerous_command(command):
+            return None
+        parts = command.strip().split()
+        base = parts[0]
+        compound = ["git", "npm", "npx", "pip", "cargo", "go", "gh", "python3"]
+        if base in compound and len(parts) > 1:
+            sub = parts[1]
+            if sub.lower() in {"rm", "delete", "destroy", "publish"}:
+                return None
+            return f"Bash({base} {sub}:*)"
+        return f"Bash({base}:*)"
+    elif tool_name == "Bash":  # Không bao giờ cho phép Bash(*) chung
+        return None
+    else:
+        return f"{tool_name}(*)"
+
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = hook_input.get("tool_name", "")
+    tool_input = hook_input.get("tool_input", {})
+    if not tool_name:
+        sys.exit(0)
+
+    settings = json.load(open(SETTINGS_PATH)) if SETTINGS_PATH.exists() else {}
+    allow = settings.setdefault("permissions", {}).setdefault("allow", [])
+
+    marker = Path.home() / ".claude" / ".auto-adapt-mode-initialized"
+    if not marker.exists():
+        existing = set(allow)
+        for rule in AUTO_MODE_BASELINE:
+            if rule not in existing:
+                allow.append(rule)
+        marker.touch()
+
+    rule = generalize_tool_permission(tool_name, tool_input)
+    if rule and rule not in allow:
+        allow.append(rule)
+        with open(SETTINGS_PATH, "w") as f:
+            json.dump(settings, f, indent=2)
+            f.write("\n")
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+```
+
+**Cấu hình:**
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/auto-adapt-mode.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Cách hoạt động:**
+1. `PostToolUse` kích hoạt sau **mỗi** lần thực thi tool thành công (nghĩa là bạn đã chấp nhận)
+2. Hook trích xuất tên tool và đầu vào, sau đó tổng quát hóa thành quy tắc quyền
+3. Các lệnh phức hợp như `git push origin main` trở thành `Bash(git push:*)` — khớp với mọi biến thể `git push`
+4. Quy tắc được thêm vào `~/.claude/settings.json` → `permissions.allow` nếu chưa có
+5. Khi chạy lần đầu, gieo ~70 quyền nền tảng tương đương auto-mode
+
+**Đảm bảo an toàn:**
+- Các lệnh nguy hiểm (force push, rm -rf, sudo, DROP TABLE, v.v.) **không bao giờ** được ghi nhớ
+- Các thao tác không thể hoàn tác (npm publish, terraform destroy, deploy prod) **luôn bị chặn**
+- Các lệnh trong danh sách `deny` không bao giờ bị ghi đè
+- Hook không bao giờ chặn thực thi tool (luôn thoát 0)
+- File log tại `~/.claude/auto-adapt-mode.log` theo dõi tất cả quyết định để kiểm tra
+
+**Ví dụ tổng quát hóa:**
+
+| Bạn chấp nhận | Quy tắc được thêm | Bao phủ |
+|--------------|------------------|---------|
+| `git push origin main` | `Bash(git push:*)` | Tất cả biến thể git push |
+| `npm run build` | `Bash(npm run:*)` | Tất cả npm scripts |
+| `ls -la src/` | `Bash(ls:*)` | Tất cả lời gọi ls |
+| `rm -rf /tmp/test` | *(bị chặn)* | Không bao giờ ghi nhớ |
+| `git push --force` | *(bị chặn)* | Không bao giờ ghi nhớ |
+| Tool `Write` | `Write(*)` | Tất cả ghi file |
+
+> **Mẹo:** Xóa `~/.claude/.auto-adapt-mode-initialized` để gieo lại quyền nền tảng. Kiểm tra `~/.claude/auto-adapt-mode.log` để xem quy tắc nào được thêm và quy tắc nào bị chặn.
+
+## Plugin Hooks
+
+Plugins có thể bao gồm hooks trong file `hooks/hooks.json` của chúng:
+
+**File:** `plugins/hooks/hooks.json`
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Biến môi trường trong Plugin Hooks:**
+- `${CLAUDE_PLUGIN_ROOT}` - Đường dẫn đến thư mục plugin
+- `${CLAUDE_PLUGIN_DATA}` - Đường dẫn đến thư mục data của plugin
+
+Điều này cho phép plugins bao gồm validation và automation hooks tùy chỉnh.
+
+## MCP Tool Hooks
+
+Các MCP tools theo pattern `mcp__<server>__<tool>`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__memory__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"systemMessage\": \"Thao tác bộ nhớ đã được ghi log\"}'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Cân nhắc bảo mật
+
+### Tuyên bố miễn trách
+
+**DÙNG TRÊN RỦI RO CỦA BẠN**: Hooks thực thi các lệnh shell tùy ý. Bạn hoàn toàn chịu trách nhiệm về:
+- Các lệnh bạn cấu hình
+- Quyền truy cập/sửa đổi file
+- Khả năng mất dữ liệu hoặc hư hại hệ thống
+- Kiểm tra hooks trong môi trường an toàn trước khi dùng production
+
+### Lưu ý bảo mật
+
+- **Yêu cầu tin cậy workspace:** Các lệnh hook output `statusLine` và `fileSuggestion` giờ yêu cầu chấp nhận tin cậy workspace trước khi có hiệu lực.
+- **HTTP hooks và biến môi trường:** HTTP hooks yêu cầu danh sách `allowedEnvVars` rõ ràng để dùng nội suy biến môi trường trong URLs. Điều này ngăn vô tình rò rỉ biến môi trường nhạy cảm ra endpoint từ xa.
+- **Thứ bậc cài đặt quản lý:** Cài đặt `disableAllHooks` giờ tôn trọng thứ bậc cài đặt quản lý, nghĩa là cài đặt cấp tổ chức có thể bắt buộc tắt hooks mà người dùng cá nhân không thể ghi đè.
+
+### Thực hành tốt nhất
+
+| Nên làm | Không nên làm |
+|---------|--------------|
+| Xác thực và làm sạch tất cả đầu vào | Tin tưởng dữ liệu đầu vào mù quáng |
+| Quote biến shell: `"$VAR"` | Dùng không quote: `$VAR` |
+| Chặn path traversal (`..`) | Cho phép đường dẫn tùy ý |
+| Dùng đường dẫn tuyệt đối với `$CLAUDE_PROJECT_DIR` | Hardcode đường dẫn |
+| Bỏ qua file nhạy cảm (`.env`, `.git/`, keys) | Xử lý tất cả file |
+| Kiểm tra hooks riêng lẻ trước | Deploy hooks chưa được kiểm tra |
+| Dùng `allowedEnvVars` rõ ràng cho HTTP hooks | Expose tất cả biến môi trường cho webhooks |
+
+## Gỡ lỗi
+
+### Bật chế độ Debug
+
+Chạy Claude với cờ debug để xem log hook chi tiết:
+
+```bash
+claude --debug
+```
+
+### Chế độ Verbose
+
+Dùng `Ctrl+O` trong Claude Code để bật chế độ verbose và xem tiến trình thực thi hook.
+
+### Kiểm tra Hooks độc lập
+
+```bash
+# Kiểm tra với đầu vào JSON mẫu
+echo '{"tool_name": "Bash", "tool_input": {"command": "ls -la"}}' | python3 .claude/hooks/validate-bash.py
+
+# Kiểm tra exit code
+echo $?
+```
+
+## Ví dụ cấu hình đầy đủ
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-bash.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/format-code.sh\"",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/security-scan.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-prompt.py\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/session-init.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Xác minh tất cả tác vụ đã hoàn thành trước khi dừng.",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Chi tiết thực thi Hook
+
+| Khía cạnh | Hành vi |
+|-----------|---------|
+| **Timeout** | 60 giây mặc định, có thể cấu hình cho mỗi lệnh |
+| **Song song hóa** | Tất cả hooks khớp chạy song song |
+| **Loại trùng lặp** | Các lệnh hook giống hệt được loại trùng |
+| **Môi trường** | Chạy trong thư mục hiện tại với môi trường của Claude Code |
+
+## Xử lý sự cố
+
+### Hook không thực thi
+- Kiểm tra cú pháp JSON cấu hình có đúng không
+- Kiểm tra pattern matcher có khớp tên tool không
+- Đảm bảo script tồn tại và có thể thực thi: `chmod +x script.sh`
+- Chạy `claude --debug` để xem log thực thi hook
+- Kiểm tra hook đọc JSON từ stdin (không phải đối số lệnh)
+
+### Hook chặn bất ngờ
+- Kiểm tra hook với JSON mẫu: `echo '{"tool_name": "Write", ...}' | ./hook.py`
+- Kiểm tra exit code: phải là 0 để cho phép, 2 để chặn
+- Kiểm tra đầu ra stderr (hiển thị khi exit code 2)
+
+### Lỗi phân tích JSON
+- Luôn đọc từ stdin, không phải đối số lệnh
+- Dùng phân tích JSON đúng cách (không phải thao tác chuỗi)
+- Xử lý các trường thiếu một cách nhẹ nhàng
+
+## Cài đặt
+
+### Bước 1: Tạo thư mục Hooks
+```bash
+mkdir -p ~/.claude/hooks
+```
+
+### Bước 2: Sao chép Hooks ví dụ
+```bash
+cp 06-hooks/*.sh ~/.claude/hooks/
+chmod +x ~/.claude/hooks/*.sh
+```
+
+### Bước 3: Cấu hình trong Settings
+Chỉnh sửa `~/.claude/settings.json` hoặc `.claude/settings.json` với cấu hình hook hiển thị ở trên.
+
+## Khái niệm liên quan
+
+- **[Checkpoints và Rewind](../08-checkpoints/)** - Lưu và khôi phục trạng thái hội thoại
+- **[Slash Commands](../01-slash-commands/)** - Tạo slash commands tùy chỉnh
+- **[Skills](../03-skills/)** - Khả năng tự chủ có thể tái sử dụng
+- **[Subagents](../04-subagents/)** - Thực thi tác vụ được ủy quyền
+- **[Plugins](../07-plugins/)** - Gói mở rộng tích hợp sẵn
+- **[Advanced Features](../09-advanced-features/)** - Khám phá các tính năng nâng cao của Claude Code
+
+## Tài nguyên bổ sung
+
+- **[Tài liệu Hooks chính thức](https://code.claude.com/docs/en/hooks)** - Tài liệu tham chiếu hooks đầy đủ
+- **[Tài liệu CLI](https://code.claude.com/docs/en/cli-reference)** - Tài liệu giao diện dòng lệnh
+- **[Hướng dẫn Memory](../02-memory/)** - Cấu hình ngữ cảnh liên tục

--- a/07-plugins/README.vi.md
+++ b/07-plugins/README.vi.md
@@ -939,5 +939,5 @@ Các tính năng Claude Code sau hoạt động cùng với plugins:
 - [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
 - [Tài liệu tham chiếu Plugins](https://code.claude.com/docs/en/plugins-reference)
 - [Tài liệu tham chiếu MCP Server](https://modelcontextprotocol.io/)
-- [Hướng dẫn cấu hình Subagent](../04-subagents/README.md)
-- [Tài liệu tham chiếu hệ thống Hook](../06-hooks/README.md)
+- [Hướng dẫn cấu hình Subagent](../04-subagents/README.vi.md)
+- [Tài liệu tham chiếu hệ thống Hook](../06-hooks/README.vi.md)

--- a/07-plugins/README.vi.md
+++ b/07-plugins/README.vi.md
@@ -1,0 +1,943 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Claude Code Plugins
+
+Thư mục này chứa các ví dụ plugin hoàn chỉnh kết hợp nhiều tính năng Claude Code thành các gói có thể cài đặt nhất quán.
+
+## Tổng quan
+
+Claude Code Plugins là các bộ tùy chỉnh được đóng gói (slash commands, subagents, MCP servers và hooks) được cài đặt bằng một lệnh duy nhất. Chúng đại diện cho cơ chế mở rộng cao nhất — kết hợp nhiều tính năng thành các gói có thể chia sẻ nhất quán.
+
+## Kiến trúc Plugin
+
+```mermaid
+graph TB
+    A["Plugin"]
+    B["Slash Commands"]
+    C["Subagents"]
+    D["MCP Servers"]
+    E["Hooks"]
+    F["Cấu hình"]
+
+    A -->|đóng gói| B
+    A -->|đóng gói| C
+    A -->|đóng gói| D
+    A -->|đóng gói| E
+    A -->|đóng gói| F
+```
+
+## Quy trình tải Plugin
+
+```mermaid
+sequenceDiagram
+    participant User as Người dùng
+    participant Claude as Claude Code
+    participant Plugin as Marketplace Plugin
+    participant Install as Cài đặt
+    participant SlashCmds as Slash Commands
+    participant Subagents as Subagents
+    participant MCPServers as MCP Servers
+    participant Hooks as Hooks
+    participant Tools as Tools đã cấu hình
+
+    User->>Claude: /plugin install pr-review
+    Claude->>Plugin: Tải manifest plugin
+    Plugin-->>Claude: Trả về định nghĩa plugin
+    Claude->>Install: Trích xuất các thành phần
+    Install->>SlashCmds: Cấu hình
+    Install->>Subagents: Cấu hình
+    Install->>MCPServers: Cấu hình
+    Install->>Hooks: Cấu hình
+    SlashCmds-->>Tools: Sẵn sàng dùng
+    Subagents-->>Tools: Sẵn sàng dùng
+    MCPServers-->>Tools: Sẵn sàng dùng
+    Hooks-->>Tools: Sẵn sàng dùng
+    Tools-->>Claude: Plugin đã cài đặt ✅
+```
+
+## Loại & Phân phối Plugin
+
+| Loại | Phạm vi | Chia sẻ | Thẩm quyền | Ví dụ |
+|------|---------|---------|-----------|-------|
+| Official | Toàn cầu | Tất cả user | Anthropic | PR Review, Security Guidance |
+| Community | Công khai | Tất cả user | Cộng đồng | DevOps, Data Science |
+| Organization | Nội bộ | Thành viên nhóm | Công ty | Tiêu chuẩn nội bộ, tools |
+| Personal | Cá nhân | Người dùng đơn | Developer | Quy trình tùy chỉnh |
+
+## Cấu trúc định nghĩa Plugin
+
+Manifest plugin dùng định dạng JSON trong `.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "my-first-plugin",
+  "description": "Plugin chào hỏi",
+  "version": "1.0.0",
+  "author": {
+    "name": "Tên của bạn"
+  },
+  "homepage": "https://example.com",
+  "repository": "https://github.com/user/repo",
+  "license": "MIT"
+}
+```
+
+## Ví dụ cấu trúc Plugin
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json       # Manifest (name, description, version, author)
+├── commands/             # Skills dạng file Markdown
+│   ├── task-1.md
+│   ├── task-2.md
+│   └── workflows/
+├── agents/               # Định nghĩa agent tùy chỉnh
+│   ├── specialist-1.md
+│   ├── specialist-2.md
+│   └── configs/
+├── skills/               # Agent Skills với file SKILL.md
+│   ├── skill-1.md
+│   └── skill-2.md
+├── hooks/                # Event handlers trong hooks.json
+│   └── hooks.json
+├── .mcp.json             # Cấu hình MCP server
+├── .lsp.json             # Cấu hình LSP server
+├── settings.json         # Cài đặt mặc định
+├── templates/
+│   └── issue-template.md
+├── scripts/
+│   ├── helper-1.sh
+│   └── helper-2.py
+├── docs/
+│   ├── README.md
+│   └── USAGE.md
+└── tests/
+    └── plugin.test.js
+```
+
+### Cấu hình LSP server
+
+Plugins có thể bao gồm hỗ trợ Language Server Protocol (LSP) để cung cấp thông tin code thời gian thực. LSP servers cung cấp diagnostics, điều hướng code và thông tin symbol khi bạn làm việc.
+
+**Vị trí cấu hình**:
+- File `.lsp.json` trong thư mục gốc plugin
+- Khóa `lsp` nội tuyến trong `plugin.json`
+
+#### Tham chiếu trường
+
+| Trường | Bắt buộc | Mô tả |
+|--------|----------|-------|
+| `command` | Có | Binary LSP server (phải ở trong PATH) |
+| `extensionToLanguage` | Có | Ánh xạ phần mở rộng file sang language IDs |
+| `args` | Không | Đối số dòng lệnh cho server |
+| `transport` | Không | Phương thức giao tiếp: `stdio` (mặc định) hoặc `socket` |
+| `env` | Không | Biến môi trường cho tiến trình server |
+| `initializationOptions` | Không | Tùy chọn gửi trong quá trình khởi tạo LSP |
+| `settings` | Không | Cấu hình workspace truyền cho server |
+| `workspaceFolder` | Không | Ghi đè đường dẫn workspace folder |
+| `startupTimeout` | Không | Thời gian tối đa (ms) chờ server khởi động |
+| `shutdownTimeout` | Không | Thời gian tối đa (ms) để tắt nhẹ nhàng |
+| `restartOnCrash` | Không | Tự động khởi động lại nếu server bị crash |
+| `maxRestarts` | Không | Số lần khởi động lại tối đa trước khi từ bỏ |
+
+#### Ví dụ cấu hình
+
+**Go (gopls)**:
+
+```json
+{
+  "go": {
+    "command": "gopls",
+    "args": ["serve"],
+    "extensionToLanguage": {
+      ".go": "go"
+    }
+  }
+}
+```
+
+**Python (pyright)**:
+
+```json
+{
+  "python": {
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".py": "python",
+      ".pyi": "python"
+    }
+  }
+}
+```
+
+**TypeScript**:
+
+```json
+{
+  "typescript": {
+    "command": "typescript-language-server",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".js": "javascript",
+      ".jsx": "javascriptreact"
+    }
+  }
+}
+```
+
+#### LSP plugins có sẵn
+
+Marketplace chính thức bao gồm các LSP plugin được cấu hình sẵn:
+
+| Plugin | Ngôn ngữ | Binary Server | Lệnh cài đặt |
+|--------|---------|---------------|-------------|
+| `pyright-lsp` | Python | `pyright-langserver` | `pip install pyright` |
+| `typescript-lsp` | TypeScript/JavaScript | `typescript-language-server` | `npm install -g typescript-language-server typescript` |
+| `rust-lsp` | Rust | `rust-analyzer` | Cài qua `rustup component add rust-analyzer` |
+
+#### Khả năng LSP
+
+Khi được cấu hình, LSP servers cung cấp:
+
+- **Diagnostics tức thì** — lỗi và cảnh báo xuất hiện ngay sau khi chỉnh sửa
+- **Điều hướng code** — đi đến định nghĩa, tìm tham chiếu, triển khai
+- **Thông tin hover** — chữ ký kiểu và tài liệu khi hover
+- **Liệt kê symbol** — duyệt symbols trong file hiện tại hoặc workspace
+
+## Tùy chọn Plugin (v2.1.83+)
+
+Plugins có thể khai báo các tùy chọn có thể cấu hình của người dùng trong manifest qua `userConfig`. Các giá trị được đánh dấu `sensitive: true` được lưu trong keychain hệ thống thay vì file cài đặt văn bản thường:
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "userConfig": {
+    "apiKey": {
+      "description": "API key cho dịch vụ",
+      "sensitive": true
+    },
+    "region": {
+      "description": "Vùng deployment",
+      "default": "us-east-1"
+    }
+  }
+}
+```
+
+## Dữ liệu Plugin liên tục (`${CLAUDE_PLUGIN_DATA}`) (v2.1.78+)
+
+Plugins có quyền truy cập vào thư mục trạng thái liên tục qua biến môi trường `${CLAUDE_PLUGIN_DATA}`. Thư mục này là duy nhất cho mỗi plugin và tồn tại qua các phiên, phù hợp cho caches, databases và trạng thái liên tục khác:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "command": "node ${CLAUDE_PLUGIN_DATA}/track-usage.js"
+      }
+    ]
+  }
+}
+```
+
+Thư mục được tạo tự động khi plugin được cài đặt. Các file lưu ở đây tồn tại cho đến khi plugin được gỡ cài đặt.
+
+## Plugin nội tuyến qua Settings (`source: 'settings'`) (v2.1.80+)
+
+Plugins có thể được định nghĩa nội tuyến trong file settings như các mục marketplace dùng trường `source: 'settings'`. Điều này cho phép nhúng định nghĩa plugin trực tiếp mà không cần repository hoặc marketplace riêng:
+
+```json
+{
+  "pluginMarketplaces": [
+    {
+      "name": "inline-tools",
+      "source": "settings",
+      "plugins": [
+        {
+          "name": "quick-lint",
+          "source": "./local-plugins/quick-lint"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Cài đặt Plugin
+
+Plugins có thể đi kèm file `settings.json` để cung cấp cấu hình mặc định. Hiện tại hỗ trợ khóa `agent`, đặt agent thread chính cho plugin:
+
+```json
+{
+  "agent": "agents/specialist-1.md"
+}
+```
+
+Khi plugin bao gồm `settings.json`, các giá trị mặc định của nó được áp dụng khi cài đặt. Người dùng có thể ghi đè các cài đặt này trong cấu hình dự án hoặc người dùng của họ.
+
+## So sánh Standalone vs Plugin
+
+| Cách tiếp cận | Tên lệnh | Cấu hình | Tốt nhất cho |
+|--------------|---------|---------|-------------|
+| **Standalone** | `/hello` | Thiết lập thủ công trong CLAUDE.md | Cá nhân, theo dự án cụ thể |
+| **Plugins** | `/tên-plugin:hello` | Tự động qua plugin.json | Chia sẻ, phân phối, dùng nhóm |
+
+Dùng **slash commands standalone** cho các quy trình cá nhân nhanh. Dùng **plugins** khi bạn muốn đóng gói nhiều tính năng, chia sẻ với nhóm hoặc xuất bản để phân phối.
+
+## Ví dụ thực tế
+
+### Ví dụ 1: Plugin PR Review
+
+**File:** `.claude-plugin/plugin.json`
+
+```json
+{
+  "name": "pr-review",
+  "version": "1.0.0",
+  "description": "Quy trình review PR hoàn chỉnh với kiểm tra bảo mật, testing và docs",
+  "author": {
+    "name": "Anthropic"
+  },
+  "repository": "https://github.com/anthropic/pr-review",
+  "license": "MIT"
+}
+```
+
+**File:** `commands/review-pr.md`
+
+```markdown
+---
+name: Review PR
+description: Bắt đầu review PR toàn diện với kiểm tra bảo mật và testing
+---
+
+# PR Review
+
+Lệnh này bắt đầu review pull request đầy đủ bao gồm:
+
+1. Phân tích bảo mật
+2. Xác minh độ phủ test
+3. Cập nhật tài liệu
+4. Kiểm tra chất lượng code
+5. Đánh giá tác động hiệu năng
+```
+
+**File:** `agents/security-reviewer.md`
+
+```yaml
+---
+name: security-reviewer
+description: Review code tập trung bảo mật
+tools: read, grep, diff
+---
+
+# Security Reviewer
+
+Chuyên tìm lỗ hổng bảo mật:
+- Vấn đề xác thực/ủy quyền
+- Lộ dữ liệu
+- Tấn công injection
+- Cấu hình bảo mật
+```
+
+**Cài đặt:**
+
+```bash
+/plugin install pr-review
+
+# Kết quả:
+# ✅ 3 slash commands đã cài đặt
+# ✅ 3 subagents đã cấu hình
+# ✅ 2 MCP servers đã kết nối
+# ✅ 4 hooks đã đăng ký
+# ✅ Sẵn sàng dùng!
+```
+
+### Ví dụ 2: Plugin DevOps
+
+**Các thành phần:**
+
+```
+devops-automation/
+├── commands/
+│   ├── deploy.md
+│   ├── rollback.md
+│   ├── status.md
+│   └── incident.md
+├── agents/
+│   ├── deployment-specialist.md
+│   ├── incident-commander.md
+│   └── alert-analyzer.md
+├── mcp/
+│   ├── github-config.json
+│   ├── kubernetes-config.json
+│   └── prometheus-config.json
+├── hooks/
+│   ├── pre-deploy.js
+│   ├── post-deploy.js
+│   └── on-error.js
+└── scripts/
+    ├── deploy.sh
+    ├── rollback.sh
+    └── health-check.sh
+```
+
+### Ví dụ 3: Plugin Tài liệu
+
+**Các thành phần được đóng gói:**
+
+```
+documentation/
+├── commands/
+│   ├── generate-api-docs.md
+│   ├── generate-readme.md
+│   ├── sync-docs.md
+│   └── validate-docs.md
+├── agents/
+│   ├── api-documenter.md
+│   ├── code-commentator.md
+│   └── example-generator.md
+├── mcp/
+│   ├── github-docs-config.json
+│   └── slack-announce-config.json
+└── templates/
+    ├── api-endpoint.md
+    ├── function-docs.md
+    └── adr-template.md
+```
+
+## Marketplace Plugin
+
+Thư mục plugin chính thức do Anthropic quản lý là `anthropics/claude-plugins-official`. Quản trị viên doanh nghiệp cũng có thể tạo marketplace plugin riêng để phân phối nội bộ.
+
+```mermaid
+graph TB
+    A["Plugin Marketplace"]
+    B["Chính thức<br/>anthropics/claude-plugins-official"]
+    C["Community<br/>Marketplace"]
+    D["Enterprise<br/>Registry riêng"]
+
+    A --> B
+    A --> C
+    A --> D
+
+    B -->|Danh mục| B1["Development"]
+    B -->|Danh mục| B2["DevOps"]
+    B -->|Danh mục| B3["Documentation"]
+
+    C -->|Tìm kiếm| C1["DevOps Automation"]
+    C -->|Tìm kiếm| C2["Mobile Dev"]
+    C -->|Tìm kiếm| C3["Data Science"]
+
+    D -->|Nội bộ| D1["Tiêu chuẩn công ty"]
+    D -->|Nội bộ| D2["Hệ thống cũ"]
+    D -->|Nội bộ| D3["Compliance"]
+
+    style A fill:#e1f5fe,stroke:#333,color:#333
+    style B fill:#e8f5e9,stroke:#333,color:#333
+    style C fill:#f3e5f5,stroke:#333,color:#333
+    style D fill:#fff3e0,stroke:#333,color:#333
+```
+
+### Cấu hình Marketplace
+
+Người dùng doanh nghiệp và nâng cao có thể kiểm soát hành vi marketplace qua cài đặt:
+
+| Cài đặt | Mô tả |
+|---------|-------|
+| `extraKnownMarketplaces` | Thêm nguồn marketplace bổ sung ngoài mặc định |
+| `strictKnownMarketplaces` | Kiểm soát marketplace nào người dùng được phép thêm |
+| `deniedPlugins` | Danh sách chặn do admin quản lý để ngăn cài đặt plugin cụ thể |
+
+### Tính năng Marketplace bổ sung
+
+- **Timeout git mặc định**: Tăng từ 30s lên 120s cho các repository plugin lớn
+- **npm registry tùy chỉnh**: Plugins có thể chỉ định URL npm registry tùy chỉnh để giải quyết dependency
+- **Ghim phiên bản**: Khóa plugins ở phiên bản cụ thể cho môi trường có thể tái tạo
+
+### Schema định nghĩa Marketplace
+
+Plugin marketplaces được định nghĩa trong `.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "my-team-plugins",
+  "owner": "my-org",
+  "plugins": [
+    {
+      "name": "code-standards",
+      "source": "./plugins/code-standards",
+      "description": "Áp đặt tiêu chuẩn coding của nhóm",
+      "version": "1.2.0",
+      "author": "platform-team"
+    },
+    {
+      "name": "deploy-helper",
+      "source": {
+        "source": "github",
+        "repo": "my-org/deploy-helper",
+        "ref": "v2.0.0"
+      },
+      "description": "Quy trình tự động hóa deployment"
+    }
+  ]
+}
+```
+
+| Trường | Bắt buộc | Mô tả |
+|--------|----------|-------|
+| `name` | Có | Tên marketplace dạng kebab-case |
+| `owner` | Có | Tổ chức hoặc người dùng duy trì marketplace |
+| `plugins` | Có | Mảng các mục plugin |
+| `plugins[].name` | Có | Tên plugin (kebab-case) |
+| `plugins[].source` | Có | Nguồn plugin (chuỗi đường dẫn hoặc object nguồn) |
+| `plugins[].description` | Không | Mô tả plugin ngắn gọn |
+| `plugins[].version` | Không | Chuỗi phiên bản semantic |
+| `plugins[].author` | Không | Tên tác giả plugin |
+
+### Loại nguồn Plugin
+
+Plugins có thể được lấy từ nhiều vị trí:
+
+| Nguồn | Cú pháp | Ví dụ |
+|-------|---------|-------|
+| **Đường dẫn tương đối** | Chuỗi đường dẫn | `"./plugins/my-plugin"` |
+| **GitHub** | `{ "source": "github", "repo": "owner/repo" }` | `{ "source": "github", "repo": "acme/lint-plugin", "ref": "v1.0" }` |
+| **Git URL** | `{ "source": "url", "url": "..." }` | `{ "source": "url", "url": "https://git.internal/plugin.git" }` |
+| **Git subdirectory** | `{ "source": "git-subdir", "url": "...", "path": "..." }` | `{ "source": "git-subdir", "url": "https://github.com/org/monorepo.git", "path": "packages/plugin" }` |
+| **npm** | `{ "source": "npm", "package": "..." }` | `{ "source": "npm", "package": "@acme/claude-plugin", "version": "^2.0" }` |
+| **pip** | `{ "source": "pip", "package": "..." }` | `{ "source": "pip", "package": "claude-data-plugin", "version": ">=1.0" }` |
+
+Các nguồn GitHub và git hỗ trợ các trường `ref` (branch/tag) và `sha` (commit hash) tùy chọn để ghim phiên bản.
+
+### Phương thức phân phối
+
+**GitHub (khuyến nghị)**:
+```bash
+# Người dùng thêm marketplace của bạn
+/plugin marketplace add owner/repo-name
+```
+
+**Các dịch vụ git khác** (yêu cầu URL đầy đủ):
+```bash
+/plugin marketplace add https://gitlab.com/org/marketplace-repo.git
+```
+
+**Repository riêng tư**: Được hỗ trợ qua git credential helpers hoặc environment tokens. Người dùng phải có quyền đọc repository.
+
+**Gửi marketplace chính thức**: Gửi plugins lên marketplace được Anthropic tuyển chọn để phân phối rộng hơn.
+
+### Chế độ Strict
+
+Kiểm soát cách định nghĩa marketplace tương tác với các file `plugin.json` cục bộ:
+
+| Cài đặt | Hành vi |
+|---------|---------|
+| `strict: true` (mặc định) | `plugin.json` cục bộ là có thẩm quyền; mục marketplace bổ sung nó |
+| `strict: false` | Mục marketplace là toàn bộ định nghĩa plugin |
+
+**Hạn chế của tổ chức** với `strictKnownMarketplaces`:
+
+| Giá trị | Hiệu lực |
+|---------|---------|
+| Chưa đặt | Không hạn chế — người dùng có thể thêm bất kỳ marketplace nào |
+| Mảng rỗng `[]` | Khóa — không cho phép marketplace nào |
+| Mảng patterns | Whitelist — chỉ marketplace khớp mới được thêm |
+
+```json
+{
+  "strictKnownMarketplaces": [
+    "my-org/*",
+    "github.com/trusted-vendor/*"
+  ]
+}
+```
+
+> **Cảnh báo**: Trong chế độ strict với `strictKnownMarketplaces`, người dùng chỉ có thể cài plugins từ marketplaces được whitelist. Hữu ích cho môi trường doanh nghiệp yêu cầu phân phối plugin được kiểm soát.
+
+## Cài đặt & Vòng đời Plugin
+
+```mermaid
+graph LR
+    A["Khám phá"] -->|Duyệt| B["Marketplace"]
+    B -->|Chọn| C["Trang Plugin"]
+    C -->|Xem| D["Thành phần"]
+    D -->|Cài đặt| E["/plugin install"]
+    E -->|Trích xuất| F["Cấu hình"]
+    F -->|Kích hoạt| G["Dùng"]
+    G -->|Kiểm tra| H["Cập nhật"]
+    H -->|Có sẵn| G
+    G -->|Xong| I["Tắt"]
+    I -->|Sau đó| J["Bật"]
+    J -->|Quay lại| G
+```
+
+## So sánh tính năng Plugin
+
+| Tính năng | Slash Command | Skill | Subagent | Plugin |
+|-----------|---------------|-------|----------|--------|
+| **Cài đặt** | Sao chép thủ công | Sao chép thủ công | Cấu hình thủ công | Một lệnh |
+| **Thời gian thiết lập** | 5 phút | 10 phút | 15 phút | 2 phút |
+| **Đóng gói** | File đơn | File đơn | File đơn | Nhiều file |
+| **Versioning** | Thủ công | Thủ công | Thủ công | Tự động |
+| **Chia sẻ nhóm** | Sao chép file | Sao chép file | Sao chép file | ID cài đặt |
+| **Cập nhật** | Thủ công | Thủ công | Thủ công | Tự động |
+| **Dependencies** | Không | Không | Không | Có thể có |
+| **Marketplace** | Không | Không | Không | Có |
+| **Phân phối** | Repository | Repository | Repository | Marketplace |
+
+## Lệnh CLI Plugin
+
+Tất cả thao tác plugin có sẵn dưới dạng lệnh CLI:
+
+```bash
+claude plugin install <tên>@<marketplace>   # Cài từ marketplace
+claude plugin uninstall <tên>               # Xóa plugin
+claude plugin list                          # Liệt kê plugins đã cài
+claude plugin enable <tên>                  # Bật plugin đã tắt
+claude plugin disable <tên>                 # Tắt plugin
+claude plugin validate                      # Xác thực cấu trúc plugin
+```
+
+## Phương thức cài đặt
+
+### Từ Marketplace
+```bash
+/plugin install tên-plugin
+# hoặc từ CLI:
+claude plugin install tên-plugin@tên-marketplace
+```
+
+### Bật / Tắt (với phạm vi tự động phát hiện)
+```bash
+/plugin enable tên-plugin
+/plugin disable tên-plugin
+```
+
+### Plugin cục bộ (để phát triển)
+```bash
+# Cờ CLI để kiểm tra cục bộ (có thể lặp lại cho nhiều plugins)
+claude --plugin-dir ./path/to/plugin
+claude --plugin-dir ./plugin-a --plugin-dir ./plugin-b
+```
+
+### Từ Git Repository
+```bash
+/plugin install github:username/repo
+```
+
+## Khi nào nên tạo Plugin
+
+```mermaid
+graph TD
+    A["Tôi có nên tạo plugin không?"]
+    A -->|Cần nhiều thành phần| B{"Nhiều commands<br/>hoặc subagents<br/>hoặc MCPs?"}
+    B -->|Có| C["✅ Tạo Plugin"]
+    B -->|Không| D["Dùng tính năng riêng lẻ"]
+    A -->|Quy trình nhóm| E{"Chia sẻ với<br/>nhóm?"}
+    E -->|Có| C
+    E -->|Không| F["Giữ làm Thiết lập cục bộ"]
+    A -->|Thiết lập phức tạp| G{"Cần cấu hình<br/>tự động?"}
+    G -->|Có| C
+    G -->|Không| D
+```
+
+### Trường hợp dùng Plugin
+
+| Trường hợp dùng | Khuyến nghị | Lý do |
+|----------------|-------------|-------|
+| **Onboarding nhóm** | ✅ Dùng Plugin | Thiết lập tức thì, tất cả cấu hình |
+| **Thiết lập Framework** | ✅ Dùng Plugin | Đóng gói lệnh theo framework cụ thể |
+| **Tiêu chuẩn Enterprise** | ✅ Dùng Plugin | Phân phối tập trung, kiểm soát phiên bản |
+| **Tự động hóa tác vụ nhanh** | ❌ Dùng Command | Quá phức tạp không cần thiết |
+| **Chuyên môn một lĩnh vực** | ❌ Dùng Skill | Quá nặng, dùng skill thay thế |
+| **Phân tích chuyên biệt** | ❌ Dùng Subagent | Tạo thủ công hoặc dùng skill |
+| **Truy cập dữ liệu trực tiếp** | ❌ Dùng MCP | Độc lập, không đóng gói |
+
+## Kiểm tra Plugin
+
+Trước khi xuất bản, kiểm tra plugin cục bộ bằng cờ `--plugin-dir` CLI (có thể lặp lại cho nhiều plugins):
+
+```bash
+claude --plugin-dir ./my-plugin
+claude --plugin-dir ./my-plugin --plugin-dir ./another-plugin
+```
+
+Điều này khởi động Claude Code với plugin đã tải, cho phép bạn:
+- Xác minh tất cả slash commands có sẵn
+- Kiểm tra subagents và agents hoạt động đúng
+- Xác nhận MCP servers kết nối đúng
+- Xác thực thực thi hook
+- Kiểm tra cấu hình LSP server
+- Kiểm tra bất kỳ lỗi cấu hình nào
+
+## Hot-Reload
+
+Plugins hỗ trợ hot-reload trong quá trình phát triển. Khi bạn sửa đổi file plugin, Claude Code có thể phát hiện thay đổi tự động. Bạn cũng có thể buộc reload bằng:
+
+```bash
+/reload-plugins
+```
+
+Lệnh này đọc lại tất cả manifests plugin, commands, agents, skills, hooks và cấu hình MCP/LSP mà không cần khởi động lại phiên.
+
+## Cài đặt quản lý cho Plugins
+
+Quản trị viên có thể kiểm soát hành vi plugin trong tổ chức bằng cài đặt quản lý:
+
+| Cài đặt | Mô tả |
+|---------|-------|
+| `enabledPlugins` | Whitelist plugins được bật theo mặc định |
+| `deniedPlugins` | Blacklist plugins không thể cài đặt |
+| `extraKnownMarketplaces` | Thêm nguồn marketplace bổ sung ngoài mặc định |
+| `strictKnownMarketplaces` | Hạn chế marketplace nào người dùng được phép thêm |
+| `allowedChannelPlugins` | Kiểm soát plugins nào được phép theo kênh phát hành |
+
+Các cài đặt này có thể được áp dụng ở cấp tổ chức qua các file cấu hình quản lý và được ưu tiên hơn cài đặt cấp người dùng.
+
+## Bảo mật Plugin
+
+Subagents của plugin chạy trong sandbox bị hạn chế. Các khóa frontmatter sau **không được phép** trong định nghĩa subagent plugin:
+
+- `hooks` -- Subagents không thể đăng ký event handlers
+- `mcpServers` -- Subagents không thể cấu hình MCP servers
+- `permissionMode` -- Subagents không thể ghi đè mô hình quyền
+
+Điều này đảm bảo plugins không thể leo thang đặc quyền hoặc sửa đổi môi trường host ngoài phạm vi đã khai báo.
+
+## Xuất bản Plugin
+
+**Các bước xuất bản:**
+
+1. Tạo cấu trúc plugin với tất cả thành phần
+2. Viết manifest `.claude-plugin/plugin.json`
+3. Tạo `README.md` với tài liệu
+4. Kiểm tra cục bộ với `claude --plugin-dir ./my-plugin`
+5. Gửi lên marketplace plugin
+6. Được review và phê duyệt
+7. Được xuất bản trên marketplace
+8. Người dùng có thể cài đặt bằng một lệnh
+
+**Ví dụ gửi:**
+
+```markdown
+# Plugin PR Review
+
+## Mô tả
+Quy trình review PR hoàn chỉnh với kiểm tra bảo mật, testing và tài liệu.
+
+## Bao gồm gì
+- 3 slash commands cho các loại review khác nhau
+- 3 subagents chuyên biệt
+- Tích hợp GitHub và CodeQL MCP
+- Hooks quét bảo mật tự động
+
+## Cài đặt
+\`\`\`bash
+/plugin install pr-review
+\`\`\`
+
+## Tính năng
+✅ Phân tích bảo mật
+✅ Kiểm tra độ phủ test
+✅ Xác minh tài liệu
+✅ Đánh giá chất lượng code
+✅ Phân tích tác động hiệu năng
+
+## Cách dùng
+\`\`\`bash
+/review-pr
+/check-security
+/check-tests
+\`\`\`
+
+## Yêu cầu
+- Claude Code 1.0+
+- Quyền truy cập GitHub
+- CodeQL (tùy chọn)
+```
+
+## Plugin vs Cấu hình thủ công
+
+**Thiết lập thủ công (2+ giờ):**
+- Cài slash commands từng cái một
+- Tạo subagents riêng lẻ
+- Cấu hình MCPs riêng
+- Thiết lập hooks thủ công
+- Ghi lại mọi thứ
+- Chia sẻ với nhóm (hy vọng họ cấu hình đúng)
+
+**Với Plugin (2 phút):**
+```bash
+/plugin install pr-review
+# ✅ Mọi thứ đã cài đặt và cấu hình
+# ✅ Sẵn sàng dùng ngay
+# ✅ Nhóm có thể tái tạo thiết lập chính xác
+```
+
+## Thực hành tốt nhất
+
+### Nên làm ✅
+- Dùng tên plugin rõ ràng, mô tả
+- Bao gồm README toàn diện
+- Đặt phiên bản plugin đúng cách (semver)
+- Kiểm tra tất cả thành phần cùng nhau
+- Ghi lại yêu cầu rõ ràng
+- Cung cấp ví dụ sử dụng
+- Bao gồm xử lý lỗi
+- Tag phù hợp để dễ khám phá
+- Duy trì khả năng tương thích ngược
+- Giữ plugins tập trung và nhất quán
+- Bao gồm tests toàn diện
+- Ghi lại tất cả dependencies
+
+### Không nên làm ❌
+- Đừng đóng gói các tính năng không liên quan
+- Đừng hardcode thông tin xác thực
+- Đừng bỏ qua testing
+- Đừng quên tài liệu
+- Đừng tạo plugins dư thừa
+- Đừng bỏ qua versioning
+- Đừng làm phức tạp không cần thiết dependencies giữa các thành phần
+- Đừng quên xử lý lỗi nhẹ nhàng
+
+## Hướng dẫn cài đặt
+
+### Cài từ Marketplace
+
+1. **Duyệt plugins có sẵn:**
+   ```bash
+   /plugin list
+   ```
+
+2. **Xem chi tiết plugin:**
+   ```bash
+   /plugin info tên-plugin
+   ```
+
+3. **Cài đặt plugin:**
+   ```bash
+   /plugin install tên-plugin
+   ```
+
+### Cài từ đường dẫn cục bộ
+
+```bash
+/plugin install ./path/to/plugin-directory
+```
+
+### Cài từ GitHub
+
+```bash
+/plugin install github:username/repo
+```
+
+### Liệt kê Plugins đã cài
+
+```bash
+/plugin list --installed
+```
+
+### Cập nhật Plugin
+
+```bash
+/plugin update tên-plugin
+```
+
+### Tắt/Bật Plugin
+
+```bash
+# Tắt tạm thời
+/plugin disable tên-plugin
+
+# Bật lại
+/plugin enable tên-plugin
+```
+
+### Gỡ cài đặt Plugin
+
+```bash
+/plugin uninstall tên-plugin
+```
+
+## Khái niệm liên quan
+
+Các tính năng Claude Code sau hoạt động cùng với plugins:
+
+- **[Slash Commands](../01-slash-commands/)** - Lệnh riêng lẻ được đóng gói trong plugins
+- **[Memory](../02-memory/)** - Ngữ cảnh liên tục cho plugins
+- **[Skills](../03-skills/)** - Chuyên môn lĩnh vực có thể được bọc thành plugins
+- **[Subagents](../04-subagents/)** - Agents chuyên biệt được bao gồm như thành phần plugin
+- **[MCP Servers](../05-mcp/)** - Tích hợp Model Context Protocol được đóng gói trong plugins
+- **[Hooks](../06-hooks/)** - Event handlers kích hoạt quy trình plugin
+
+## Ví dụ quy trình đầy đủ
+
+### Quy trình đầy đủ Plugin PR Review
+
+```
+1. Người dùng: /review-pr
+
+2. Plugin thực thi:
+   ├── Hook pre-review.js xác thực git repo
+   ├── GitHub MCP lấy dữ liệu PR
+   ├── Subagent security-reviewer phân tích bảo mật
+   ├── Subagent test-checker xác minh độ phủ
+   └── Subagent performance-analyzer kiểm tra hiệu năng
+
+3. Kết quả tổng hợp và trình bày:
+   ✅ Bảo mật: Không có vấn đề nghiêm trọng
+   ⚠️  Testing: Độ phủ 65% (khuyến nghị 80%+)
+   ✅ Hiệu năng: Không tác động đáng kể
+   📝 12 khuyến nghị được cung cấp
+```
+
+## Xử lý sự cố
+
+### Plugin không cài được
+- Kiểm tra khả năng tương thích phiên bản Claude Code: `/version`
+- Xác thực cú pháp `plugin.json` bằng JSON validator
+- Kiểm tra kết nối internet (cho plugins từ xa)
+- Review quyền: `ls -la plugin/`
+
+### Thành phần không tải được
+- Xác minh đường dẫn trong `plugin.json` khớp với cấu trúc thư mục thực tế
+- Kiểm tra quyền file: `chmod +x scripts/`
+- Review cú pháp file thành phần
+- Kiểm tra logs: `/plugin debug tên-plugin`
+
+### Kết nối MCP thất bại
+- Xác minh biến môi trường được đặt đúng
+- Kiểm tra cài đặt và sức khỏe MCP server
+- Kiểm tra kết nối MCP độc lập với `/mcp test`
+- Review cấu hình MCP trong thư mục `mcp/`
+
+### Lệnh không có sẵn sau khi cài
+- Đảm bảo plugin được cài thành công: `/plugin list --installed`
+- Kiểm tra plugin có được bật không: `/plugin status tên-plugin`
+- Khởi động lại Claude Code: `exit` và mở lại
+- Kiểm tra xung đột tên với lệnh hiện có
+
+### Vấn đề thực thi Hook
+- Xác minh file hook có quyền đúng
+- Kiểm tra cú pháp hook và tên sự kiện
+- Review log hook để biết chi tiết lỗi
+- Kiểm tra hooks thủ công nếu có thể
+
+## Tài nguyên bổ sung
+
+- [Tài liệu Plugins chính thức](https://code.claude.com/docs/en/plugins)
+- [Khám phá Plugins](https://code.claude.com/docs/en/discover-plugins)
+- [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Tài liệu tham chiếu Plugins](https://code.claude.com/docs/en/plugins-reference)
+- [Tài liệu tham chiếu MCP Server](https://modelcontextprotocol.io/)
+- [Hướng dẫn cấu hình Subagent](../04-subagents/README.md)
+- [Tài liệu tham chiếu hệ thống Hook](../06-hooks/README.md)

--- a/08-checkpoints/README.vi.md
+++ b/08-checkpoints/README.vi.md
@@ -1,0 +1,305 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Checkpoints và Rewind
+
+Checkpoints (điểm lưu trạng thái) cho phép bạn lưu lại trạng thái cuộc hội thoại và quay ngược về các thời điểm trước trong phiên Claude Code. Tính năng này cực kỳ hữu ích khi bạn muốn thử nhiều hướng tiếp cận khác nhau, phục hồi sau khi mắc lỗi, hoặc so sánh các giải pháp khác nhau.
+
+## Tổng quan
+
+Checkpoints cho phép lưu trạng thái cuộc hội thoại và quay lại các thời điểm trước, giúp bạn thử nghiệm an toàn và khám phá nhiều hướng tiếp cận. Mỗi checkpoint là một "ảnh chụp" trạng thái hội thoại, bao gồm:
+- Toàn bộ tin nhắn đã trao đổi
+- Các thay đổi file đã thực hiện
+- Lịch sử sử dụng công cụ
+- Ngữ cảnh phiên làm việc
+
+Checkpoints đặc biệt hữu ích khi thử nhiều hướng tiếp cận, phục hồi sau lỗi, hoặc so sánh các giải pháp khác nhau.
+
+## Các khái niệm chính
+
+| Khái niệm | Mô tả |
+|-----------|-------|
+| **Checkpoint** | Ảnh chụp trạng thái hội thoại, bao gồm tin nhắn, file và ngữ cảnh |
+| **Rewind** | Quay về checkpoint trước, bỏ đi các thay đổi sau đó |
+| **Branch Point** | Checkpoint để từ đó phân nhánh và thử nhiều hướng tiếp cận |
+
+## Cách truy cập Checkpoints
+
+Có hai cách chính để truy cập và quản lý checkpoints:
+
+### Dùng phím tắt
+Nhấn `Esc` hai lần (`Esc` + `Esc`) để mở giao diện checkpoint và duyệt qua các checkpoint đã lưu.
+
+### Dùng lệnh Slash
+Dùng lệnh `/rewind` (hoặc bí danh `/checkpoint`) để truy cập nhanh:
+
+```bash
+# Mở giao diện rewind
+/rewind
+
+# Hoặc dùng bí danh
+/checkpoint
+```
+
+## Các tùy chọn khi Rewind
+
+Khi thực hiện rewind, bạn sẽ thấy menu với năm lựa chọn:
+
+1. **Restore code and conversation** — Hoàn nguyên cả file lẫn tin nhắn về checkpoint đó
+2. **Restore conversation** — Chỉ hoàn nguyên tin nhắn, giữ nguyên code hiện tại
+3. **Restore code** — Chỉ hoàn nguyên các thay đổi file, giữ nguyên toàn bộ lịch sử hội thoại
+4. **Summarize from here** — Nén hội thoại từ điểm này trở đi thành bản tóm tắt do AI tạo, thay vì xóa bỏ. Các tin nhắn gốc vẫn được lưu trong transcript. Bạn có thể cung cấp hướng dẫn để tóm tắt tập trung vào các chủ đề cụ thể.
+5. **Never mind** — Hủy và quay về trạng thái hiện tại
+
+## Checkpoint tự động
+
+Claude Code tự động tạo checkpoint cho bạn:
+
+- **Mỗi lần bạn gửi tin nhắn** — Checkpoint mới được tạo với mỗi lần nhập liệu
+- **Bền vững** — Checkpoints tồn tại qua các phiên làm việc
+- **Tự dọn dẹp** — Checkpoints được tự động xóa sau 30 ngày
+
+Nghĩa là bạn luôn có thể quay về bất kỳ thời điểm nào trong cuộc hội thoại, từ vài phút trước đến vài ngày trước.
+
+## Các trường hợp sử dụng
+
+| Tình huống | Quy trình |
+|-----------|-----------|
+| **Thử nhiều hướng tiếp cận** | Lưu → Thử A → Lưu → Rewind → Thử B → So sánh |
+| **Refactor an toàn** | Lưu → Refactor → Test → Nếu fail: Rewind |
+| **A/B Testing** | Lưu → Thiết kế A → Lưu → Rewind → Thiết kế B → So sánh |
+| **Phục hồi sau lỗi** | Phát hiện vấn đề → Rewind về trạng thái tốt gần nhất |
+
+## Cách dùng Checkpoints
+
+### Xem và Rewind
+
+Nhấn `Esc` hai lần hoặc dùng `/rewind` để mở trình duyệt checkpoint. Bạn sẽ thấy danh sách các checkpoint có sẵn với nhãn thời gian. Chọn checkpoint bất kỳ để quay về trạng thái đó.
+
+### Chi tiết Checkpoint
+
+Mỗi checkpoint hiển thị:
+- Thời điểm tạo
+- Các file đã thay đổi
+- Số lượng tin nhắn trong hội thoại
+- Các công cụ đã dùng
+
+## Ví dụ thực tế
+
+### Ví dụ 1: Thử nhiều hướng tiếp cận
+
+```
+User: Let's add a caching layer to the API
+
+Claude: I'll add Redis caching to your API endpoints...
+[Thực hiện thay đổi tại checkpoint A]
+
+User: Actually, let's try in-memory caching instead
+
+Claude: I'll rewind to explore a different approach...
+[Người dùng nhấn Esc+Esc và rewind về checkpoint A]
+[Triển khai in-memory caching tại checkpoint B]
+
+User: Now I can compare both approaches
+```
+
+### Ví dụ 2: Phục hồi sau lỗi
+
+```
+User: Refactor the authentication module to use JWT
+
+Claude: I'll refactor the authentication module...
+[Thực hiện nhiều thay đổi]
+
+User: Wait, that broke the OAuth integration. Let's go back.
+
+Claude: I'll help you rewind to before the refactoring...
+[Người dùng nhấn Esc+Esc và chọn checkpoint trước khi refactor]
+
+User: Let's try a more conservative approach this time
+```
+
+### Ví dụ 3: Thử nghiệm an toàn
+
+```
+User: Let's try rewriting this in a functional style
+[Tạo checkpoint trước khi thử nghiệm]
+
+Claude: [Thực hiện các thay đổi thử nghiệm]
+
+User: The tests are failing. Let's rewind.
+[Người dùng nhấn Esc+Esc và rewind về checkpoint]
+
+Claude: I've rewound the changes. Let's try a different approach.
+```
+
+### Ví dụ 4: Phân nhánh hướng tiếp cận
+
+```
+User: I want to compare two database designs
+[Ghi nhớ checkpoint — đặt tên "Start"]
+
+Claude: I'll create the first design...
+[Triển khai Schema A]
+
+User: Now let me go back and try the second approach
+[Người dùng nhấn Esc+Esc và rewind về "Start"]
+
+Claude: Now I'll implement Schema B...
+[Triển khai Schema B]
+
+User: Great! Now I have both schemas to choose from
+```
+
+## Thời hạn lưu Checkpoint
+
+Claude Code tự động quản lý checkpoint của bạn:
+
+- Checkpoint được tạo tự động với mỗi lần gửi tin nhắn
+- Checkpoint cũ được lưu tối đa 30 ngày
+- Checkpoint được tự động dọn dẹp để tránh tốn quá nhiều dung lượng
+
+## Các mẫu quy trình làm việc
+
+### Chiến lược phân nhánh khi khám phá
+
+Khi thử nhiều hướng tiếp cận:
+
+```
+1. Bắt đầu với triển khai ban đầu → Checkpoint A
+2. Thử Hướng 1 → Checkpoint B
+3. Rewind về Checkpoint A
+4. Thử Hướng 2 → Checkpoint C
+5. So sánh kết quả từ B và C
+6. Chọn hướng tốt nhất và tiếp tục
+```
+
+### Mẫu Refactor an toàn
+
+Khi thực hiện thay đổi lớn:
+
+```
+1. Trạng thái hiện tại → Checkpoint (tự động)
+2. Bắt đầu refactor
+3. Chạy tests
+4. Nếu tests pass → Tiếp tục làm việc
+5. Nếu tests fail → Rewind và thử hướng khác
+```
+
+## Thực hành tốt
+
+Vì checkpoint được tạo tự động, bạn có thể tập trung vào công việc mà không cần lo lưu trạng thái thủ công. Tuy nhiên, hãy ghi nhớ:
+
+### Dùng Checkpoints hiệu quả
+
+✅ **Nên làm:**
+- Xem lại các checkpoint có sẵn trước khi rewind
+- Dùng rewind khi muốn khám phá hướng khác
+- Giữ checkpoint để so sánh các hướng tiếp cận khác nhau
+- Hiểu rõ từng tùy chọn rewind (restore code and conversation, restore conversation, restore code, hoặc summarize)
+
+❌ **Không nên:**
+- Chỉ dựa vào checkpoint để bảo toàn code
+- Kỳ vọng checkpoint theo dõi thay đổi file ngoài hệ thống
+- Dùng checkpoint thay thế cho git commits
+
+## Cấu hình
+
+Bạn có thể bật/tắt checkpoint tự động trong cài đặt:
+
+```json
+{
+  "autoCheckpoint": true
+}
+```
+
+- `autoCheckpoint`: Bật/tắt tính năng tự động tạo checkpoint với mỗi lần gửi tin nhắn (mặc định: `true`)
+
+## Giới hạn
+
+Checkpoints có các giới hạn sau:
+
+- **Không theo dõi thay đổi từ lệnh Bash** — Các thao tác như `rm`, `mv`, `cp` trên hệ thống file không được ghi lại trong checkpoint
+- **Không theo dõi thay đổi bên ngoài** — Thay đổi thực hiện ngoài Claude Code (trong editor, terminal...) không được ghi lại
+- **Không thay thế version control** — Dùng git cho các thay đổi cần lưu vĩnh viễn và có thể kiểm tra lại
+
+## Xử lý sự cố
+
+### Checkpoint bị thiếu
+
+**Vấn đề**: Không tìm thấy checkpoint mong đợi
+
+**Giải pháp**:
+- Kiểm tra xem checkpoints có bị xóa không
+- Xác nhận `autoCheckpoint` đã được bật trong cài đặt
+- Kiểm tra dung lượng ổ đĩa
+
+### Rewind thất bại
+
+**Vấn đề**: Không thể rewind về checkpoint
+
+**Giải pháp**:
+- Đảm bảo không có thay đổi chưa commit gây xung đột
+- Kiểm tra xem checkpoint có bị hỏng không
+- Thử rewind về checkpoint khác
+
+## Tích hợp với Git
+
+Checkpoints bổ trợ cho git (không thay thế):
+
+| Tính năng | Git | Checkpoints |
+|-----------|-----|-------------|
+| Phạm vi | Hệ thống file | Hội thoại + file |
+| Tính bền vững | Vĩnh viễn | Theo phiên |
+| Độ chi tiết | Commits | Bất kỳ thời điểm nào |
+| Tốc độ | Chậm hơn | Tức thì |
+| Chia sẻ | Có | Hạn chế |
+
+Dùng kết hợp cả hai:
+1. Dùng checkpoint để thử nghiệm nhanh
+2. Dùng git commit cho các thay đổi hoàn chỉnh
+3. Tạo checkpoint trước khi thực hiện git operations
+4. Commit các trạng thái checkpoint thành công vào git
+
+## Hướng dẫn bắt đầu nhanh
+
+### Quy trình cơ bản
+
+1. **Làm việc bình thường** — Claude Code tự động tạo checkpoint
+2. **Muốn quay lại?** — Nhấn `Esc` hai lần hoặc dùng `/rewind`
+3. **Chọn checkpoint** — Chọn từ danh sách để rewind
+4. **Chọn nội dung cần khôi phục** — Chọn restore code and conversation, restore conversation, restore code, summarize from here, hoặc hủy
+5. **Tiếp tục làm việc** — Bạn đã quay về thời điểm đó
+
+### Phím tắt
+
+- **`Esc` + `Esc`** — Mở trình duyệt checkpoint
+- **`/rewind`** — Cách khác để truy cập checkpoint
+- **`/checkpoint`** — Bí danh của `/rewind`
+
+## Các khái niệm liên quan
+
+- **[Advanced Features](../09-advanced-features/)** — Chế độ lập kế hoạch và các tính năng nâng cao khác
+- **[Memory Management](../02-memory/)** — Quản lý lịch sử hội thoại và ngữ cảnh
+- **[Slash Commands](../01-slash-commands/)** — Các lệnh tắt do người dùng kích hoạt
+- **[Hooks](../06-hooks/)** — Tự động hóa theo sự kiện
+- **[Plugins](../07-plugins/)** — Gói mở rộng tích hợp sẵn
+
+## Tài nguyên bổ sung
+
+- [Tài liệu chính thức về Checkpointing](https://code.claude.com/docs/en/checkpointing)
+- [Hướng dẫn Advanced Features](../09-advanced-features/) — Extended thinking và các tính năng khác
+
+## Tóm tắt
+
+Checkpoints là tính năng tự động của Claude Code giúp bạn thử nghiệm thoải mái mà không sợ mất công. Mỗi lần bạn gửi tin nhắn, một checkpoint mới được tạo tự động — bạn có thể quay về bất kỳ thời điểm nào trong phiên làm việc.
+
+Lợi ích chính:
+- Thử nghiệm nhiều hướng tiếp cận mà không lo rủi ro
+- Phục hồi nhanh sau khi mắc lỗi
+- So sánh các giải pháp cạnh nhau
+- Tích hợp an toàn với hệ thống version control
+
+Nhớ rằng: checkpoint không thay thế git. Dùng checkpoint để thử nghiệm nhanh, dùng git cho các thay đổi code hoàn chỉnh.

--- a/08-checkpoints/checkpoint-examples.vi.md
+++ b/08-checkpoints/checkpoint-examples.vi.md
@@ -1,0 +1,339 @@
+# Ví dụ về Checkpoints
+
+Các ví dụ thực tế về cách dùng checkpoints hiệu quả trong Claude Code.
+
+Lưu ý: Checkpoints được tạo tự động với mỗi lần bạn gửi tin nhắn. Bạn không cần lưu thủ công. Để rewind, nhấn `Esc` hai lần (`Esc+Esc`) hoặc dùng `/rewind` để mở trình duyệt checkpoint.
+
+## Ví dụ 1: Di chuyển cơ sở dữ liệu
+
+### Tình huống
+Bạn cần chuyển từ MySQL sang PostgreSQL và muốn thử cả hai hướng: migrate trực tiếp và migrate dần dần theo kiểu dual-write.
+
+### Quy trình
+
+```
+User: Let's implement a direct migration from MySQL to PostgreSQL
+      [Checkpoint A được tạo tự động]
+
+Claude: I'll implement the direct migration...
+[Thay đổi database driver, cập nhật queries, chỉnh schema]
+
+User: Run the tests
+      [Checkpoint B được tạo tự động]
+
+Claude: Running tests...
+❌ 15 tests failing - connection pool issues
+
+User: This approach has issues. Let's try the dual-write pattern instead.
+[Người dùng nhấn Esc+Esc, chọn Checkpoint A, chọn "Restore code and conversation"]
+
+User: Now implement a dual-write pattern where we write to both databases
+
+Claude: I'll implement dual-write migration...
+[Triển khai dual-write layer, chiến lược migrate dần dần]
+
+User: Run the tests
+
+Claude: Running tests...
+✅ All tests passing
+
+User: The dual-write approach is clearly safer. Let's commit this.
+```
+
+## Ví dụ 2: Tối ưu hiệu năng
+
+### Tình huống
+Thử nhiều chiến lược tối ưu hiệu năng khác nhau.
+
+### Quy trình
+
+```
+User: Let's optimize the API response time. Current: 450ms
+      [Checkpoint "Baseline" được tạo tự động]
+
+Claude: I'll add database query caching...
+[Triển khai Redis caching]
+
+User: Run performance tests
+
+Claude: Results: 280ms average response time (38% improvement)
+
+User: Let me try a different approach.
+[Người dùng nhấn Esc+Esc, chọn checkpoint "Baseline", chọn "Restore code and conversation"]
+
+User: Try database query optimization instead
+
+Claude: I'll optimize database queries...
+[Thêm indexes, tối ưu N+1 queries]
+
+User: Run performance tests
+
+Claude: Results: 180ms average response time (60% improvement)
+
+User: Let me also try a third approach.
+[Người dùng nhấn Esc+Esc, chọn checkpoint "Baseline", chọn "Restore code and conversation"]
+
+User: Try response compression and CDN
+
+Claude: I'll add compression and CDN...
+[Triển khai gzip, thiết lập CDN]
+
+User: Run performance tests
+
+Claude: Results: 320ms average response time (29% improvement)
+
+User: Query optimization was the best. Let me go back and combine it with caching.
+[Người dùng nhấn Esc+Esc, chọn checkpoint sau khi tối ưu query, chọn "Restore code and conversation"]
+
+User: Now add Redis caching on top of these optimized queries
+
+Claude: [Thêm Redis caching lên trên các queries đã tối ưu]
+
+User: Run performance tests
+
+Claude: Results: 95ms average response time (79% improvement) 🎉
+
+User: Perfect! This is the winner. Let's commit this.
+```
+
+## Ví dụ 3: Lặp lại thiết kế UI/UX
+
+### Tình huống
+Thử các layout khác nhau cho một dashboard.
+
+### Quy trình
+
+```
+User: Let's redesign the dashboard with a sidebar layout
+      [Checkpoint "Start" được tạo tự động]
+
+Claude: [Triển khai sidebar layout]
+
+User: Show me a screenshot
+
+Claude: [Hiển thị screenshot]
+
+User: The sidebar feels cramped. Let's try a top navigation instead.
+[Người dùng nhấn Esc+Esc, chọn checkpoint "Start", chọn "Restore code and conversation"]
+
+User: Try a top navigation layout
+
+Claude: [Triển khai top navigation]
+
+User: Show me a screenshot
+
+Claude: [Hiển thị screenshot]
+
+User: Better, but let's try a card-based grid layout
+[Người dùng nhấn Esc+Esc, chọn checkpoint "Start", chọn "Restore code and conversation"]
+
+User: Try a card-based grid layout
+
+Claude: [Triển khai card grid]
+
+User: Show me a screenshot
+
+Claude: [Hiển thị screenshot]
+
+User: This is great! But can we combine the top nav with the card grid?
+[Người dùng nhấn Esc+Esc, chọn checkpoint sau khi có card grid, chọn "Restore code and conversation"]
+
+User: Add top navigation to the card grid layout
+
+Claude: [Thêm top navigation vào card grid]
+
+User: Perfect! This is the final design.
+```
+
+## Ví dụ 4: Phiên debug
+
+### Tình huống
+Truy tìm bug khó với nhiều giả thuyết khác nhau.
+
+### Quy trình
+
+```
+User: There's a memory leak in the application
+      [Checkpoint "Before debugging" được tạo tự động]
+
+Claude: Let me investigate...
+[Phân tích code]
+
+User: I think it's in the event listeners. Let's fix those.
+
+Claude: [Sửa việc dọn dẹp event listener]
+
+User: Run memory profiler
+
+Claude: Still leaking memory - event listeners weren't the issue
+
+User: Let me go back and try a different hypothesis.
+[Người dùng nhấn Esc+Esc, chọn checkpoint "Before debugging", chọn "Restore code and conversation"]
+
+User: Maybe it's the database connections?
+
+Claude: [Sửa connection pooling]
+
+User: Run memory profiler
+
+Claude: Still leaking - not the connections either
+
+User: Let me go back and try another angle.
+[Người dùng nhấn Esc+Esc, chọn checkpoint "Before debugging", chọn "Restore code and conversation"]
+
+User: Let's check for circular references
+
+Claude: [Tìm và sửa circular references trong cache]
+
+User: Run memory profiler
+
+Claude: ✅ Memory leak fixed! The circular references in the caching layer were the culprit.
+
+User: Excellent! Let's commit this fix.
+```
+
+## Ví dụ 5: Phát triển thiết kế API
+
+### Tình huống
+Thiết kế REST API qua nhiều vòng lặp.
+
+### Quy trình
+
+```
+User: Create a REST API for our blog platform
+      [Checkpoint "Before API design" được tạo tự động]
+
+Claude: [Tạo CRUD API cơ bản]
+
+User: This is too simple. Let's add pagination and filtering
+
+Claude: [Thêm pagination và filtering]
+
+User: We need better resource relationships
+
+Claude: [Triển khai HATEOAS links]
+
+User: Actually, let's try GraphQL instead of REST
+[Người dùng nhấn Esc+Esc, chọn checkpoint "Before API design", chọn "Restore code and conversation"]
+
+User: Implement a GraphQL API for our blog platform instead
+
+Claude: [Triển khai GraphQL API]
+
+User: I think REST is better for our use case.
+[Người dùng nhấn Esc+Esc, chọn checkpoint sau khi có HATEOAS, chọn "Restore code and conversation"]
+
+User: Let's finalize the REST approach.
+```
+
+## Ví dụ 6: Quản lý cấu hình
+
+### Tình huống
+Thử các cách tiếp cận cấu hình khác nhau.
+
+### Quy trình
+
+```
+User: Move configuration to environment variables
+      [Checkpoint "Original config" được tạo tự động]
+
+Claude: [Triển khai cấu hình bằng env var]
+
+User: Test in development
+
+Claude: Works locally but deployment issues in production
+
+User: Let me try a different approach.
+[Người dùng nhấn Esc+Esc, chọn checkpoint "Original config", chọn "Restore code and conversation"]
+
+User: Try a config file approach with validation
+
+Claude: [Triển khai YAML config với JSON schema validation]
+
+User: Test in development
+
+Claude: ✅ Works well, good validation errors
+
+User: Can we also support env vars for sensitive values?
+
+Claude: [Thêm env var override cho secrets]
+
+User: Test deployment
+
+Claude: ✅ All environments working correctly
+
+User: Perfect! This is production-ready.
+```
+
+## Ví dụ 7: Chiến lược kiểm thử
+
+### Tình huống
+Triển khai bộ kiểm thử toàn diện.
+
+### Quy trình
+
+```
+User: Add unit tests for the auth module
+      [Checkpoint được tạo tự động]
+
+Claude: [Thêm Jest unit tests]
+
+User: Run tests
+
+Claude: 45 tests passing, 78% coverage
+
+User: Add integration tests too
+
+Claude: [Thêm integration tests]
+
+User: Run tests
+
+Claude: 89 tests passing, 92% coverage, but tests are slow (3 minutes)
+
+User: The tests are too slow. Let's optimize.
+
+Claude: [Tối ưu test setup, thêm parallel execution]
+
+User: Run tests
+
+Claude: 89 tests passing, 92% coverage, 35 seconds ✅
+
+User: Great! Now add E2E tests for critical paths
+
+Claude: [Thêm Playwright E2E tests]
+
+User: Run all tests
+
+Claude: 112 tests passing, 94% coverage, 2 minutes
+
+User: Perfect balance of coverage and speed!
+```
+
+## Ví dụ 8: Dùng tính năng Summarize from Checkpoint
+
+### Tình huống
+Sau một phiên debug dài, bạn muốn rút gọn hội thoại nhưng vẫn giữ lại ngữ cảnh.
+
+### Quy trình
+
+```
+User: [Sau 20+ tin nhắn debug và khám phá]
+
+[Người dùng nhấn Esc+Esc, chọn checkpoint đầu, chọn "Summarize from here"]
+[Tùy chọn cung cấp hướng dẫn: "Focus on what we tried and what worked"]
+
+Claude: [Tạo bản tóm tắt hội thoại từ điểm đó trở đi]
+[Tin nhắn gốc vẫn được lưu trong transcript]
+[Bản tóm tắt thay thế hội thoại hiển thị, giảm lượng context window sử dụng]
+
+User: Now let's continue with the approach that worked.
+```
+
+## Bài học rút ra
+
+1. **Checkpoints là tự động**: Mỗi lần gửi tin nhắn tạo một checkpoint — không cần lưu thủ công
+2. **Dùng Esc+Esc hoặc /rewind**: Đây là hai cách truy cập trình duyệt checkpoint
+3. **Chọn đúng tùy chọn khôi phục**: Restore code, conversation, cả hai, hoặc summarize tùy nhu cầu
+4. **Đừng sợ thử nghiệm**: Checkpoints giúp bạn thử thay đổi táo bạo mà không lo rủi ro
+5. **Kết hợp với git**: Dùng checkpoint để khám phá, dùng git cho công việc hoàn chỉnh
+6. **Tóm tắt phiên dài**: Dùng "Summarize from here" để giữ hội thoại gọn gàng

--- a/09-advanced-features/README.vi.md
+++ b/09-advanced-features/README.vi.md
@@ -1,0 +1,1836 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Tính Năng Nâng Cao
+
+Hướng dẫn toàn diện về các tính năng nâng cao của Claude Code bao gồm chế độ lập kế hoạch (planning mode), suy nghĩ mở rộng (extended thinking), chế độ tự động (auto mode), tác vụ nền (background tasks), chế độ phân quyền (permission modes), chế độ in (print mode - phi tương tác), quản lý phiên làm việc, tính năng tương tác, kênh truyền thông, nhập liệu bằng giọng nói, điều khiển từ xa (remote control), phiên web (web sessions), ứng dụng desktop (desktop app), danh sách tác vụ (task list), gợi ý lệnh (prompt suggestions), git worktrees, sandbox, cài đặt quản lý (managed settings) và cấu hình.
+
+## Mục Lục
+
+1. [Tổng Quan](#tổng-quan)
+2. [Chế Độ Lập Kế Hoạch](#chế-độ-lập-kế-hoạch)
+3. [Suy Nghĩ Mở Rộng](#suy-nghĩ-mở-rộng)
+4. [Chế Độ Tự Động](#chế-độ-tự-động)
+5. [Tác Vụ Nền](#tác-vụ-nền)
+6. [Tác Vụ Theo Lịch](#tác-vụ-theo-lịch)
+7. [Chế Độ Phân Quyền](#chế-độ-phân-quyền)
+8. [Chế Độ Headless](#chế-độ-headless)
+9. [Quản Lý Phiên Làm Việc](#quản-lý-phiên-làm-việc)
+10. [Tính Năng Tương Tác](#tính-năng-tương-tác)
+11. [Nhập Liệu Bằng Giọng Nói](#nhập-liệu-bằng-giọng-nói)
+12. [Kênh Truyền Thông](#kênh-truyền-thông)
+13. [Tích Hợp Chrome](#tích-hợp-chrome)
+14. [Điều Khiển Từ Xa](#điều-khiển-từ-xa)
+15. [Phiên Web](#phiên-web)
+16. [Ứng Dụng Desktop](#ứng-dụng-desktop)
+17. [Danh Sách Tác Vụ](#danh-sách-tác-vụ)
+18. [Gợi Ý Lệnh](#gợi-ý-lệnh)
+19. [Git Worktrees](#git-worktrees)
+20. [Sandboxing](#sandboxing)
+21. [Cài Đặt Quản Lý (Enterprise)](#cài-đặt-quản-lý-enterprise)
+22. [Cấu Hình và Thiết Lập](#cấu-hình-và-thiết-lập)
+23. [Thực Hành Tốt Nhất](#thực-hành-tốt-nhất)
+24. [Tài Nguyên Liên Quan](#tài-nguyên-liên-quan)
+
+---
+
+## Tổng Quan
+
+Các tính năng nâng cao trong Claude Code mở rộng khả năng cốt lõi với cơ chế lập kế hoạch, suy luận, tự động hóa và kiểm soát. Những tính năng này cho phép các quy trình làm việc phức tạp cho các tác vụ phát triển phức tạp, review code, tự động hóa và quản lý đa phiên.
+
+**Các tính năng nâng cao chính bao gồm:**
+- **Planning Mode**: Tạo kế hoạch triển khai chi tiết trước khi lập trình
+- **Extended Thinking**: Suy luận sâu cho các vấn đề phức tạp
+- **Auto Mode**: Bộ phân loại an toàn nền xem xét mỗi hành động trước khi thực thi (Research Preview)
+- **Background Tasks**: Chạy các hoạt động dài mà không chặn cuộc hội thoại
+- **Permission Modes**: Kiểm soát những gì Claude có thể làm (`default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`)
+- **Print Mode**: Chạy Claude Code phi tương tác cho tự động hóa và CI/CD (`claude -p`)
+- **Session Management**: Quản lý nhiều phiên làm việc
+- **Interactive Features**: Phím tắt, nhập đa dòng và lịch sử lệnh
+- **Voice Dictation**: Nhập liệu bằng giọng nói push-to-talk hỗ trợ 20 ngôn ngữ STT
+- **Channels**: Các MCP server đẩy tin nhắn vào phiên đang chạy (Research Preview)
+- **Remote Control**: Điều khiển Claude Code từ Claude.ai hoặc ứng dụng Claude
+- **Web Sessions**: Chạy Claude Code trên trình duyệt tại claude.ai/code
+- **Desktop App**: Ứng dụng độc lập cho review diff trực quan và nhiều phiên song song
+- **Task List**: Theo dõi tác vụ liên tục qua các lần nén context
+- **Prompt Suggestions**: Gợi ý lệnh thông minh dựa trên ngữ cảnh
+- **Git Worktrees**: Các nhánh worktree cách ly cho công việc song song
+- **Sandboxing**: Cách ly filesystem và mạng ở cấp độ OS
+- **Managed Settings**: Triển khai enterprise qua plist, Registry hoặc file quản lý
+- **Configuration**: Tùy chỉnh hành vi với file cấu hình JSON
+
+---
+
+## Chế Độ Lập Kế Hoạch
+
+Chế độ lập kế hoạch cho phép Claude suy nghĩ qua các tác vụ phức tạp trước khi triển khai, tạo ra một kế hoạch chi tiết để bạn có thể xem xét và phê duyệt.
+
+### Planning Mode là gì?
+
+Planning mode là phương pháp hai giai đoạn:
+1. **Giai đoạn Lập Kế Hoạch**: Claude phân tích tác vụ và tạo kế hoạch triển khai chi tiết
+2. **Giai đoạn Triển Khai**: Sau khi phê duyệt, Claude thực thi kế hoạch
+
+### Khi Nào Dùng Planning Mode
+
+✅ Dùng planning mode cho:
+- Tái cấu trúc phức tạp nhiều file
+- Triển khai tính năng mới
+- Thay đổi kiến trúc
+- Migration database
+- Thiết kế lại API lớn
+
+❌ Không dùng planning mode cho:
+- Sửa lỗi đơn giản
+- Thay đổi định dạng
+- Chỉnh sửa một file
+- Câu hỏi nhanh
+
+### Kích Hoạt Planning Mode
+
+**Slash command**:
+```bash
+/plan Implement user authentication system
+```
+
+**CLI flag**:
+```bash
+claude --permission-mode plan
+```
+
+**Đặt làm mặc định**:
+```json
+{
+  "permissions": {
+    "defaultMode": "plan"
+  }
+}
+```
+
+**Phím tắt**:
+- `Shift + Tab` - Chuyển đổi các chế độ phân quyền (bao gồm plan)
+- `Alt + M` - Chuyển đổi chế độ phân quyền (Windows/Linux)
+
+### Lợi Ích Của Planning Mode
+
+- **Phương pháp triển khai có cấu trúc**: Phân tách chi tiết các bước triển khai
+- **Xem xét và phê duyệt**: Phê duyệt hoặc điều chỉnh kế hoạch trước khi thực thi
+- **Xác định rủi ro**: Nhận diện các vấn đề tiềm ẩn trước khi triển khai
+- **Giai đoạn rõ ràng**: Các giai đoạn và mốc triển khai được tổ chức
+
+### Ví Dụ: Triển Khai Tính Năng
+
+```
+User: /plan Add a real-time notification system
+
+Claude: I'll create a plan for implementing real-time notifications.
+
+## Implementation Plan
+
+### Phase 1: Infrastructure Setup
+1. Install WebSocket libraries (socket.io)
+2. Set up WebSocket server
+3. Configure connection management
+
+### Phase 2: Backend Implementation
+4. Create notification service
+5. Implement notification queue
+6. Add database schema for notifications
+7. Create API endpoints
+
+### Phase 3: Frontend Integration
+8. Set up WebSocket client
+9. Create notification UI components
+10. Implement notification state management
+11. Add notification permissions
+
+### Phase 4: Testing & Deployment
+12. Write unit tests
+13. Write integration tests
+14. Update documentation
+15. Deploy to staging
+
+Estimated time: 3-4 hours
+Files to modify: 12
+New files to create: 8
+
+Ready to proceed? (yes/no/modify plan)
+
+User: yes
+
+Claude: [Begins implementation following the plan]
+```
+
+### Sửa Đổi Kế Hoạch
+
+```
+User: Modify the plan - skip the queue for now, we'll add it later
+
+Claude: Updated plan:
+[Shows modified plan with queue removed]
+
+User: Looks good, proceed
+
+Claude: [Implements modified plan]
+```
+
+### Cấu Hình Planning Mode
+
+Planning mode được kích hoạt qua CLI flag hoặc slash command:
+
+```bash
+# Kích hoạt plan mode qua CLI
+claude --permission-mode plan
+
+# Hoặc dùng slash command /plan trong REPL
+/plan Implement user authentication system
+```
+
+**Model alias cho planning**: Dùng `opusplan` làm model alias để sử dụng Opus cho lập kế hoạch và Sonnet cho thực thi:
+
+```bash
+claude --model opusplan "design and implement the new API"
+```
+
+**Chỉnh sửa kế hoạch bên ngoài**: Nhấn `Ctrl+G` để mở kế hoạch hiện tại trong trình soạn thảo ngoài để sửa đổi chi tiết.
+
+---
+
+## Suy Nghĩ Mở Rộng
+
+Extended thinking (suy nghĩ mở rộng) cho phép Claude dành nhiều thời gian hơn để suy luận về các vấn đề phức tạp trước khi đưa ra giải pháp.
+
+### Extended Thinking là gì?
+
+Extended thinking là quá trình suy luận từng bước có chủ ý, trong đó Claude:
+- Phân tích các vấn đề phức tạp
+- Xem xét nhiều cách tiếp cận
+- Đánh giá sự đánh đổi
+- Suy luận qua các trường hợp biên
+
+### Kích Hoạt Extended Thinking
+
+**Phím tắt**:
+- `Option + T` (macOS) / `Alt + T` (Windows/Linux) - Bật/tắt extended thinking
+
+**Kích hoạt tự động**:
+- Bật theo mặc định cho tất cả model (Opus 4.6, Sonnet 4.6, Haiku 4.5)
+- Opus 4.6: Suy luận thích ứng với mức độ effort: `low` (○), `medium` (◐), `high` (●), `max` (chỉ Opus 4.6)
+- Các model khác: Ngân sách cố định tối đa 31.999 token
+
+**Phương thức cấu hình**:
+- Bật/tắt: `Alt+T` / `Option+T`, hoặc qua `/config`
+- Xem suy luận: `Ctrl+O` (chế độ verbose)
+- Đặt effort: lệnh `/effort` hoặc flag `--effort`
+
+**Ngân sách tùy chỉnh**:
+```bash
+export MAX_THINKING_TOKENS=1024
+```
+
+**Mức độ effort** (chỉ Opus 4.6):
+```bash
+export CLAUDE_CODE_EFFORT_LEVEL=high   # low (○), medium (◐), high (●), hoặc max (chỉ Opus 4.6)
+```
+
+**CLI flag**:
+```bash
+claude --effort high "complex architectural review"
+```
+
+**Slash command**:
+```
+/effort high
+```
+
+> **Lưu ý:** Từ khóa "ultrathink" trong prompt kích hoạt chế độ suy luận sâu. Mức độ effort `low`, `medium`, `high` và `max` (chỉ Opus 4.6) kiểm soát mức độ suy luận mà Claude thực hiện.
+
+### Lợi Ích Của Extended Thinking
+
+- **Suy luận sâu**: Dành nhiều thời gian hơn để suy nghĩ về các vấn đề phức tạp
+- **Quyết định kiến trúc tốt hơn**: Đưa ra lựa chọn có thông tin với đánh giá toàn diện
+- **Xem xét các trường hợp biên**: Suy nghĩ qua các vấn đề và kịch bản tiềm ẩn
+- **Phân tích kỹ lưỡng**: Phương pháp có cấu trúc để giải quyết vấn đề phức tạp
+
+### Ví Dụ: Quyết Định Kiến Trúc
+
+```
+User: /think Should we use microservices or a monolith for our e-commerce platform?
+
+Claude: Let me think through this architectural decision carefully...
+
+<extended_thinking>
+## Context Analysis
+- Team size: 5 developers
+- Expected traffic: 10k daily users initially
+- Need to scale to 100k+ users
+- Limited DevOps resources
+- 6-month timeline to MVP
+
+## Approach 1: Microservices
+Pros:
++ Independent scaling
++ Technology flexibility
++ Team independence
++ Fault isolation
+
+Cons:
+- Operational complexity
+- Network overhead
+- Distributed tracing needed
+- Requires DevOps expertise
+- Slower initial development
+
+## Approach 2: Monolith
+Pros:
++ Simpler deployment
++ Faster initial development
++ Easier debugging
++ Lower operational overhead
++ Single codebase
+
+Cons:
+- Scaling challenges later
+- All-or-nothing deployments
+- Technology lock-in
+- Potential for tight coupling
+
+## Decision Factors
+1. Team size (5 devs) → Favors monolith
+2. DevOps resources (limited) → Favors monolith
+3. Timeline (6 months) → Favors monolith
+4. Future scale (100k users) → Achievable with monolith + caching
+5. Complexity budget → Limited
+
+## Recommendation
+Start with a **modular monolith**:
+- Single deployment unit
+- Clear module boundaries
+- Clean interfaces between modules
+- Prepare for future extraction to microservices if needed
+
+This gives you:
+✓ Fast initial development
+✓ Low operational complexity
+✓ Option to extract services later
+✓ Clear architecture
+
+Migration path: When you reach 50k+ users or specific modules need independent scaling, extract those modules into microservices.
+</extended_thinking>
+
+**Recommendation**: Implement a modular monolith with clean module boundaries.
+
+This approach balances your current constraints (team size, timeline, DevOps resources) with future scalability needs. You can migrate specific modules to microservices later when there's a clear business need.
+```
+
+### Cấu Hình Extended Thinking
+
+Extended thinking được kiểm soát qua biến môi trường, phím tắt và CLI flag:
+
+```bash
+# Đặt ngân sách token suy nghĩ
+export MAX_THINKING_TOKENS=16000
+
+# Đặt mức độ effort (chỉ Opus 4.6): low (○), medium (◐), high (●), hoặc max (chỉ Opus 4.6)
+export CLAUDE_CODE_EFFORT_LEVEL=high
+```
+
+Bật/tắt trong phiên làm việc với `Alt+T` / `Option+T`, đặt effort với `/effort`, hoặc cấu hình qua `/config`.
+
+---
+
+## Chế Độ Tự Động
+
+Auto Mode là chế độ phân quyền Research Preview (tháng 3 năm 2026) sử dụng bộ phân loại an toàn nền để xem xét mỗi hành động trước khi thực thi. Nó cho phép Claude làm việc tự chủ trong khi chặn các hoạt động nguy hiểm.
+
+### Yêu Cầu
+
+- **Plan**: Team plan (Enterprise và API đang được triển khai)
+- **Model**: Claude Sonnet 4.6 hoặc Opus 4.6
+- **Classifier**: Chạy trên Claude Sonnet 4.6 (thêm chi phí token)
+
+### Bật Auto Mode
+
+```bash
+# Mở khóa auto mode bằng CLI flag
+claude --enable-auto-mode
+
+# Sau đó chuyển đến nó bằng Shift+Tab trong REPL
+```
+
+Hoặc đặt làm chế độ phân quyền mặc định:
+
+```bash
+claude --permission-mode auto
+```
+
+Cài đặt qua config:
+```json
+{
+  "permissions": {
+    "defaultMode": "auto"
+  }
+}
+```
+
+### Cách Bộ Phân Loại Hoạt Động
+
+Bộ phân loại nền đánh giá mỗi hành động theo thứ tự quyết định sau:
+
+1. **Quy tắc cho phép/từ chối** -- Các quy tắc phân quyền tường minh được kiểm tra trước
+2. **Chỉ đọc/chỉnh sửa tự động phê duyệt** -- Đọc và chỉnh sửa file tự động được phép
+3. **Classifier** -- Bộ phân loại nền xem xét hành động
+4. **Dự phòng** -- Chuyển sang hỏi người dùng sau 3 lần chặn liên tiếp hoặc 20 lần chặn tổng cộng
+
+### Các Hành Động Bị Chặn Mặc Định
+
+Auto mode chặn các hành động sau theo mặc định:
+
+| Hành Động Bị Chặn | Ví Dụ |
+|-------------------|-------|
+| Cài đặt pipe-to-shell | `curl \| bash` |
+| Gửi dữ liệu nhạy cảm ra ngoài | API key, thông tin xác thực qua mạng |
+| Triển khai production | Lệnh deploy nhắm vào production |
+| Xóa hàng loạt | `rm -rf` trên thư mục lớn |
+| Thay đổi IAM | Sửa đổi quyền và vai trò |
+| Force push lên main | `git push --force origin main` |
+
+### Các Hành Động Được Phép Mặc Định
+
+| Hành Động Được Phép | Ví Dụ |
+|--------------------|-------|
+| Thao tác file cục bộ | Đọc, ghi, chỉnh sửa file dự án |
+| Cài đặt dependency đã khai báo | `npm install`, `pip install` từ manifest |
+| HTTP chỉ đọc | `curl` để lấy tài liệu |
+| Push lên nhánh hiện tại | `git push origin feature-branch` |
+
+### Cấu Hình Auto Mode
+
+**In các quy tắc mặc định dạng JSON**:
+```bash
+claude auto-mode defaults
+```
+
+**Cấu hình cơ sở hạ tầng tin cậy** qua cài đặt quản lý `autoMode.environment` cho triển khai enterprise. Điều này cho phép quản trị viên định nghĩa các môi trường CI/CD tin cậy, mục tiêu triển khai và các mẫu cơ sở hạ tầng.
+
+### Hành Vi Dự Phòng
+
+Khi bộ phân loại không chắc chắn, auto mode chuyển sang hỏi người dùng:
+- Sau **3 lần chặn liên tiếp** của bộ phân loại
+- Sau **20 lần chặn tổng cộng** trong một phiên
+
+Điều này đảm bảo người dùng luôn giữ quyền kiểm soát khi bộ phân loại không thể tự tin phê duyệt một hành động.
+
+---
+
+## Tác Vụ Nền
+
+Tác vụ nền cho phép các hoạt động chạy dài thực thi mà không chặn cuộc hội thoại của bạn.
+
+### Tác Vụ Nền là gì?
+
+Tác vụ nền chạy không đồng bộ trong khi bạn tiếp tục làm việc:
+- Bộ test lớn
+- Quá trình build
+- Migration database
+- Script triển khai
+- Công cụ phân tích
+
+**Cách dùng cơ bản:**
+```bash
+User: Run tests in background
+
+Claude: Started task bg-1234
+
+/task list           # Hiển thị tất cả tác vụ
+/task status bg-1234 # Kiểm tra tiến độ
+/task show bg-1234   # Xem output
+/task cancel bg-1234 # Hủy tác vụ
+```
+
+### Khởi Động Tác Vụ Nền
+
+```
+User: Run the full test suite in the background
+
+Claude: Starting tests in background (task-id: bg-1234)
+You can continue working while tests run.
+
+[You can continue the conversation]
+
+User: Meanwhile, let's refactor the auth module
+
+Claude: [Works on auth module while tests run in background]
+
+[Later, when tests complete]
+
+Claude: 📢 Background task bg-1234 completed:
+✅ 245 tests passed
+❌ 3 tests failed
+View results: /task show bg-1234
+```
+
+### Quản Lý Tác Vụ Nền
+
+**Liệt kê tác vụ đang hoạt động**:
+```
+User: /task list
+
+Active background tasks:
+1. [bg-1234] Running tests (50% complete, 2min remaining)
+2. [bg-1235] Building Docker image (25% complete, 8min remaining)
+3. [bg-1236] Deploying to staging (90% complete, 30sec remaining)
+```
+
+**Kiểm tra trạng thái tác vụ**:
+```
+User: /task status bg-1234
+
+Task bg-1234: Running tests
+Status: In progress
+Progress: 120/245 tests (49%)
+Started: 2025-11-08 10:30:15
+Estimated completion: 2025-11-08 10:34:22
+```
+
+**Xem output tác vụ**:
+```
+User: /task show bg-1234
+
+[Shows live output from the test run]
+```
+
+**Hủy tác vụ**:
+```
+User: /task cancel bg-1234
+
+Cancelled background task bg-1234
+```
+
+### Ví Dụ: Phát Triển Song Song
+
+```
+User: Run the build in the background
+
+Claude: Starting build... (task-id: bg-5001)
+
+User: Also run the linter in background
+
+Claude: Starting linter... (task-id: bg-5002)
+
+User: While those run, let's implement the new API endpoint
+
+Claude: [Implements API endpoint while build and linter run]
+
+[10 minutes later]
+
+Claude: 📢 Build completed successfully (bg-5001)
+📢 Linter found 12 issues (bg-5002)
+
+User: Show me the linter issues
+
+Claude: [Shows linter output from bg-5002]
+```
+
+### Cấu Hình
+
+```json
+{
+  "backgroundTasks": {
+    "enabled": true,
+    "maxConcurrentTasks": 5,
+    "notifyOnCompletion": true,
+    "autoCleanup": true,
+    "logOutput": true
+  }
+}
+```
+
+---
+
+## Tác Vụ Theo Lịch
+
+Scheduled Tasks (tác vụ theo lịch) cho phép bạn chạy các prompt tự động theo lịch lặp lại hoặc như lời nhắc một lần. Tác vụ có phạm vi phiên — chúng chạy trong khi Claude Code đang hoạt động và bị xóa khi phiên kết thúc. Có sẵn từ v2.1.72+.
+
+### Lệnh `/loop`
+
+```bash
+# Khoảng thời gian tường minh
+/loop 5m check if the deployment finished
+
+# Ngôn ngữ tự nhiên
+/loop check build status every 30 minutes
+```
+
+Các biểu thức cron 5 trường tiêu chuẩn cũng được hỗ trợ để lập lịch chính xác.
+
+### Lời Nhắc Một Lần
+
+Đặt lời nhắc chỉ bắt đầu một lần tại thời điểm cụ thể:
+
+```
+remind me at 3pm to push the release branch
+in 45 minutes, run the integration tests
+```
+
+### Quản Lý Tác Vụ Theo Lịch
+
+| Tool | Mô Tả |
+|------|--------|
+| `CronCreate` | Tạo tác vụ theo lịch mới |
+| `CronList` | Liệt kê tất cả tác vụ theo lịch đang hoạt động |
+| `CronDelete` | Xóa tác vụ theo lịch |
+
+**Giới hạn và hành vi**:
+- Tối đa **50 tác vụ theo lịch** mỗi phiên
+- Phạm vi phiên — bị xóa khi phiên kết thúc
+- Tác vụ lặp lại tự động hết hạn sau **3 ngày**
+- Tác vụ chỉ kích hoạt trong khi Claude Code đang chạy — không bắt kịp các lần bị bỏ lỡ
+
+### Chi Tiết Hành Vi
+
+| Khía Cạnh | Chi Tiết |
+|-----------|---------|
+| **Jitter lặp lại** | Tối đa 10% của khoảng thời gian (tối đa 15 phút) |
+| **Jitter một lần** | Tối đa 90 giây trên ranh giới :00/:30 |
+| **Lần bị bỏ lỡ** | Không bắt kịp — bị bỏ qua nếu Claude Code không chạy |
+| **Persistence** | Không được lưu qua các lần khởi động lại |
+
+### Tác Vụ Theo Lịch Trên Cloud
+
+Dùng `/schedule` để tạo tác vụ theo lịch Cloud chạy trên cơ sở hạ tầng Anthropic:
+
+```
+/schedule daily at 9am run the test suite and report failures
+```
+
+Tác vụ theo lịch Cloud được lưu qua các lần khởi động lại và không yêu cầu Claude Code đang chạy cục bộ.
+
+### Tắt Tác Vụ Theo Lịch
+
+```bash
+export CLAUDE_CODE_DISABLE_CRON=1
+```
+
+### Ví Dụ: Theo Dõi Triển Khai
+
+```
+/loop 5m check the deployment status of the staging environment.
+        If the deploy succeeded, notify me and stop looping.
+        If it failed, show the error logs.
+```
+
+> **Mẹo**: Tác vụ theo lịch có phạm vi phiên. Để tự động hóa liên tục tồn tại qua các lần khởi động lại, hãy dùng CI/CD pipelines, GitHub Actions hoặc tác vụ theo lịch của Desktop App.
+
+---
+
+## Chế Độ Phân Quyền
+
+Chế độ phân quyền kiểm soát những hành động nào Claude có thể thực hiện mà không cần phê duyệt rõ ràng.
+
+### Các Chế Độ Phân Quyền Có Sẵn
+
+| Chế Độ | Hành Vi |
+|--------|---------|
+| `default` | Chỉ đọc file; nhắc cho tất cả các hành động khác |
+| `acceptEdits` | Đọc và chỉnh sửa file; nhắc cho các lệnh |
+| `plan` | Chỉ đọc file (chế độ nghiên cứu, không chỉnh sửa) |
+| `auto` | Tất cả hành động với kiểm tra bộ phân loại an toàn nền (Research Preview) |
+| `bypassPermissions` | Tất cả hành động, không kiểm tra quyền (nguy hiểm) |
+| `dontAsk` | Chỉ các tool được phê duyệt trước thực thi; tất cả các tool khác bị từ chối |
+
+Chuyển đổi giữa các chế độ bằng `Shift+Tab` trong CLI. Đặt mặc định bằng flag `--permission-mode` hoặc cài đặt `permissions.defaultMode`.
+
+### Phương Thức Kích Hoạt
+
+**Phím tắt**:
+```bash
+Shift + Tab  # Chuyển đổi qua cả 6 chế độ
+```
+
+**Slash command**:
+```bash
+/plan                  # Vào chế độ plan
+```
+
+**CLI flag**:
+```bash
+claude --permission-mode plan
+claude --permission-mode auto
+```
+
+**Setting**:
+```json
+{
+  "permissions": {
+    "defaultMode": "auto"
+  }
+}
+```
+
+### Ví Dụ Về Chế Độ Phân Quyền
+
+#### Chế Độ Default
+Claude yêu cầu xác nhận cho các hành động quan trọng:
+
+```
+User: Fix the bug in auth.ts
+
+Claude: I need to modify src/auth.ts to fix the bug.
+The change will update the password validation logic.
+
+Approve this change? (yes/no/show)
+```
+
+#### Chế Độ Plan
+Xem xét kế hoạch triển khai trước khi thực thi:
+
+```
+User: /plan Implement user authentication system
+
+Claude: I'll create a plan for implementing authentication.
+
+## Implementation Plan
+[Detailed plan with phases and steps]
+
+Ready to proceed? (yes/no/modify)
+```
+
+#### Chế Độ Accept Edits
+Tự động chấp nhận các sửa đổi file:
+
+```
+User: acceptEdits
+User: Fix the bug in auth.ts
+
+Claude: [Makes changes without asking]
+```
+
+### Các Trường Hợp Sử Dụng
+
+**Review Code**:
+```
+User: claude --permission-mode plan
+User: Review this PR and suggest improvements
+
+Claude: [Reads code, provides feedback, but cannot modify]
+```
+
+**Lập Trình Cùng Nhau**:
+```
+User: claude --permission-mode default
+User: Let's implement the feature together
+
+Claude: [Asks for approval before each change]
+```
+
+**Tác Vụ Tự Động**:
+```
+User: claude --permission-mode acceptEdits
+User: Fix all linting issues in the codebase
+
+Claude: [Auto-accepts file edits without asking]
+```
+
+---
+
+## Chế Độ Headless
+
+Print mode (`claude -p`) cho phép Claude Code chạy mà không có đầu vào tương tác, hoàn hảo cho tự động hóa và CI/CD. Đây là chế độ phi tương tác, thay thế flag `--headless` cũ.
+
+### Print Mode là gì?
+
+Print mode cho phép:
+- Thực thi script tự động
+- Tích hợp CI/CD
+- Xử lý hàng loạt
+- Tác vụ theo lịch
+
+### Chạy Trong Print Mode (Phi Tương Tác)
+
+```bash
+# Chạy tác vụ cụ thể
+claude -p "Run all tests"
+
+# Xử lý nội dung được pipe
+cat error.log | claude -p "Analyze these errors"
+
+# Tích hợp CI/CD (GitHub Actions)
+- name: AI Code Review
+  run: claude -p "Review PR"
+```
+
+### Các Ví Dụ Dùng Print Mode Bổ Sung
+
+```bash
+# Chạy tác vụ cụ thể với lưu output
+claude -p "Run all tests and generate coverage report"
+
+# Với output có cấu trúc
+claude -p --output-format json "Analyze code quality"
+
+# Với đầu vào từ stdin
+echo "Analyze code quality" | claude -p "explain this"
+```
+
+### Ví Dụ: Tích Hợp CI/CD
+
+**GitHub Actions**:
+```yaml
+# .github/workflows/code-review.yml
+name: AI Code Review
+
+on: [pull_request]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Claude Code Review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          claude -p --output-format json \
+            --max-turns 3 \
+            "Review this PR for:
+            - Code quality issues
+            - Security vulnerabilities
+            - Performance concerns
+            - Test coverage
+            Output results as JSON" > review.json
+
+      - name: Post Review Comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const review = JSON.parse(fs.readFileSync('review.json', 'utf8'));
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: JSON.stringify(review, null, 2)
+            });
+```
+
+### Cấu Hình Print Mode
+
+Print mode (`claude -p`) hỗ trợ nhiều flag cho tự động hóa:
+
+```bash
+# Giới hạn số lượt tự chủ
+claude -p --max-turns 5 "refactor this module"
+
+# Output JSON có cấu trúc
+claude -p --output-format json "analyze this codebase"
+
+# Với xác thực schema
+claude -p --json-schema '{"type":"object","properties":{"issues":{"type":"array"}}}' \
+  "find bugs in this code"
+
+# Tắt lưu phiên
+claude -p --no-session-persistence "one-off analysis"
+```
+
+---
+
+## Quản Lý Phiên Làm Việc
+
+Quản lý nhiều phiên Claude Code hiệu quả.
+
+### Lệnh Quản Lý Phiên
+
+| Lệnh | Mô Tả |
+|------|--------|
+| `/resume` | Tiếp tục cuộc hội thoại theo ID hoặc tên |
+| `/rename` | Đặt tên cho phiên hiện tại |
+| `/fork` | Fork phiên hiện tại thành nhánh mới |
+| `claude -c` | Tiếp tục cuộc hội thoại gần nhất |
+| `claude -r "session"` | Tiếp tục phiên theo tên hoặc ID |
+
+### Tiếp Tục Phiên
+
+**Tiếp tục cuộc hội thoại cuối**:
+```bash
+claude -c
+```
+
+**Tiếp tục phiên có tên**:
+```bash
+claude -r "auth-refactor" "finish this PR"
+```
+
+**Đặt tên phiên hiện tại** (trong REPL):
+```
+/rename auth-refactor
+```
+
+### Fork Phiên
+
+Fork một phiên để thử cách tiếp cận khác mà không mất phiên ban đầu:
+
+```
+/fork
+```
+
+Hoặc từ CLI:
+```bash
+claude --resume auth-refactor --fork-session "try OAuth instead"
+```
+
+### Lưu Phiên
+
+Các phiên được tự động lưu và có thể tiếp tục:
+
+```bash
+# Tiếp tục cuộc hội thoại cuối
+claude -c
+
+# Tiếp tục phiên cụ thể theo tên hoặc ID
+claude -r "auth-refactor"
+
+# Tiếp tục và fork để thử nghiệm
+claude --resume auth-refactor --fork-session "alternative approach"
+```
+
+---
+
+## Tính Năng Tương Tác
+
+### Phím Tắt
+
+Claude Code hỗ trợ phím tắt để tăng hiệu quả. Dưới đây là tài liệu tham khảo đầy đủ từ tài liệu chính thức:
+
+| Phím Tắt | Mô Tả |
+|----------|--------|
+| `Ctrl+C` | Hủy đầu vào/quá trình tạo hiện tại |
+| `Ctrl+D` | Thoát Claude Code |
+| `Ctrl+G` | Chỉnh sửa kế hoạch trong trình soạn thảo ngoài |
+| `Ctrl+L` | Xóa màn hình terminal |
+| `Ctrl+O` | Bật/tắt output verbose (xem suy luận) |
+| `Ctrl+R` | Tìm kiếm ngược lịch sử |
+| `Ctrl+T` | Bật/tắt chế độ xem danh sách tác vụ |
+| `Ctrl+B` | Các tác vụ đang chạy nền |
+| `Esc+Esc` | Tua lại code/cuộc hội thoại |
+| `Shift+Tab` / `Alt+M` | Chuyển đổi chế độ phân quyền |
+| `Option+P` / `Alt+P` | Chuyển đổi model |
+| `Option+T` / `Alt+T` | Bật/tắt extended thinking |
+
+**Chỉnh Sửa Dòng (phím tắt readline tiêu chuẩn):**
+
+| Phím Tắt | Hành Động |
+|----------|-----------|
+| `Ctrl + A` | Di chuyển đến đầu dòng |
+| `Ctrl + E` | Di chuyển đến cuối dòng |
+| `Ctrl + K` | Cắt đến cuối dòng |
+| `Ctrl + U` | Cắt đến đầu dòng |
+| `Ctrl + W` | Xóa từ về phía sau |
+| `Ctrl + Y` | Dán (yank) |
+| `Tab` | Tự động hoàn thành |
+| `↑ / ↓` | Lịch sử lệnh |
+
+### Tùy Chỉnh Phím Tắt
+
+Tạo phím tắt bàn phím tùy chỉnh bằng cách chạy `/keybindings`, mở `~/.claude/keybindings.json` để chỉnh sửa (v2.1.18+).
+
+**Định dạng cấu hình**:
+
+```json
+{
+  "$schema": "https://www.schemastore.org/claude-code-keybindings.json",
+  "bindings": [
+    {
+      "context": "Chat",
+      "bindings": {
+        "ctrl+e": "chat:externalEditor",
+        "ctrl+u": null,
+        "ctrl+k ctrl+s": "chat:stash"
+      }
+    },
+    {
+      "context": "Confirmation",
+      "bindings": {
+        "ctrl+a": "confirmation:yes"
+      }
+    }
+  ]
+}
+```
+
+Đặt binding thành `null` để hủy liên kết phím tắt mặc định.
+
+### Các Context Có Sẵn
+
+Các keybinding được giới hạn trong các context UI cụ thể:
+
+| Context | Các Hành Động Phím |
+|---------|-------------------|
+| **Chat** | `submit`, `cancel`, `cycleMode`, `modelPicker`, `thinkingToggle`, `undo`, `externalEditor`, `stash`, `imagePaste` |
+| **Confirmation** | `yes`, `no`, `previous`, `next`, `nextField`, `cycleMode`, `toggleExplanation` |
+| **Global** | `interrupt`, `exit`, `toggleTodos`, `toggleTranscript` |
+| **Autocomplete** | `accept`, `dismiss`, `next`, `previous` |
+| **HistorySearch** | `search`, `previous`, `next` |
+| **Settings** | Điều hướng cài đặt theo context |
+| **Tabs** | Chuyển đổi và quản lý tab |
+| **Help** | Điều hướng panel trợ giúp |
+
+Có tổng cộng 18 context bao gồm `Transcript`, `Task`, `ThemePicker`, `Attachments`, `Footer`, `MessageSelector`, `DiffDialog`, `ModelPicker` và `Select`.
+
+### Hỗ Trợ Chord
+
+Keybindings hỗ trợ chuỗi chord (kết hợp nhiều phím):
+
+```
+"ctrl+k ctrl+s"   → Chuỗi hai phím: nhấn ctrl+k, rồi ctrl+s
+"ctrl+shift+p"    → Phím modifier đồng thời
+```
+
+**Cú pháp phím**:
+- **Modifiers**: `ctrl`, `alt` (hoặc `opt`), `shift`, `meta` (hoặc `cmd`)
+- **Chữ hoa ngụ ý Shift**: `K` tương đương với `shift+k`
+- **Phím đặc biệt**: `escape`, `enter`, `return`, `tab`, `space`, `backspace`, `delete`, phím mũi tên
+
+### Phím Dành Riêng và Xung Đột
+
+| Phím | Trạng Thái | Ghi Chú |
+|------|-----------|---------|
+| `Ctrl+C` | Dành riêng | Không thể rebind (ngắt) |
+| `Ctrl+D` | Dành riêng | Không thể rebind (thoát) |
+| `Ctrl+B` | Xung đột terminal | Phím tiền tố tmux |
+| `Ctrl+A` | Xung đột terminal | Phím tiền tố GNU Screen |
+| `Ctrl+Z` | Xung đột terminal | Tạm dừng tiến trình |
+
+> **Mẹo**: Nếu phím tắt không hoạt động, kiểm tra xung đột với terminal emulator hoặc multiplexer của bạn.
+
+### Tab Completion
+
+Claude Code cung cấp tab completion thông minh:
+
+```
+User: /rew<TAB>
+→ /rewind
+
+User: /plu<TAB>
+→ /plugin
+
+User: /plugin <TAB>
+→ /plugin install
+→ /plugin enable
+→ /plugin disable
+```
+
+### Lịch Sử Lệnh
+
+Truy cập các lệnh trước đó:
+
+```
+User: <↑>  # Lệnh trước
+User: <↓>  # Lệnh tiếp theo
+User: Ctrl+R  # Tìm kiếm lịch sử
+
+(reverse-i-search)`test': run all tests
+```
+
+### Nhập Đa Dòng
+
+Cho các câu hỏi phức tạp, dùng chế độ đa dòng:
+
+```bash
+User: \
+> Long complex prompt
+> spanning multiple lines
+> \end
+```
+
+**Ví dụ:**
+
+```
+User: \
+> Implement a user authentication system
+> with the following requirements:
+> - JWT tokens
+> - Email verification
+> - Password reset
+> - 2FA support
+> \end
+
+Claude: [Processes the multi-line request]
+```
+
+### Chỉnh Sửa Inline
+
+Chỉnh sửa lệnh trước khi gửi:
+
+```
+User: Deploy to prodcution<Backspace><Backspace>uction
+
+[Edit in-place before sending]
+```
+
+### Chế Độ Vim
+
+Bật các keybinding Vi/Vim để chỉnh sửa văn bản:
+
+**Kích hoạt**:
+- Dùng lệnh `/vim` hoặc `/config` để bật
+- Chuyển đổi chế độ bằng `Esc` cho NORMAL, `i/a/o` cho INSERT
+
+**Phím điều hướng**:
+- `h` / `l` - Di chuyển trái/phải
+- `j` / `k` - Di chuyển xuống/lên
+- `w` / `b` / `e` - Di chuyển theo từ
+- `0` / `$` - Di chuyển đến đầu/cuối dòng
+- `gg` / `G` - Nhảy đến đầu/cuối văn bản
+
+**Text objects**:
+- `iw` / `aw` - Bên trong/xung quanh từ
+- `i"` / `a"` - Bên trong/xung quanh chuỗi có dấu nháy
+- `i(` / `a(` - Bên trong/xung quanh dấu ngoặc đơn
+
+### Chế Độ Bash
+
+Thực thi lệnh shell trực tiếp với tiền tố `!`:
+
+```bash
+! npm test
+! git status
+! cat src/index.js
+```
+
+Dùng cái này để thực thi lệnh nhanh mà không cần chuyển ngữ cảnh.
+
+---
+
+## Nhập Liệu Bằng Giọng Nói
+
+Voice Dictation (nhập liệu bằng giọng nói) cung cấp đầu vào giọng nói push-to-talk cho Claude Code, cho phép bạn nói prompt thay vì gõ.
+
+### Kích Hoạt Voice Dictation
+
+```
+/voice
+```
+
+### Tính Năng
+
+| Tính Năng | Mô Tả |
+|----------|--------|
+| **Push-to-talk** | Giữ phím để ghi âm, thả ra để gửi |
+| **20 ngôn ngữ** | Speech-to-text hỗ trợ 20 ngôn ngữ |
+| **Phím tắt tùy chỉnh** | Cấu hình phím push-to-talk qua `/keybindings` |
+| **Yêu cầu tài khoản** | Yêu cầu tài khoản Claude.ai để xử lý STT |
+
+### Cấu Hình
+
+Tùy chỉnh keybinding push-to-talk trong file keybindings của bạn (`/keybindings`). Voice dictation dùng tài khoản Claude.ai của bạn để xử lý speech-to-text.
+
+---
+
+## Kênh Truyền Thông
+
+Channels (Research Preview) cho phép các MCP server đẩy tin nhắn vào các phiên Claude Code đang chạy, cho phép tích hợp thời gian thực với các dịch vụ bên ngoài.
+
+### Đăng Ký Kênh
+
+```bash
+# Đăng ký channel plugins khi khởi động
+claude --channels discord,telegram
+```
+
+### Các Tích Hợp Được Hỗ Trợ
+
+| Tích Hợp | Mô Tả |
+|---------|--------|
+| **Discord** | Nhận và phản hồi tin nhắn Discord trong phiên của bạn |
+| **Telegram** | Nhận và phản hồi tin nhắn Telegram trong phiên của bạn |
+
+### Cấu Hình
+
+**Cài đặt quản lý** cho triển khai enterprise:
+
+```json
+{
+  "allowedChannelPlugins": ["discord", "telegram"]
+}
+```
+
+Cài đặt `allowedChannelPlugins` kiểm soát các channel plugin nào được phép trong toàn tổ chức.
+
+### Cách Hoạt Động
+
+1. Các MCP server hoạt động như channel plugin kết nối với các dịch vụ bên ngoài
+2. Tin nhắn đến được đẩy vào phiên Claude Code đang hoạt động
+3. Claude có thể đọc và phản hồi tin nhắn trong ngữ cảnh phiên
+4. Channel plugin phải được phê duyệt qua cài đặt quản lý `allowedChannelPlugins`
+
+---
+
+## Tích Hợp Chrome
+
+Chrome Integration (tích hợp Chrome) kết nối Claude Code với trình duyệt Chrome hoặc Microsoft Edge của bạn để tự động hóa và debug web trực tiếp. Đây là tính năng beta có sẵn từ v2.0.73+ (hỗ trợ Edge được thêm trong v1.0.36+).
+
+### Bật Tích Hợp Chrome
+
+**Khi khởi động**:
+
+```bash
+claude --chrome      # Bật kết nối Chrome
+claude --no-chrome   # Tắt kết nối Chrome
+```
+
+**Trong phiên làm việc**:
+
+```
+/chrome
+```
+
+Chọn "Enabled by default" để kích hoạt Chrome Integration cho tất cả phiên trong tương lai. Claude Code chia sẻ trạng thái đăng nhập trình duyệt của bạn, vì vậy nó có thể tương tác với các ứng dụng web đã xác thực.
+
+### Khả Năng
+
+| Khả Năng | Mô Tả |
+|---------|--------|
+| **Debug trực tiếp** | Đọc console log, kiểm tra phần tử DOM, debug JavaScript theo thời gian thực |
+| **Xác minh thiết kế** | So sánh các trang đã render với mockup thiết kế |
+| **Xác thực form** | Test gửi form, xác thực đầu vào và xử lý lỗi |
+| **Test ứng dụng web** | Tương tác với các ứng dụng đã xác thực (Gmail, Google Docs, Notion, v.v.) |
+| **Trích xuất dữ liệu** | Scrape và xử lý nội dung từ trang web |
+| **Ghi phiên** | Ghi lại các tương tác trình duyệt dưới dạng file GIF |
+
+### Quyền Theo Trang
+
+Chrome extension quản lý quyền truy cập theo từng trang. Cấp hoặc thu hồi quyền truy cập cho các trang cụ thể bất kỳ lúc nào qua popup của extension. Claude Code chỉ tương tác với các trang bạn đã cấp phép rõ ràng.
+
+### Cách Hoạt Động
+
+Claude Code điều khiển trình duyệt trong một cửa sổ hiển thị — bạn có thể xem các hành động xảy ra theo thời gian thực. Khi trình duyệt gặp trang đăng nhập hoặc CAPTCHA, Claude tạm dừng và chờ bạn xử lý thủ công trước khi tiếp tục.
+
+### Giới Hạn Đã Biết
+
+- **Hỗ trợ trình duyệt**: Chỉ Chrome và Edge — Brave, Arc và các trình duyệt Chromium khác không được hỗ trợ
+- **WSL**: Không có sẵn trong Windows Subsystem for Linux
+- **Nhà cung cấp bên thứ ba**: Không được hỗ trợ với Bedrock, Vertex hoặc Foundry API provider
+- **Service worker idle**: Service worker của Chrome extension có thể đi vào trạng thái idle trong các phiên dài
+
+> **Mẹo**: Chrome Integration là tính năng beta. Hỗ trợ trình duyệt có thể mở rộng trong các phiên bản tương lai.
+
+---
+
+## Điều Khiển Từ Xa
+
+Remote Control (điều khiển từ xa) cho phép bạn tiếp tục phiên Claude Code đang chạy cục bộ từ điện thoại, máy tính bảng hoặc bất kỳ trình duyệt nào. Phiên cục bộ của bạn tiếp tục chạy trên máy của bạn — không có gì được chuyển lên cloud. Có sẵn trên các plan Pro, Max, Team và Enterprise (v2.1.51+).
+
+### Bắt Đầu Remote Control
+
+**Từ CLI**:
+
+```bash
+# Bắt đầu với tên phiên mặc định
+claude remote-control
+
+# Bắt đầu với tên tùy chỉnh
+claude remote-control --name "Auth Refactor"
+```
+
+**Trong phiên làm việc**:
+
+```
+/remote-control
+/remote-control "Auth Refactor"
+```
+
+**Các flag có sẵn**:
+
+| Flag | Mô Tả |
+|------|--------|
+| `--name "title"` | Tiêu đề phiên tùy chỉnh để dễ nhận dạng |
+| `--verbose` | Hiển thị log kết nối chi tiết |
+| `--sandbox` | Bật cách ly filesystem và mạng |
+| `--no-sandbox` | Tắt sandboxing (mặc định) |
+
+### Kết Nối Đến Phiên
+
+Ba cách kết nối từ thiết bị khác:
+
+1. **Session URL** — Được in ra terminal khi phiên bắt đầu; mở trong bất kỳ trình duyệt nào
+2. **QR code** — Nhấn `spacebar` sau khi khởi động để hiển thị mã QR có thể quét
+3. **Tìm theo tên** — Duyệt các phiên của bạn tại claude.ai/code hoặc trong ứng dụng Claude mobile (iOS/Android)
+
+### Bảo Mật
+
+- **Không mở cổng inbound** trên máy của bạn
+- **Chỉ HTTPS outbound** qua TLS
+- **Thông tin xác thực có phạm vi** — nhiều token tồn tại ngắn hạn, phạm vi hẹp
+- **Cách ly phiên** — mỗi phiên từ xa là độc lập
+
+### Remote Control vs Claude Code trên Web
+
+| Khía Cạnh | Remote Control | Claude Code trên Web |
+|-----------|---------------|---------------------|
+| **Thực thi** | Chạy trên máy của bạn | Chạy trên cloud Anthropic |
+| **Tool cục bộ** | Truy cập đầy đủ MCP server cục bộ, file và CLI | Không có dependency cục bộ |
+| **Trường hợp dùng** | Tiếp tục công việc cục bộ từ thiết bị khác | Bắt đầu mới từ bất kỳ trình duyệt nào |
+
+### Giới Hạn
+
+- Một phiên từ xa cho mỗi instance Claude Code
+- Terminal phải giữ mở trên máy host
+- Phiên timeout sau khoảng 10 phút nếu mạng không thể truy cập
+
+### Các Trường Hợp Sử Dụng
+
+- Điều khiển Claude Code từ thiết bị di động hoặc máy tính bảng khi rời khỏi bàn làm việc
+- Dùng UI claude.ai phong phú hơn trong khi duy trì thực thi tool cục bộ
+- Review code nhanh khi di chuyển với toàn bộ môi trường phát triển cục bộ
+
+---
+
+## Phiên Web
+
+Web Sessions cho phép bạn chạy Claude Code trực tiếp trên trình duyệt tại claude.ai/code, hoặc tạo phiên web từ CLI.
+
+### Tạo Phiên Web
+
+```bash
+# Tạo phiên web mới từ CLI
+claude --remote "implement the new API endpoints"
+```
+
+Lệnh này khởi động phiên Claude Code trên claude.ai mà bạn có thể truy cập từ bất kỳ trình duyệt nào.
+
+### Tiếp Tục Phiên Web Cục Bộ
+
+Nếu bạn đã bắt đầu phiên trên web và muốn tiếp tục cục bộ:
+
+```bash
+# Tiếp tục phiên web trong terminal cục bộ
+claude --teleport
+```
+
+Hoặc trong một REPL tương tác:
+```
+/teleport
+```
+
+### Các Trường Hợp Sử Dụng
+
+- Bắt đầu công việc trên một máy và tiếp tục trên máy khác
+- Chia sẻ URL phiên với các thành viên nhóm
+- Dùng UI web để review diff trực quan, rồi chuyển sang terminal để thực thi
+
+---
+
+## Ứng Dụng Desktop
+
+Claude Code Desktop App cung cấp ứng dụng độc lập với review diff trực quan, phiên song song và connectors tích hợp. Có sẵn cho macOS và Windows (các plan Pro, Max, Team và Enterprise).
+
+### Cài Đặt
+
+Tải từ [claude.ai](https://claude.ai) cho nền tảng của bạn:
+- **macOS**: Build universal (Apple Silicon và Intel)
+- **Windows**: Bộ cài đặt x64 và ARM64 có sẵn
+
+Xem [Desktop Quickstart](https://code.claude.com/docs/en/desktop-quickstart) để biết hướng dẫn cài đặt.
+
+### Bàn Giao Từ CLI
+
+Chuyển phiên CLI hiện tại sang Desktop App:
+
+```
+/desktop
+```
+
+### Tính Năng Cốt Lõi
+
+| Tính Năng | Mô Tả |
+|----------|--------|
+| **Diff view** | Review trực quan từng file với comment inline; Claude đọc comment và sửa đổi |
+| **App preview** | Tự động khởi động dev server với trình duyệt nhúng để xác minh trực tiếp |
+| **PR monitoring** | Tích hợp GitHub CLI với tự động sửa lỗi CI và tự động merge khi kiểm tra qua |
+| **Phiên song song** | Nhiều phiên trong sidebar với cách ly Git worktree tự động |
+| **Tác vụ theo lịch** | Tác vụ lặp lại (hàng giờ, hàng ngày, các ngày trong tuần, hàng tuần) chạy khi app mở |
+| **Render phong phú** | Render code, markdown và diagram với syntax highlighting |
+
+### Cấu Hình App Preview
+
+Cấu hình hành vi dev server trong `.claude/launch.json`:
+
+```json
+{
+  "command": "npm run dev",
+  "port": 3000,
+  "readyPattern": "ready on",
+  "persistCookies": true
+}
+```
+
+### Connectors
+
+Kết nối các dịch vụ bên ngoài để có ngữ cảnh phong phú hơn:
+
+| Connector | Khả Năng |
+|-----------|---------|
+| **GitHub** | Theo dõi PR, issue tracking, review code |
+| **Slack** | Thông báo, ngữ cảnh kênh |
+| **Linear** | Issue tracking, quản lý sprint |
+| **Notion** | Tài liệu, truy cập knowledge base |
+| **Asana** | Quản lý tác vụ, theo dõi dự án |
+| **Calendar** | Nhận thức lịch trình, ngữ cảnh cuộc họp |
+
+> **Lưu ý**: Connectors không có sẵn cho các phiên từ xa (cloud).
+
+### Phiên Từ Xa và SSH
+
+- **Phiên từ xa**: Chạy trên cơ sở hạ tầng cloud Anthropic; tiếp tục ngay cả khi app đóng. Có thể truy cập từ claude.ai/code hoặc ứng dụng Claude mobile
+- **Phiên SSH**: Kết nối với máy từ xa qua SSH với truy cập đầy đủ vào filesystem và tool từ xa. Claude Code phải được cài đặt trên máy từ xa
+
+### Chế Độ Phân Quyền Trong Desktop
+
+Desktop App hỗ trợ 4 chế độ phân quyền giống CLI:
+
+| Chế Độ | Hành Vi |
+|--------|---------|
+| **Ask permissions** (mặc định) | Xem xét và phê duyệt mọi chỉnh sửa và lệnh |
+| **Auto accept edits** | Chỉnh sửa file tự động phê duyệt; lệnh yêu cầu phê duyệt thủ công |
+| **Plan mode** | Xem xét cách tiếp cận trước khi thực hiện bất kỳ thay đổi nào |
+| **Bypass permissions** | Thực thi tự động (chỉ sandbox, do admin kiểm soát) |
+
+### Tính Năng Enterprise
+
+- **Admin console**: Kiểm soát quyền truy cập Code tab và cài đặt phân quyền cho tổ chức
+- **MDM deployment**: Triển khai qua MDM trên macOS hoặc MSIX trên Windows
+- **SSO integration**: Yêu cầu đăng nhập một lần cho các thành viên tổ chức
+- **Managed settings**: Quản lý tập trung cấu hình nhóm và tính khả dụng model
+
+---
+
+## Danh Sách Tác Vụ
+
+Tính năng Task List cung cấp theo dõi tác vụ liên tục tồn tại qua các lần nén context (khi lịch sử hội thoại được cắt để vừa với cửa sổ context).
+
+### Bật/Tắt Danh Sách Tác Vụ
+
+Nhấn `Ctrl+T` để bật/tắt chế độ xem danh sách tác vụ trong phiên.
+
+### Tác Vụ Liên Tục
+
+Tác vụ tồn tại qua các lần nén context, đảm bảo rằng các mục công việc chạy dài không bị mất khi context hội thoại bị cắt. Điều này đặc biệt hữu ích cho các triển khai phức tạp, nhiều bước.
+
+### Thư Mục Tác Vụ Có Tên
+
+Dùng biến môi trường `CLAUDE_CODE_TASK_LIST_ID` để tạo thư mục tác vụ có tên được chia sẻ qua các phiên:
+
+```bash
+export CLAUDE_CODE_TASK_LIST_ID=my-project-sprint-3
+```
+
+Điều này cho phép nhiều phiên chia sẻ cùng một danh sách tác vụ, hữu ích cho quy trình làm việc nhóm hoặc dự án nhiều phiên.
+
+---
+
+## Gợi Ý Lệnh
+
+Prompt Suggestions (gợi ý lệnh) hiển thị các lệnh ví dụ mờ dựa trên lịch sử git và ngữ cảnh hội thoại hiện tại.
+
+### Cách Hoạt Động
+
+- Gợi ý xuất hiện dưới dạng văn bản mờ bên dưới prompt nhập của bạn
+- Nhấn `Tab` để chấp nhận gợi ý
+- Nhấn `Enter` để chấp nhận và gửi ngay lập tức
+- Gợi ý nhận thức ngữ cảnh, lấy từ lịch sử git và trạng thái hội thoại
+
+### Tắt Gợi Ý Lệnh
+
+```bash
+export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false
+```
+
+---
+
+## Git Worktrees
+
+Git Worktrees cho phép bạn khởi động Claude Code trong một worktree cách ly, cho phép làm việc song song trên các nhánh khác nhau mà không cần stash hoặc chuyển nhánh.
+
+### Khởi Động Trong Worktree
+
+```bash
+# Khởi động Claude Code trong worktree cách ly
+claude --worktree
+# hoặc
+claude -w
+```
+
+### Vị Trí Worktree
+
+Worktrees được tạo tại:
+```
+<repo>/.claude/worktrees/<name>
+```
+
+### Sparse Checkout Cho Monorepo
+
+Dùng cài đặt `worktree.sparsePaths` để thực hiện sparse-checkout trong các monorepo, giảm dung lượng đĩa và thời gian clone:
+
+```json
+{
+  "worktree": {
+    "sparsePaths": ["packages/my-package", "shared/"]
+  }
+}
+```
+
+### Tool và Hook Của Worktree
+
+| Mục | Mô Tả |
+|-----|--------|
+| `ExitWorktree` | Tool để thoát và dọn sạch worktree hiện tại |
+| `WorktreeCreate` | Sự kiện hook được kích hoạt khi worktree được tạo |
+| `WorktreeRemove` | Sự kiện hook được kích hoạt khi worktree bị xóa |
+
+### Tự Động Dọn Sạch
+
+Nếu không có thay đổi nào được thực hiện trong worktree, nó sẽ tự động được dọn sạch khi phiên kết thúc.
+
+### Các Trường Hợp Sử Dụng
+
+- Làm việc trên nhánh tính năng trong khi giữ nhánh main không bị ảnh hưởng
+- Chạy test trong môi trường cách ly mà không ảnh hưởng thư mục làm việc
+- Thử các thay đổi thử nghiệm trong môi trường có thể bỏ đi
+- Sparse-checkout các package cụ thể trong monorepo để khởi động nhanh hơn
+
+---
+
+## Sandboxing
+
+Sandboxing cung cấp cách ly filesystem và mạng ở cấp độ OS cho các lệnh Bash được thực thi bởi Claude Code. Đây là phần bổ sung cho các quy tắc phân quyền và cung cấp một lớp bảo mật bổ sung.
+
+### Bật Sandboxing
+
+**Slash command**:
+```
+/sandbox
+```
+
+**CLI flags**:
+```bash
+claude --sandbox       # Bật sandboxing
+claude --no-sandbox    # Tắt sandboxing
+```
+
+### Cài Đặt Cấu Hình
+
+| Cài Đặt | Mô Tả |
+|---------|--------|
+| `sandbox.enabled` | Bật hoặc tắt sandboxing |
+| `sandbox.failIfUnavailable` | Thất bại nếu sandboxing không thể kích hoạt |
+| `sandbox.filesystem.allowWrite` | Các đường dẫn được phép ghi |
+| `sandbox.filesystem.allowRead` | Các đường dẫn được phép đọc |
+| `sandbox.filesystem.denyRead` | Các đường dẫn bị từ chối đọc |
+| `sandbox.enableWeakerNetworkIsolation` | Bật cách ly mạng yếu hơn trên macOS |
+
+### Cấu Hình Ví Dụ
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "failIfUnavailable": true,
+    "filesystem": {
+      "allowWrite": ["/Users/me/project"],
+      "allowRead": ["/Users/me/project", "/usr/local/lib"],
+      "denyRead": ["/Users/me/.ssh", "/Users/me/.aws"]
+    },
+    "enableWeakerNetworkIsolation": true
+  }
+}
+```
+
+### Cách Hoạt Động
+
+- Các lệnh Bash chạy trong môi trường sandbox với quyền truy cập filesystem bị hạn chế
+- Quyền truy cập mạng có thể bị cách ly để ngăn các kết nối bên ngoài không mong muốn
+- Hoạt động cùng với các quy tắc phân quyền để phòng thủ theo chiều sâu
+- Trên macOS, dùng `sandbox.enableWeakerNetworkIsolation` để hạn chế mạng (cách ly mạng hoàn toàn không có sẵn trên macOS)
+
+### Các Trường Hợp Sử Dụng
+
+- Chạy code không tin cậy hoặc được tạo tự động một cách an toàn
+- Ngăn các sửa đổi vô tình đối với file ngoài dự án
+- Hạn chế quyền truy cập mạng trong các tác vụ tự động
+
+---
+
+## Cài Đặt Quản Lý (Enterprise)
+
+Managed Settings (cài đặt quản lý) cho phép quản trị viên enterprise triển khai cấu hình Claude Code trên toàn tổ chức bằng các công cụ quản lý native của nền tảng.
+
+### Phương Thức Triển Khai
+
+| Nền Tảng | Phương Thức | Từ Phiên Bản |
+|---------|------------|--------------|
+| macOS | File plist được quản lý (MDM) | v2.1.51+ |
+| Windows | Windows Registry | v2.1.51+ |
+| Đa nền tảng | File cấu hình được quản lý | v2.1.51+ |
+| Đa nền tảng | Drop-in được quản lý (thư mục `managed-settings.d/`) | v2.1.83+ |
+
+### Drop-in Được Quản Lý
+
+Từ v2.1.83, quản trị viên có thể triển khai nhiều file cài đặt được quản lý vào thư mục `managed-settings.d/`. Các file được merge theo thứ tự bảng chữ cái, cho phép cấu hình mô-đun trên các nhóm:
+
+```
+~/.claude/managed-settings.d/
+  00-org-defaults.json
+  10-team-policies.json
+  20-project-overrides.json
+```
+
+### Các Cài Đặt Quản Lý Có Sẵn
+
+| Cài Đặt | Mô Tả |
+|---------|--------|
+| `disableBypassPermissionsMode` | Ngăn người dùng bật bypass permissions |
+| `availableModels` | Hạn chế model người dùng có thể chọn |
+| `allowedChannelPlugins` | Kiểm soát channel plugin nào được phép |
+| `autoMode.environment` | Cấu hình cơ sở hạ tầng tin cậy cho auto mode |
+| Chính sách tùy chỉnh | Chính sách phân quyền và tool đặc thù của tổ chức |
+
+### Ví Dụ: macOS Plist
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>disableBypassPermissionsMode</key>
+  <true/>
+  <key>availableModels</key>
+  <array>
+    <string>claude-sonnet-4-6</string>
+    <string>claude-haiku-4-5</string>
+  </array>
+</dict>
+</plist>
+```
+
+---
+
+## Cấu Hình và Thiết Lập
+
+### Vị Trí File Cấu Hình
+
+1. **Global config**: `~/.claude/config.json`
+2. **Project config**: `./.claude/config.json`
+3. **User config**: `~/.config/claude-code/settings.json`
+
+### Ví Dụ Cấu Hình Đầy Đủ
+
+**Cấu hình tính năng nâng cao cốt lõi:**
+
+```json
+{
+  "permissions": {
+    "mode": "default"
+  },
+  "hooks": {
+    "PreToolUse:Edit": "eslint --fix ${file_path}",
+    "PostToolUse:Write": "~/.claude/hooks/security-scan.sh"
+  },
+  "mcp": {
+    "enabled": true,
+    "servers": {
+      "github": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"]
+      }
+    }
+  }
+}
+```
+
+**Ví dụ cấu hình mở rộng:**
+
+```json
+{
+  "permissions": {
+    "mode": "default",
+    "allowedTools": ["Bash(git log:*)", "Read"],
+    "disallowedTools": ["Bash(rm -rf:*)"]
+  },
+
+  "hooks": {
+    "PreToolUse": [{ "matcher": "Edit", "hooks": ["eslint --fix ${file_path}"] }],
+    "PostToolUse": [{ "matcher": "Write", "hooks": ["~/.claude/hooks/security-scan.sh"] }],
+    "Stop": [{ "hooks": ["~/.claude/hooks/notify.sh"] }]
+  },
+
+  "mcp": {
+    "enabled": true,
+    "servers": {
+      "github": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"],
+        "env": {
+          "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+        }
+      }
+    }
+  }
+}
+```
+
+### Biến Môi Trường
+
+Ghi đè cấu hình bằng biến môi trường:
+
+```bash
+# Chọn model
+export ANTHROPIC_MODEL=claude-opus-4-6
+export ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6
+export ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-6
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5
+
+# Cấu hình API
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Cấu hình thinking
+export MAX_THINKING_TOKENS=16000
+export CLAUDE_CODE_EFFORT_LEVEL=high
+
+# Bật/tắt tính năng
+export CLAUDE_CODE_DISABLE_AUTO_MEMORY=true
+export CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=true
+export CLAUDE_CODE_DISABLE_CRON=1
+export CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=true
+export CLAUDE_CODE_DISABLE_TERMINAL_TITLE=true
+export CLAUDE_CODE_DISABLE_1M_CONTEXT=true
+export CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=true
+export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false
+export CLAUDE_CODE_ENABLE_TASKS=true
+export CLAUDE_CODE_SIMPLE=true              # Được đặt bởi flag --bare
+
+# Cấu hình MCP
+export MAX_MCP_OUTPUT_TOKENS=50000
+export ENABLE_TOOL_SEARCH=true
+
+# Quản lý tác vụ
+export CLAUDE_CODE_TASK_LIST_ID=my-project-tasks
+
+# Agent teams (thử nghiệm)
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=true
+
+# Cấu hình subagent và plugin
+export CLAUDE_CODE_SUBAGENT_MODEL=sonnet
+export CLAUDE_CODE_PLUGIN_SEED_DIR=./my-plugins
+export CLAUDE_CODE_NEW_INIT=true
+
+# Subprocess và streaming
+export CLAUDE_CODE_SUBPROCESS_ENV_SCRUB="SECRET_KEY,DB_PASSWORD"
+export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80
+export CLAUDE_STREAM_IDLE_TIMEOUT_MS=30000
+export ANTHROPIC_CUSTOM_MODEL_OPTION=my-custom-model
+export SLASH_COMMAND_TOOL_CHAR_BUDGET=50000
+```
+
+### Lệnh Quản Lý Cấu Hình
+
+```
+User: /config
+[Opens interactive configuration menu]
+```
+
+Lệnh `/config` cung cấp menu tương tác để bật/tắt các cài đặt như:
+- Extended thinking bật/tắt
+- Output verbose
+- Chế độ phân quyền
+- Chọn model
+
+### Cấu Hình Theo Dự Án
+
+Tạo `.claude/config.json` trong dự án của bạn:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{ "matcher": "Bash", "hooks": ["npm test && npm run lint"] }]
+  },
+  "permissions": {
+    "mode": "default"
+  },
+  "mcp": {
+    "servers": {
+      "project-db": {
+        "command": "mcp-postgres",
+        "env": {
+          "DATABASE_URL": "${PROJECT_DB_URL}"
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Thực Hành Tốt Nhất
+
+### Chế Độ Lập Kế Hoạch
+- ✅ Dùng cho tác vụ phức tạp nhiều bước
+- ✅ Xem xét kế hoạch trước khi phê duyệt
+- ✅ Sửa đổi kế hoạch khi cần
+- ❌ Không dùng cho tác vụ đơn giản
+
+### Suy Nghĩ Mở Rộng
+- ✅ Dùng cho quyết định kiến trúc
+- ✅ Dùng cho giải quyết vấn đề phức tạp
+- ✅ Xem xét quá trình suy nghĩ
+- ❌ Không dùng cho câu hỏi đơn giản
+
+### Tác Vụ Nền
+- ✅ Dùng cho các hoạt động chạy dài
+- ✅ Theo dõi tiến độ tác vụ
+- ✅ Xử lý lỗi tác vụ một cách nhẹ nhàng
+- ❌ Không khởi động quá nhiều tác vụ đồng thời
+
+### Phân Quyền
+- ✅ Dùng `plan` để review code (chỉ đọc)
+- ✅ Dùng `default` để phát triển tương tác
+- ✅ Dùng `acceptEdits` cho quy trình tự động hóa
+- ✅ Dùng `auto` cho công việc tự chủ với các biện pháp bảo vệ an toàn
+- ❌ Không dùng `bypassPermissions` trừ khi thực sự cần thiết
+
+### Phiên Làm Việc
+- ✅ Dùng các phiên riêng biệt cho các tác vụ khác nhau
+- ✅ Lưu các trạng thái phiên quan trọng
+- ✅ Dọn sạch các phiên cũ
+- ❌ Không trộn lẫn công việc không liên quan trong một phiên
+
+---
+
+## Tài Nguyên Liên Quan
+
+Để biết thêm thông tin về Claude Code và các tính năng liên quan:
+
+- [Official Interactive Mode Documentation](https://code.claude.com/docs/en/interactive-mode)
+- [Official Headless Mode Documentation](https://code.claude.com/docs/en/headless)
+- [CLI Reference](https://code.claude.com/docs/en/cli-reference)
+- [Checkpoints Guide](../08-checkpoints/) - Quản lý phiên và tua lại
+- [Slash Commands](../01-slash-commands/) - Tài liệu tham khảo lệnh
+- [Memory Guide](../02-memory/) - Ngữ cảnh liên tục
+- [Skills Guide](../03-skills/) - Khả năng tự chủ
+- [Subagents Guide](../04-subagents/) - Thực thi tác vụ được ủy thác
+- [MCP Guide](../05-mcp/) - Truy cập dữ liệu bên ngoài
+- [Hooks Guide](../06-hooks/) - Tự động hóa hướng sự kiện
+- [Plugins Guide](../07-plugins/) - Extension đóng gói
+- [Official Scheduled Tasks Documentation](https://code.claude.com/docs/en/scheduled-tasks)
+- [Official Chrome Integration Documentation](https://code.claude.com/docs/en/chrome)
+- [Official Remote Control Documentation](https://code.claude.com/docs/en/remote-control)
+- [Official Keybindings Documentation](https://code.claude.com/docs/en/keybindings)
+- [Official Desktop App Documentation](https://code.claude.com/docs/en/desktop)

--- a/09-advanced-features/planning-mode-examples.vi.md
+++ b/09-advanced-features/planning-mode-examples.vi.md
@@ -1,0 +1,533 @@
+# Ví Dụ Về Planning Mode
+
+Các ví dụ thực tế minh họa việc sử dụng hiệu quả planning mode trong Claude Code.
+
+## Ví Dụ 1: Xây Dựng REST API
+
+### Không Dùng Planning Mode
+
+```
+User: Build a REST API for a blog
+
+Claude: I'll create the API...
+[Starts coding immediately, may miss requirements]
+```
+
+### Dùng Planning Mode
+
+```
+User: /plan Build a REST API for a blog
+
+Claude: Let me create a comprehensive plan for the blog API.
+
+## Blog REST API Implementation Plan
+
+### Phase 1: Project Setup (15 min)
+1. Initialize Node.js project with Express
+2. Set up TypeScript configuration
+3. Install dependencies (express, pg, jwt, joi)
+4. Configure environment variables
+5. Set up project structure
+
+### Phase 2: Database Layer (30 min)
+6. Design database schema
+   - users table (id, email, password_hash, created_at)
+   - posts table (id, user_id, title, content, published, created_at, updated_at)
+   - comments table (id, post_id, user_id, content, created_at)
+7. Create migration files
+8. Set up database connection pool
+9. Implement database models
+
+### Phase 3: Authentication (45 min)
+10. Implement user registration endpoint
+11. Implement login endpoint with JWT
+12. Create authentication middleware
+13. Add password hashing with bcrypt
+14. Implement token refresh logic
+
+### Phase 4: Posts API (40 min)
+15. GET /api/posts - List all published posts (with pagination)
+16. GET /api/posts/:id - Get single post
+17. POST /api/posts - Create new post (auth required)
+18. PUT /api/posts/:id - Update post (auth required, ownership check)
+19. DELETE /api/posts/:id - Delete post (auth required, ownership check)
+20. GET /api/users/:id/posts - Get user's posts
+
+### Phase 5: Comments API (30 min)
+21. GET /api/posts/:id/comments - Get post comments
+22. POST /api/posts/:id/comments - Add comment (auth required)
+23. DELETE /api/comments/:id - Delete comment (auth required, ownership check)
+
+### Phase 6: Validation & Error Handling (30 min)
+24. Add request validation with Joi
+25. Implement global error handler
+26. Add input sanitization
+27. Implement rate limiting
+
+### Phase 7: Testing (60 min)
+28. Write unit tests for models
+29. Write integration tests for auth endpoints
+30. Write integration tests for posts endpoints
+31. Write integration tests for comments endpoints
+32. Achieve 80%+ code coverage
+
+### Phase 8: Documentation & Deployment (30 min)
+33. Generate API documentation with Swagger
+34. Create README with setup instructions
+35. Add Docker configuration
+36. Set up CI/CD pipeline
+
+**Estimated Time**: 4.5 hours
+**Files to Create**: ~25
+**Key Technologies**: Express, PostgreSQL, JWT, TypeScript
+
+**API Endpoints Summary**:
+- Authentication: 2 endpoints
+- Posts: 6 endpoints
+- Comments: 3 endpoints
+- Total: 11 endpoints
+
+Ready to proceed? (yes/no/modify)
+
+User: yes
+
+Claude: Starting Phase 1: Project Setup...
+[Implements each phase systematically]
+```
+
+## Ví Dụ 2: Migration Database
+
+### Dùng Planning Mode
+
+```
+User: /plan Migrate from MongoDB to PostgreSQL
+
+Claude: This is a complex migration. Let me create a detailed plan.
+
+## MongoDB to PostgreSQL Migration Plan
+
+### Phase 1: Analysis & Preparation (Day 1)
+1. Analyze current MongoDB schema
+2. Identify data relationships and constraints
+3. Document current data volume and growth rate
+4. Design equivalent PostgreSQL schema
+5. Plan data type mappings
+6. Identify potential migration challenges
+
+### Phase 2: PostgreSQL Setup (Day 1)
+7. Set up PostgreSQL database
+8. Create schema with tables, indexes, constraints
+9. Set up connection pooling
+10. Configure backup strategy
+
+### Phase 3: Dual-Write Implementation (Day 2-3)
+11. Create database abstraction layer
+12. Implement dual-write to both databases
+13. Add data consistency checks
+14. Deploy dual-write to staging
+15. Monitor for issues
+
+### Phase 4: Data Migration (Day 4)
+16. Create data export scripts for MongoDB
+17. Create data import scripts for PostgreSQL
+18. Implement data transformation logic
+19. Run initial migration on copy of production data
+20. Validate migrated data integrity
+
+### Phase 5: Gradual Cutover (Day 5-7)
+21. Enable dual-write in production
+22. Migrate historical data in batches
+23. Continuously validate data consistency
+24. Monitor both databases
+25. Fix any data synchronization issues
+
+### Phase 6: PostgreSQL Primary (Day 8)
+26. Switch read operations to PostgreSQL
+27. Monitor query performance
+28. Optimize slow queries
+29. Continue dual-write for safety
+
+### Phase 7: MongoDB Retirement (Day 9-10)
+30. Stop writing to MongoDB
+31. Keep MongoDB as backup for 2 weeks
+32. Remove MongoDB dependencies from code
+33. Archive MongoDB data
+34. Decommission MongoDB instance
+
+**Estimated Time**: 10 days
+**Risk Level**: High
+**Rollback Strategy**: Keep MongoDB running with dual-write
+**Success Criteria**:
+- Zero data loss
+- <5% performance regression
+- All tests passing
+
+**Key Risks**:
+1. Data inconsistency during migration
+2. Query performance degradation
+3. Application downtime
+4. Data loss
+
+**Mitigation**:
+- Dual-write pattern for safety
+- Gradual cutover
+- Continuous monitoring
+- Quick rollback capability
+
+Proceed with this plan? (yes/no/modify)
+
+User: Modify - let's add a rollback plan for each phase
+
+Claude: Updated plan with rollback procedures for each phase...
+```
+
+## Ví Dụ 3: Tái Cấu Trúc Frontend
+
+```
+User: /plan Refactor our React app from class components to hooks
+
+Claude: I'll create a systematic refactoring plan.
+
+## React Class to Hooks Migration Plan
+
+### Phase 1: Preparation & Analysis (2 hours)
+1. Audit all class components (find all .jsx/.tsx files)
+2. Categorize by complexity:
+   - Simple (state only): ~15 components
+   - Medium (lifecycle methods): ~23 components
+   - Complex (multiple lifecycle, refs): ~8 components
+3. Identify third-party libraries that need updates
+4. Create component dependency graph
+5. Plan migration order (leaf nodes first)
+
+### Phase 2: Setup & Tooling (1 hour)
+6. Update React to v18+
+7. Set up ESLint rules for hooks
+8. Create conversion templates
+9. Set up automated tests
+10. Create checkpoint before starting
+
+### Phase 3: Migrate Simple Components (4 hours)
+11. Convert simple stateful components (15 components)
+12. Replace this.state with useState
+13. Replace this.setState with state setters
+14. Test each component after conversion
+15. Update tests
+
+### Phase 4: Migrate Medium Components (8 hours)
+16. Convert components with lifecycle methods (23 components)
+17. Replace componentDidMount with useEffect
+18. Replace componentDidUpdate with useEffect
+19. Replace componentWillUnmount with useEffect cleanup
+20. Test thoroughly
+
+### Phase 5: Migrate Complex Components (12 hours)
+21. Convert complex components (8 components)
+22. Replace refs with useRef
+23. Extract custom hooks for shared logic
+24. Handle edge cases (multiple useEffect)
+25. Extensive testing
+
+### Phase 6: Shared Logic Extraction (6 hours)
+26. Identify duplicated logic across components
+27. Create custom hooks:
+    - useAuth
+    - useFetch
+    - useLocalStorage
+    - useDebounce
+28. Refactor components to use custom hooks
+29. Test custom hooks independently
+
+### Phase 7: Performance Optimization (4 hours)
+30. Add React.memo where needed
+31. Optimize with useCallback
+32. Optimize with useMemo
+33. Profile and fix performance regressions
+
+### Phase 8: Cleanup & Documentation (2 hours)
+34. Remove unused class component utilities
+35. Update documentation
+36. Update coding guidelines
+37. Create migration guide for team
+
+**Estimated Time**: 5 days (39 hours)
+**Files to Modify**: 46 components
+**Risk Level**: Medium
+
+**Migration Order**:
+1. Leaf components (no dependencies)
+2. Mid-level components
+3. Top-level container components
+4. App.jsx (last)
+
+**Testing Strategy**:
+- Unit tests for each component
+- Integration tests for user flows
+- Visual regression tests
+- Performance benchmarks
+
+**Success Metrics**:
+- All tests passing
+- No visual regressions
+- Performance maintained or improved
+- Bundle size not significantly increased
+
+Proceed? (yes/no/modify)
+```
+
+## Ví Dụ 4: Triển Khai Bảo Mật
+
+```
+User: /plan Implement comprehensive security for our web app
+
+Claude: Let me create a thorough security implementation plan.
+
+## Web Application Security Implementation Plan
+
+### Phase 1: Security Audit (Day 1)
+1. Run automated security scanners (npm audit, Snyk)
+2. Review dependencies for vulnerabilities
+3. Check OWASP Top 10 compliance
+4. Audit authentication flows
+5. Review data handling practices
+6. Document current security gaps
+
+### Phase 2: Authentication Hardening (Day 2-3)
+7. Implement strong password requirements
+8. Add password strength meter
+9. Implement rate limiting on login
+10. Add account lockout after failed attempts
+11. Implement 2FA (TOTP)
+12. Add session management improvements
+13. Implement secure password reset flow
+
+### Phase 3: Authorization & Access Control (Day 3-4)
+14. Implement RBAC (Role-Based Access Control)
+15. Add permission checks on all endpoints
+16. Implement principle of least privilege
+17. Add audit logging for sensitive operations
+18. Implement resource-level permissions
+
+### Phase 4: Data Protection (Day 4-5)
+19. Implement encryption at rest (sensitive fields)
+20. Ensure TLS/SSL for all communications
+21. Implement secure session storage
+22. Add PII data masking in logs
+23. Implement data retention policies
+24. Add secure file upload handling
+
+### Phase 5: Input Validation & Sanitization (Day 5-6)
+25. Implement input validation on all endpoints
+26. Add XSS protection (Content Security Policy)
+27. Implement SQL injection prevention (parameterized queries)
+28. Add CSRF protection
+29. Implement request size limits
+30. Add file upload type validation
+
+### Phase 6: Security Headers & Configuration (Day 6)
+31. Add security headers:
+    - Strict-Transport-Security
+    - X-Content-Type-Options
+    - X-Frame-Options
+    - X-XSS-Protection
+    - Content-Security-Policy
+32. Configure CORS properly
+33. Disable unnecessary HTTP methods
+34. Remove server version headers
+
+### Phase 7: Monitoring & Logging (Day 7)
+35. Implement security event logging
+36. Add anomaly detection
+37. Set up intrusion detection
+38. Implement real-time alerting
+39. Create security dashboard
+
+### Phase 8: Testing & Documentation (Day 8-9)
+40. Perform penetration testing
+41. Run security scanners
+42. Test all security features
+43. Create security documentation
+44. Train team on security practices
+45. Create incident response plan
+
+### Phase 9: Compliance & Policies (Day 10)
+46. GDPR compliance check
+47. Create privacy policy
+48. Implement data subject rights
+49. Add cookie consent
+50. Create security policies documentation
+
+**Estimated Time**: 10 days
+**Risk Level**: Critical
+**Priority**: High
+
+**Security Improvements Summary**:
+- Authentication: 7 enhancements
+- Authorization: 5 enhancements
+- Data Protection: 6 enhancements
+- Input Validation: 6 enhancements
+- Infrastructure: 9 enhancements
+- Monitoring: 5 enhancements
+
+**Compliance**: OWASP Top 10, GDPR
+
+**Success Criteria**:
+- Zero critical vulnerabilities
+- All OWASP Top 10 mitigated
+- Security score >90/100
+- All pen test issues resolved
+
+Proceed? (yes/no/modify)
+```
+
+## Ví Dụ 5: Tối Ưu Hóa Hiệu Suất
+
+```
+User: /plan Optimize our slow e-commerce website
+
+Claude: Let me create a comprehensive performance optimization plan.
+
+## E-commerce Performance Optimization Plan
+
+### Phase 1: Performance Audit (4 hours)
+1. Run Lighthouse audit
+2. Analyze Chrome DevTools performance profile
+3. Measure Core Web Vitals:
+   - LCP (Largest Contentful Paint)
+   - FID (First Input Delay)
+   - CLS (Cumulative Layout Shift)
+4. Identify performance bottlenecks
+5. Create baseline performance metrics
+
+**Current Metrics**:
+- LCP: 4.2s (target: <2.5s)
+- FID: 280ms (target: <100ms)
+- CLS: 0.25 (target: <0.1)
+- Page Load: 8.3s (target: <3s)
+
+### Phase 2: Image Optimization (6 hours)
+6. Convert images to WebP format
+7. Implement responsive images
+8. Add lazy loading for images
+9. Optimize image sizes (compression)
+10. Implement CDN for images
+11. Add image placeholders
+
+**Expected Impact**: -40% load time
+
+### Phase 3: Code Splitting & Lazy Loading (8 hours)
+12. Implement route-based code splitting
+13. Lazy load non-critical components
+14. Split vendor bundles
+15. Optimize chunk sizes
+16. Implement dynamic imports
+17. Add preloading for critical resources
+
+**Expected Impact**: -30% initial bundle size
+
+### Phase 4: Caching Strategy (6 hours)
+18. Implement browser caching (Cache-Control)
+19. Add service worker for offline support
+20. Implement API response caching
+21. Add Redis cache for database queries
+22. Implement stale-while-revalidate
+23. Configure CDN caching
+
+**Expected Impact**: -50% API response time
+
+### Phase 5: Database Optimization (8 hours)
+24. Add database indexes
+25. Optimize slow queries (>100ms)
+26. Implement query result caching
+27. Add connection pooling
+28. Denormalize where appropriate
+29. Implement database read replicas
+
+**Expected Impact**: -60% database query time
+
+### Phase 6: Frontend Optimization (10 hours)
+30. Minimize and compress JavaScript
+31. Minimize and compress CSS
+32. Remove unused CSS (PurgeCSS)
+33. Implement critical CSS
+34. Defer non-critical JavaScript
+35. Reduce DOM size
+36. Optimize React rendering (memo, useMemo)
+37. Implement virtual scrolling for long lists
+
+**Expected Impact**: -35% JavaScript execution time
+
+### Phase 7: Network Optimization (4 hours)
+38. Enable HTTP/2
+39. Implement resource hints (preconnect, prefetch)
+40. Reduce number of HTTP requests
+41. Enable Brotli compression
+42. Optimize third-party scripts
+
+**Expected Impact**: -25% network time
+
+### Phase 8: Monitoring & Testing (4 hours)
+43. Set up performance monitoring (Datadog/New Relic)
+44. Add Real User Monitoring (RUM)
+45. Create performance budgets
+46. Set up automated Lighthouse CI
+47. Test on real devices
+
+**Estimated Time**: 50 hours (2 weeks)
+
+**Target Metrics** (90th percentile):
+- LCP: <2.0s (from 4.2s) ✅
+- FID: <50ms (from 280ms) ✅
+- CLS: <0.05 (from 0.25) ✅
+- Page Load: <2.5s (from 8.3s) ✅
+
+**Expected Revenue Impact**:
+- 100ms faster = 1% conversion increase
+- Target: 5.8s improvement = ~58% conversion increase
+- Estimated additional revenue: Significant
+
+**Priority Order**:
+1. Image optimization (quick wins)
+2. Code splitting (high impact)
+3. Caching (high impact)
+4. Database optimization (critical)
+5. Frontend optimization (polish)
+
+Proceed with this plan? (yes/no/modify)
+```
+
+## Các Bài Học Chính
+
+### Lợi Ích Của Planning Mode
+
+1. **Rõ ràng**: Lộ trình rõ ràng trước khi bắt đầu
+2. **Ước tính**: Ước tính thời gian và công sức
+3. **Đánh giá rủi ro**: Xác định các vấn đề tiềm ẩn sớm
+4. **Ưu tiên hóa**: Thứ tự logic của các tác vụ
+5. **Phê duyệt**: Xem xét và phê duyệt trước khi thực thi
+6. **Sửa đổi**: Điều chỉnh kế hoạch dựa trên phản hồi
+
+### Khi Nào Dùng Planning Mode
+
+✅ **Luôn dùng cho**:
+- Dự án nhiều ngày
+- Hợp tác nhóm
+- Thay đổi hệ thống quan trọng
+- Học các khái niệm mới
+- Tái cấu trúc phức tạp
+
+❌ **Không dùng cho**:
+- Sửa lỗi
+- Chỉnh sửa nhỏ
+- Câu hỏi đơn giản
+- Thử nghiệm nhanh
+
+### Thực Hành Tốt Nhất
+
+1. **Xem xét kế hoạch kỹ lưỡng** trước khi phê duyệt
+2. **Sửa đổi kế hoạch** khi phát hiện vấn đề
+3. **Phân tách** các tác vụ phức tạp
+4. **Ước tính thực tế** về thời gian
+5. **Bao gồm chiến lược rollback**
+6. **Thêm tiêu chí thành công**
+7. **Lên kế hoạch kiểm thử** ở mỗi giai đoạn

--- a/10-cli/README.vi.md
+++ b/10-cli/README.vi.md
@@ -1,0 +1,831 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
+</picture>
+
+# Tham chiếu CLI
+
+## Tổng quan
+
+Claude Code CLI (Command Line Interface — giao diện dòng lệnh) là cách chính để tương tác với Claude Code. CLI cung cấp nhiều tùy chọn mạnh mẽ để chạy truy vấn, quản lý phiên làm việc, cấu hình model, và tích hợp Claude vào quy trình phát triển của bạn.
+
+## Kiến trúc
+
+```mermaid
+graph TD
+    A["Terminal của người dùng"] -->|"claude [options] [query]"| B["Claude Code CLI"]
+    B -->|Tương tác| C["Chế độ REPL"]
+    B -->|"--print"| D["Chế độ Print (SDK)"]
+    B -->|"--resume"| E["Tiếp tục phiên"]
+    C -->|Hội thoại| F["Claude API"]
+    D -->|Truy vấn đơn| F
+    E -->|Tải ngữ cảnh| F
+    F -->|Phản hồi| G["Đầu ra"]
+    G -->|text/json/stream-json| H["Terminal/Pipe"]
+```
+
+## Lệnh CLI
+
+| Lệnh | Mô tả | Ví dụ |
+|------|-------|-------|
+| `claude` | Khởi động REPL tương tác | `claude` |
+| `claude "query"` | Khởi động REPL với prompt ban đầu | `claude "explain this project"` |
+| `claude -p "query"` | Chế độ Print — truy vấn rồi thoát | `claude -p "explain this function"` |
+| `cat file \| claude -p "query"` | Xử lý nội dung qua pipe | `cat logs.txt \| claude -p "explain"` |
+| `claude -c` | Tiếp tục hội thoại gần nhất | `claude -c` |
+| `claude -c -p "query"` | Tiếp tục trong chế độ print | `claude -c -p "check for type errors"` |
+| `claude -r "<session>" "query"` | Tiếp tục phiên theo ID hoặc tên | `claude -r "auth-refactor" "finish this PR"` |
+| `claude update` | Cập nhật lên phiên bản mới nhất | `claude update` |
+| `claude mcp` | Cấu hình MCP servers | Xem [tài liệu MCP](../05-mcp/) |
+| `claude mcp serve` | Chạy Claude Code như một MCP server | `claude mcp serve` |
+| `claude agents` | Liệt kê tất cả subagents đã cấu hình | `claude agents` |
+| `claude auto-mode defaults` | In các quy tắc mặc định của auto mode dưới dạng JSON | `claude auto-mode defaults` |
+| `claude remote-control` | Khởi động Remote Control server | `claude remote-control` |
+| `claude plugin` | Quản lý plugin (cài, bật, tắt) | `claude plugin install my-plugin` |
+| `claude auth login` | Đăng nhập (hỗ trợ `--email`, `--sso`) | `claude auth login --email user@example.com` |
+| `claude auth logout` | Đăng xuất tài khoản hiện tại | `claude auth logout` |
+| `claude auth status` | Kiểm tra trạng thái đăng nhập (exit 0 nếu đã đăng nhập, 1 nếu chưa) | `claude auth status` |
+
+## Các cờ cốt lõi
+
+| Cờ | Mô tả | Ví dụ |
+|----|-------|-------|
+| `-p, --print` | In phản hồi mà không vào chế độ tương tác | `claude -p "query"` |
+| `-c, --continue` | Tải hội thoại gần nhất | `claude --continue` |
+| `-r, --resume` | Tiếp tục phiên cụ thể theo ID hoặc tên | `claude --resume auth-refactor` |
+| `-v, --version` | Hiển thị số phiên bản | `claude -v` |
+| `-w, --worktree` | Khởi động trong git worktree cô lập | `claude -w` |
+| `-n, --name` | Tên hiển thị cho phiên | `claude -n "auth-refactor"` |
+| `--from-pr <number>` | Tiếp tục phiên liên kết với GitHub PR | `claude --from-pr 42` |
+| `--remote "task"` | Tạo phiên web trên claude.ai | `claude --remote "implement API"` |
+| `--remote-control, --rc` | Phiên tương tác với Remote Control | `claude --rc` |
+| `--teleport` | Tiếp tục phiên web cục bộ | `claude --teleport` |
+| `--teammate-mode` | Chế độ hiển thị nhóm agent | `claude --teammate-mode tmux` |
+| `--bare` | Chế độ tối giản (bỏ qua hooks, skills, plugins, MCP, auto memory, CLAUDE.md) | `claude --bare` |
+| `--enable-auto-mode` | Mở khóa chế độ quyền tự động | `claude --enable-auto-mode` |
+| `--channels` | Đăng ký MCP channel plugins | `claude --channels discord,telegram` |
+| `--chrome` / `--no-chrome` | Bật/tắt tích hợp trình duyệt Chrome | `claude --chrome` |
+| `--effort` | Đặt mức độ nỗ lực tư duy | `claude --effort high` |
+| `--init` / `--init-only` | Chạy initialization hooks | `claude --init` |
+| `--maintenance` | Chạy maintenance hooks rồi thoát | `claude --maintenance` |
+| `--disable-slash-commands` | Tắt tất cả skills và slash commands | `claude --disable-slash-commands` |
+| `--no-session-persistence` | Tắt lưu phiên (chế độ print) | `claude -p --no-session-persistence "query"` |
+
+### Chế độ tương tác vs Chế độ Print
+
+```mermaid
+graph LR
+    A["claude"] -->|Mặc định| B["REPL tương tác"]
+    A -->|"cờ -p"| C["Chế độ Print"]
+    B -->|Tính năng| D["Hội thoại nhiều lượt<br>Tab completion<br>Lịch sử<br>Slash commands"]
+    C -->|Tính năng| E["Truy vấn đơn<br>Có thể script hóa<br>Có thể dùng pipe<br>Đầu ra JSON"]
+```
+
+**Chế độ tương tác** (mặc định):
+```bash
+# Khởi động phiên tương tác
+claude
+
+# Khởi động với prompt ban đầu
+claude "explain the authentication flow"
+```
+
+**Chế độ Print** (không tương tác):
+```bash
+# Truy vấn đơn rồi thoát
+claude -p "what does this function do?"
+
+# Xử lý nội dung file
+cat error.log | claude -p "explain this error"
+
+# Kết hợp với các công cụ khác
+claude -p "list todos" | grep "URGENT"
+```
+
+## Model & Cấu hình
+
+| Cờ | Mô tả | Ví dụ |
+|----|-------|-------|
+| `--model` | Chọn model (sonnet, opus, haiku, hoặc tên đầy đủ) | `claude --model opus` |
+| `--fallback-model` | Tự động chuyển model khi quá tải | `claude -p --fallback-model sonnet "query"` |
+| `--agent` | Chỉ định agent cho phiên | `claude --agent my-custom-agent` |
+| `--agents` | Định nghĩa subagents tùy chỉnh qua JSON | Xem [Cấu hình Agents](#cấu-hình-agents) |
+| `--effort` | Đặt mức độ nỗ lực (low, medium, high, max) | `claude --effort high` |
+
+### Ví dụ chọn Model
+
+```bash
+# Dùng Opus 4.6 cho tác vụ phức tạp
+claude --model opus "design a caching strategy"
+
+# Dùng Haiku 4.5 cho tác vụ nhanh
+claude --model haiku -p "format this JSON"
+
+# Tên model đầy đủ
+claude --model claude-sonnet-4-6-20250929 "review this code"
+
+# Kết hợp fallback để đảm bảo độ tin cậy
+claude -p --model opus --fallback-model sonnet "analyze architecture"
+
+# Dùng opusplan (Opus lập kế hoạch, Sonnet thực thi)
+claude --model opusplan "design and implement the caching layer"
+```
+
+## Tùy chỉnh System Prompt
+
+| Cờ | Mô tả | Ví dụ |
+|----|-------|-------|
+| `--system-prompt` | Thay thế toàn bộ prompt mặc định | `claude --system-prompt "You are a Python expert"` |
+| `--system-prompt-file` | Tải prompt từ file (chế độ print) | `claude -p --system-prompt-file ./prompt.txt "query"` |
+| `--append-system-prompt` | Thêm vào sau prompt mặc định | `claude --append-system-prompt "Always use TypeScript"` |
+
+### Ví dụ System Prompt
+
+```bash
+# Persona hoàn toàn tùy chỉnh
+claude --system-prompt "You are a senior security engineer. Focus on vulnerabilities."
+
+# Thêm hướng dẫn cụ thể
+claude --append-system-prompt "Always include unit tests with code examples"
+
+# Tải prompt phức tạp từ file
+claude -p --system-prompt-file ./prompts/code-reviewer.txt "review main.py"
+```
+
+### So sánh các cờ System Prompt
+
+| Cờ | Hành vi | Tương tác | Print |
+|----|---------|-----------|-------|
+| `--system-prompt` | Thay thế toàn bộ system prompt mặc định | ✅ | ✅ |
+| `--system-prompt-file` | Thay thế bằng prompt từ file | ❌ | ✅ |
+| `--append-system-prompt` | Thêm vào sau system prompt mặc định | ✅ | ✅ |
+
+**Chỉ dùng `--system-prompt-file` trong chế độ print. Với chế độ tương tác, dùng `--system-prompt` hoặc `--append-system-prompt`.**
+
+## Quản lý Tool & Quyền
+
+| Cờ | Mô tả | Ví dụ |
+|----|-------|-------|
+| `--tools` | Giới hạn các built-in tools được phép | `claude -p --tools "Bash,Edit,Read" "query"` |
+| `--allowedTools` | Tools thực thi mà không cần hỏi | `"Bash(git log:*)" "Read"` |
+| `--disallowedTools` | Tools bị xóa khỏi ngữ cảnh | `"Bash(rm:*)" "Edit"` |
+| `--dangerously-skip-permissions` | Bỏ qua tất cả xác nhận quyền | `claude --dangerously-skip-permissions` |
+| `--permission-mode` | Bắt đầu ở chế độ quyền chỉ định | `claude --permission-mode auto` |
+| `--permission-prompt-tool` | MCP tool để xử lý quyền | `claude -p --permission-prompt-tool mcp_auth "query"` |
+| `--enable-auto-mode` | Mở khóa chế độ quyền tự động | `claude --enable-auto-mode` |
+
+### Ví dụ về Quyền
+
+```bash
+# Chế độ chỉ đọc để review code
+claude --permission-mode plan "review this codebase"
+
+# Giới hạn chỉ dùng tools an toàn
+claude --tools "Read,Grep,Glob" -p "find all TODO comments"
+
+# Cho phép các lệnh git cụ thể mà không cần hỏi
+claude --allowedTools "Bash(git status:*)" "Bash(git log:*)"
+
+# Chặn các thao tác nguy hiểm
+claude --disallowedTools "Bash(rm -rf:*)" "Bash(git push --force:*)"
+```
+
+## Đầu ra & Định dạng
+
+| Cờ | Mô tả | Tùy chọn | Ví dụ |
+|----|-------|----------|-------|
+| `--output-format` | Định dạng đầu ra (chế độ print) | `text`, `json`, `stream-json` | `claude -p --output-format json "query"` |
+| `--input-format` | Định dạng đầu vào (chế độ print) | `text`, `stream-json` | `claude -p --input-format stream-json` |
+| `--verbose` | Bật ghi log chi tiết | | `claude --verbose` |
+| `--include-partial-messages` | Bao gồm các sự kiện streaming | Yêu cầu `stream-json` | `claude -p --output-format stream-json --include-partial-messages "query"` |
+| `--json-schema` | Lấy JSON hợp lệ theo schema | | `claude -p --json-schema '{"type":"object"}' "query"` |
+| `--max-budget-usd` | Giới hạn chi tiêu tối đa cho chế độ print | | `claude -p --max-budget-usd 5.00 "query"` |
+
+### Ví dụ Định dạng Đầu ra
+
+```bash
+# Văn bản thuần (mặc định)
+claude -p "explain this code"
+
+# JSON để dùng theo chương trình
+claude -p --output-format json "list all functions in main.py"
+
+# JSON streaming để xử lý thời gian thực
+claude -p --output-format stream-json "generate a long report"
+
+# Đầu ra có cấu trúc với kiểm tra schema
+claude -p --json-schema '{"type":"object","properties":{"bugs":{"type":"array"}}}' \
+  "find bugs in this code and return as JSON"
+```
+
+## Workspace & Thư mục
+
+| Cờ | Mô tả | Ví dụ |
+|----|-------|-------|
+| `--add-dir` | Thêm thư mục làm việc bổ sung | `claude --add-dir ../apps ../lib` |
+| `--setting-sources` | Nguồn cài đặt phân cách bằng dấu phẩy | `claude --setting-sources user,project` |
+| `--settings` | Tải cài đặt từ file hoặc JSON | `claude --settings ./settings.json` |
+| `--plugin-dir` | Tải plugins từ thư mục (có thể dùng nhiều lần) | `claude --plugin-dir ./my-plugin` |
+
+### Ví dụ Nhiều thư mục
+
+```bash
+# Làm việc trên nhiều thư mục project
+claude --add-dir ../frontend ../backend ../shared "find all API endpoints"
+
+# Tải cài đặt tùy chỉnh
+claude --settings '{"model":"opus","verbose":true}' "complex task"
+```
+
+## Cấu hình MCP
+
+| Cờ | Mô tả | Ví dụ |
+|----|-------|-------|
+| `--mcp-config` | Tải MCP servers từ JSON | `claude --mcp-config ./mcp.json` |
+| `--strict-mcp-config` | Chỉ dùng MCP config đã chỉ định | `claude --strict-mcp-config --mcp-config ./mcp.json` |
+| `--channels` | Đăng ký MCP channel plugins | `claude --channels discord,telegram` |
+
+### Ví dụ MCP
+
+```bash
+# Tải GitHub MCP server
+claude --mcp-config ./github-mcp.json "list open PRs"
+
+# Chế độ strict — chỉ dùng các server đã chỉ định
+claude --strict-mcp-config --mcp-config ./production-mcp.json "deploy to staging"
+```
+
+## Quản lý Phiên
+
+| Cờ | Mô tả | Ví dụ |
+|----|-------|-------|
+| `--session-id` | Dùng session ID cụ thể (UUID) | `claude --session-id "550e8400-..."` |
+| `--fork-session` | Tạo phiên mới khi tiếp tục | `claude --resume abc123 --fork-session` |
+
+### Ví dụ Phiên
+
+```bash
+# Tiếp tục hội thoại gần nhất
+claude -c
+
+# Tiếp tục phiên đã đặt tên
+claude -r "feature-auth" "continue implementing login"
+
+# Fork phiên để thử hướng khác
+claude --resume feature-auth --fork-session "try alternative approach"
+
+# Dùng session ID cụ thể
+claude --session-id "550e8400-e29b-41d4-a716-446655440000" "continue"
+```
+
+### Fork Phiên
+
+Tạo nhánh từ phiên hiện có để thử nghiệm:
+
+```bash
+# Fork phiên để thử hướng tiếp cận khác
+claude --resume abc123 --fork-session "try alternative implementation"
+
+# Fork với message tùy chỉnh
+claude -r "feature-auth" --fork-session "test with different architecture"
+```
+
+**Các trường hợp sử dụng:**
+- Thử các cách triển khai khác mà không mất phiên gốc
+- Thử nghiệm nhiều hướng song song
+- Tạo nhánh từ công việc đã thành công để biến tấu
+- Kiểm tra các thay đổi phá vỡ mà không ảnh hưởng phiên chính
+
+Phiên gốc không thay đổi, và fork trở thành phiên độc lập mới.
+
+## Tính năng Nâng cao
+
+| Cờ | Mô tả | Ví dụ |
+|----|-------|-------|
+| `--chrome` | Bật tích hợp Chrome | `claude --chrome` |
+| `--no-chrome` | Tắt tích hợp Chrome | `claude --no-chrome` |
+| `--ide` | Tự động kết nối IDE nếu có | `claude --ide` |
+| `--max-turns` | Giới hạn số lượt tự động (không tương tác) | `claude -p --max-turns 3 "query"` |
+| `--debug` | Bật chế độ debug với bộ lọc | `claude --debug "api,mcp"` |
+| `--enable-lsp-logging` | Bật ghi log LSP chi tiết | `claude --enable-lsp-logging` |
+| `--betas` | Beta headers cho API requests | `claude --betas interleaved-thinking` |
+| `--plugin-dir` | Tải plugins từ thư mục (có thể dùng nhiều lần) | `claude --plugin-dir ./my-plugin` |
+| `--enable-auto-mode` | Mở khóa chế độ quyền tự động | `claude --enable-auto-mode` |
+| `--effort` | Đặt mức độ nỗ lực tư duy | `claude --effort high` |
+| `--bare` | Chế độ tối giản (bỏ qua hooks, skills, plugins, MCP, auto memory, CLAUDE.md) | `claude --bare` |
+| `--channels` | Đăng ký MCP channel plugins | `claude --channels discord` |
+| `--fork-session` | Tạo session ID mới khi tiếp tục | `claude --resume abc --fork-session` |
+| `--max-budget-usd` | Chi tiêu tối đa (chế độ print) | `claude -p --max-budget-usd 5.00 "query"` |
+| `--json-schema` | Đầu ra JSON được kiểm tra schema | `claude -p --json-schema '{"type":"object"}' "q"` |
+
+### Ví dụ Nâng cao
+
+```bash
+# Giới hạn hành động tự động
+claude -p --max-turns 5 "refactor this module"
+
+# Debug API calls
+claude --debug "api" "test query"
+
+# Bật tích hợp IDE
+claude --ide "help me with this file"
+```
+
+## Cấu hình Agents
+
+Cờ `--agents` nhận một JSON object định nghĩa các subagents tùy chỉnh cho phiên.
+
+### Định dạng JSON cho Agents
+
+```json
+{
+  "agent-name": {
+    "description": "Bắt buộc: khi nào gọi agent này",
+    "prompt": "Bắt buộc: system prompt cho agent",
+    "tools": ["Tùy chọn", "mảng", "tools"],
+    "model": "tùy chọn: sonnet|opus|haiku"
+  }
+}
+```
+
+**Các trường bắt buộc:**
+- `description` — Mô tả ngôn ngữ tự nhiên về khi nào dùng agent này
+- `prompt` — System prompt định nghĩa vai trò và hành vi của agent
+
+**Các trường tùy chọn:**
+- `tools` — Mảng các tools được phép (kế thừa tất cả nếu bỏ qua)
+  - Định dạng: `["Read", "Grep", "Glob", "Bash"]`
+- `model` — Model sử dụng: `sonnet`, `opus`, hoặc `haiku`
+
+### Ví dụ đầy đủ về Agents
+
+```json
+{
+  "code-reviewer": {
+    "description": "Chuyên gia review code. Dùng chủ động sau khi thay đổi code.",
+    "prompt": "You are a senior code reviewer. Focus on code quality, security, and best practices.",
+    "tools": ["Read", "Grep", "Glob", "Bash"],
+    "model": "sonnet"
+  },
+  "debugger": {
+    "description": "Chuyên gia debug cho lỗi và test thất bại.",
+    "prompt": "You are an expert debugger. Analyze errors, identify root causes, and provide fixes.",
+    "tools": ["Read", "Edit", "Bash", "Grep"],
+    "model": "opus"
+  },
+  "documenter": {
+    "description": "Chuyên gia tài liệu để tạo hướng dẫn.",
+    "prompt": "You are a technical writer. Create clear, comprehensive documentation.",
+    "tools": ["Read", "Write"],
+    "model": "haiku"
+  }
+}
+```
+
+### Ví dụ lệnh với Agents
+
+```bash
+# Định nghĩa agents tùy chỉnh trực tiếp
+claude --agents '{
+  "security-auditor": {
+    "description": "Chuyên gia bảo mật để phân tích lỗ hổng",
+    "prompt": "You are a security expert. Find vulnerabilities and suggest fixes.",
+    "tools": ["Read", "Grep", "Glob"],
+    "model": "opus"
+  }
+}' "audit this codebase for security issues"
+
+# Tải agents từ file
+claude --agents "$(cat ~/.claude/agents.json)" "review the auth module"
+
+# Kết hợp với các cờ khác
+claude -p --agents "$(cat agents.json)" --model sonnet "analyze performance"
+```
+
+### Thứ tự ưu tiên Agent
+
+Khi có nhiều định nghĩa agent, chúng được tải theo thứ tự ưu tiên:
+1. **Định nghĩa qua CLI** (`--agents`) — Dành cho phiên hiện tại
+2. **User-level** (`~/.claude/agents/`) — Tất cả projects
+3. **Project-level** (`.claude/agents/`) — Project hiện tại
+
+Agents định nghĩa qua CLI ghi đè cả user lẫn project agents trong phiên đó.
+
+---
+
+## Các trường hợp sử dụng có giá trị cao
+
+### 1. Tích hợp CI/CD
+
+Dùng Claude Code trong CI/CD pipelines để tự động review code, kiểm thử, và tạo tài liệu.
+
+**Ví dụ GitHub Actions:**
+
+```yaml
+name: AI Code Review
+
+on: [pull_request]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Code Review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          claude -p --output-format json \
+            --max-turns 1 \
+            "Review the changes in this PR for:
+            - Security vulnerabilities
+            - Performance issues
+            - Code quality
+            Output as JSON with 'issues' array" > review.json
+
+      - name: Post Review Comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const review = JSON.parse(fs.readFileSync('review.json', 'utf8'));
+            // Xử lý và đăng nhận xét review
+```
+
+**Jenkins Pipeline:**
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('AI Review') {
+            steps {
+                sh '''
+                    claude -p --output-format json \
+                      --max-turns 3 \
+                      "Analyze test coverage and suggest missing tests" \
+                      > coverage-analysis.json
+                '''
+            }
+        }
+    }
+}
+```
+
+### 2. Pipe dữ liệu qua Script
+
+Xử lý file, log, và dữ liệu qua Claude để phân tích.
+
+**Phân tích Log:**
+
+```bash
+# Phân tích error logs
+tail -1000 /var/log/app/error.log | claude -p "summarize these errors and suggest fixes"
+
+# Tìm mẫu trong access logs
+cat access.log | claude -p "identify suspicious access patterns"
+
+# Phân tích lịch sử git
+git log --oneline -50 | claude -p "summarize recent development activity"
+```
+
+**Xử lý Code:**
+
+```bash
+# Review một file cụ thể
+cat src/auth.ts | claude -p "review this authentication code for security issues"
+
+# Tạo tài liệu
+cat src/api/*.ts | claude -p "generate API documentation in markdown"
+
+# Tìm TODOs và ưu tiên hóa
+grep -r "TODO" src/ | claude -p "prioritize these TODOs by importance"
+```
+
+### 3. Workflow Nhiều phiên
+
+Quản lý các dự án phức tạp với nhiều luồng hội thoại.
+
+```bash
+# Bắt đầu phiên cho nhánh tính năng
+claude -r "feature-auth" "let's implement user authentication"
+
+# Sau đó, tiếp tục phiên
+claude -r "feature-auth" "add password reset functionality"
+
+# Fork để thử hướng tiếp cận khác
+claude --resume feature-auth --fork-session "try OAuth instead"
+
+# Chuyển giữa các phiên tính năng khác nhau
+claude -r "feature-payments" "continue with Stripe integration"
+```
+
+### 4. Cấu hình Agent tùy chỉnh
+
+Định nghĩa các agent chuyên biệt cho workflow của nhóm.
+
+```bash
+# Lưu cấu hình agents vào file
+cat > ~/.claude/agents.json << 'EOF'
+{
+  "reviewer": {
+    "description": "Code reviewer cho PR reviews",
+    "prompt": "Review code for quality, security, and maintainability.",
+    "model": "opus"
+  },
+  "documenter": {
+    "description": "Chuyên gia tài liệu",
+    "prompt": "Generate clear, comprehensive documentation.",
+    "model": "sonnet"
+  },
+  "refactorer": {
+    "description": "Chuyên gia refactor code",
+    "prompt": "Suggest and implement clean code refactoring.",
+    "tools": ["Read", "Edit", "Glob"]
+  }
+}
+EOF
+
+# Dùng agents trong phiên
+claude --agents "$(cat ~/.claude/agents.json)" "review the auth module"
+```
+
+### 5. Xử lý hàng loạt
+
+Xử lý nhiều truy vấn với cài đặt nhất quán.
+
+```bash
+# Xử lý nhiều file
+for file in src/*.ts; do
+  echo "Processing $file..."
+  claude -p --model haiku "summarize this file: $(cat $file)" >> summaries.md
+done
+
+# Review code hàng loạt
+find src -name "*.py" -exec sh -c '
+  echo "## $1" >> review.md
+  cat "$1" | claude -p "brief code review" >> review.md
+' _ {} \;
+
+# Tạo tests cho tất cả modules
+for module in $(ls src/modules/); do
+  claude -p "generate unit tests for src/modules/$module" > "tests/$module.test.ts"
+done
+```
+
+### 6. Phát triển có ý thức về Bảo mật
+
+Dùng kiểm soát quyền để vận hành an toàn.
+
+```bash
+# Kiểm tra bảo mật chỉ đọc
+claude --permission-mode plan \
+  --tools "Read,Grep,Glob" \
+  "audit this codebase for security vulnerabilities"
+
+# Chặn các lệnh nguy hiểm
+claude --disallowedTools "Bash(rm:*)" "Bash(curl:*)" "Bash(wget:*)" \
+  "help me clean up this project"
+
+# Tự động hóa giới hạn
+claude -p --max-turns 2 \
+  --allowedTools "Read" "Glob" \
+  "find all hardcoded credentials"
+```
+
+### 7. Tích hợp JSON API
+
+Dùng Claude như một API có thể lập trình được với phân tích `jq`.
+
+```bash
+# Lấy phân tích có cấu trúc
+claude -p --output-format json \
+  --json-schema '{"type":"object","properties":{"functions":{"type":"array"},"complexity":{"type":"string"}}}' \
+  "analyze main.py and return function list with complexity rating"
+
+# Kết hợp với jq để xử lý
+claude -p --output-format json "list all API endpoints" | jq '.endpoints[]'
+
+# Dùng trong scripts
+RESULT=$(claude -p --output-format json "is this code secure? answer with {secure: boolean, issues: []}" < code.py)
+if echo "$RESULT" | jq -e '.secure == false' > /dev/null; then
+  echo "Security issues found!"
+  echo "$RESULT" | jq '.issues[]'
+fi
+```
+
+### Ví dụ phân tích với jq
+
+Phân tích và xử lý đầu ra JSON của Claude bằng `jq`:
+
+```bash
+# Trích xuất các trường cụ thể
+claude -p --output-format json "analyze this code" | jq '.result'
+
+# Lọc các phần tử mảng
+claude -p --output-format json "list issues" | jq -r '.issues[] | select(.severity=="high")'
+
+# Trích xuất nhiều trường
+claude -p --output-format json "describe the project" | jq -r '.{name, version, description}'
+
+# Chuyển đổi sang CSV
+claude -p --output-format json "list functions" | jq -r '.functions[] | [.name, .lineCount] | @csv'
+
+# Xử lý có điều kiện
+claude -p --output-format json "check security" | jq 'if .vulnerabilities | length > 0 then "UNSAFE" else "SAFE" end'
+
+# Trích xuất giá trị lồng nhau
+claude -p --output-format json "analyze performance" | jq '.metrics.cpu.usage'
+
+# Xử lý toàn bộ mảng
+claude -p --output-format json "find todos" | jq '.todos | length'
+
+# Biến đổi đầu ra
+claude -p --output-format json "list improvements" | jq 'map({title: .title, priority: .priority})'
+```
+
+---
+
+## Các Model
+
+Claude Code hỗ trợ nhiều model với các khả năng khác nhau:
+
+| Model | ID | Cửa sổ ngữ cảnh | Ghi chú |
+|-------|-----|----------------|---------|
+| Opus 4.6 | `claude-opus-4-6` | 1M tokens | Mạnh nhất, hỗ trợ các mức độ nỗ lực thích ứng |
+| Sonnet 4.6 | `claude-sonnet-4-6` | 1M tokens | Cân bằng tốc độ và khả năng |
+| Haiku 4.5 | `claude-haiku-4-5` | 1M tokens | Nhanh nhất, phù hợp cho tác vụ đơn giản |
+
+### Chọn Model
+
+```bash
+# Dùng tên ngắn
+claude --model opus "complex architectural review"
+claude --model sonnet "implement this feature"
+claude --model haiku -p "format this JSON"
+
+# Dùng bí danh opusplan (Opus lập kế hoạch, Sonnet thực thi)
+claude --model opusplan "design and implement the API"
+
+# Bật/tắt fast mode trong phiên
+/fast
+```
+
+### Mức độ nỗ lực (Opus 4.6)
+
+Opus 4.6 hỗ trợ suy luận thích ứng với các mức độ nỗ lực:
+
+```bash
+# Đặt mức nỗ lực qua cờ CLI
+claude --effort high "complex review"
+
+# Đặt mức nỗ lực qua slash command
+/effort high
+
+# Đặt mức nỗ lực qua biến môi trường
+export CLAUDE_CODE_EFFORT_LEVEL=high   # low, medium, high, hoặc max (chỉ Opus 4.6)
+```
+
+Từ khóa "ultrathink" trong prompt kích hoạt suy luận sâu. Mức `max` chỉ dành riêng cho Opus 4.6.
+
+---
+
+## Biến môi trường quan trọng
+
+| Biến | Mô tả |
+|------|-------|
+| `ANTHROPIC_API_KEY` | API key để xác thực |
+| `ANTHROPIC_MODEL` | Ghi đè model mặc định |
+| `ANTHROPIC_CUSTOM_MODEL_OPTION` | Tùy chọn model tùy chỉnh cho API |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | Ghi đè ID model Opus mặc định |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Ghi đè ID model Sonnet mặc định |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Ghi đè ID model Haiku mặc định |
+| `MAX_THINKING_TOKENS` | Đặt ngân sách token cho extended thinking |
+| `CLAUDE_CODE_EFFORT_LEVEL` | Đặt mức nỗ lực (`low`/`medium`/`high`/`max`) |
+| `CLAUDE_CODE_SIMPLE` | Chế độ tối giản, được đặt bởi cờ `--bare` |
+| `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | Tắt cập nhật CLAUDE.md tự động |
+| `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` | Tắt thực thi tác vụ nền |
+| `CLAUDE_CODE_DISABLE_CRON` | Tắt tác vụ theo lịch/cron |
+| `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` | Tắt hướng dẫn liên quan đến git |
+| `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` | Tắt cập nhật tiêu đề terminal |
+| `CLAUDE_CODE_DISABLE_1M_CONTEXT` | Tắt cửa sổ ngữ cảnh 1M token |
+| `CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK` | Tắt fallback không streaming |
+| `CLAUDE_CODE_ENABLE_TASKS` | Bật tính năng danh sách tác vụ |
+| `CLAUDE_CODE_TASK_LIST_ID` | Thư mục tác vụ được đặt tên, dùng chung giữa các phiên |
+| `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION` | Bật/tắt gợi ý prompt (`true`/`false`) |
+| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Bật tính năng nhóm agent thử nghiệm |
+| `CLAUDE_CODE_NEW_INIT` | Dùng luồng khởi tạo mới |
+| `CLAUDE_CODE_SUBAGENT_MODEL` | Model cho thực thi subagent |
+| `CLAUDE_CODE_PLUGIN_SEED_DIR` | Thư mục cho plugin seed files |
+| `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` | Biến môi trường cần xóa khỏi subprocess |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Ghi đè phần trăm auto-compaction |
+| `CLAUDE_STREAM_IDLE_TIMEOUT_MS` | Thời gian chờ stream không hoạt động (ms) |
+| `SLASH_COMMAND_TOOL_CHAR_BUDGET` | Ngân sách ký tự cho slash command tools |
+| `ENABLE_TOOL_SEARCH` | Bật khả năng tìm kiếm tool |
+| `MAX_MCP_OUTPUT_TOKENS` | Số token tối đa cho đầu ra MCP tool |
+
+---
+
+## Tham chiếu nhanh
+
+### Các lệnh thường dùng nhất
+
+```bash
+# Phiên tương tác
+claude
+
+# Câu hỏi nhanh
+claude -p "how do I..."
+
+# Tiếp tục hội thoại
+claude -c
+
+# Xử lý một file
+cat file.py | claude -p "review this"
+
+# Đầu ra JSON cho scripts
+claude -p --output-format json "query"
+```
+
+### Tổ hợp cờ theo tình huống
+
+| Tình huống | Lệnh |
+|-----------|------|
+| Review code nhanh | `cat file \| claude -p "review"` |
+| Đầu ra có cấu trúc | `claude -p --output-format json "query"` |
+| Khám phá an toàn | `claude --permission-mode plan` |
+| Tự động với an toàn | `claude --enable-auto-mode --permission-mode auto` |
+| Tích hợp CI/CD | `claude -p --max-turns 3 --output-format json` |
+| Tiếp tục công việc | `claude -r "session-name"` |
+| Model tùy chỉnh | `claude --model opus "complex task"` |
+| Chế độ tối giản | `claude --bare "quick query"` |
+| Chạy có giới hạn ngân sách | `claude -p --max-budget-usd 2.00 "analyze code"` |
+
+---
+
+## Xử lý sự cố
+
+### Lệnh không tìm thấy
+
+**Vấn đề:** `claude: command not found`
+
+**Giải pháp:**
+- Cài Claude Code: `npm install -g @anthropic-ai/claude-code`
+- Kiểm tra PATH có bao gồm thư mục npm global bin
+- Thử chạy với đường dẫn đầy đủ: `npx claude`
+
+### Vấn đề API Key
+
+**Vấn đề:** Xác thực thất bại
+
+**Giải pháp:**
+- Đặt API key: `export ANTHROPIC_API_KEY=your-key`
+- Kiểm tra key còn hợp lệ và có đủ credit
+- Xác nhận key có quyền với model được yêu cầu
+
+### Không tìm thấy Phiên
+
+**Vấn đề:** Không thể tiếp tục phiên
+
+**Giải pháp:**
+- Liệt kê các phiên có sẵn để tìm đúng tên/ID
+- Phiên có thể hết hạn sau thời gian không hoạt động
+- Dùng `-c` để tiếp tục phiên gần nhất
+
+### Vấn đề Định dạng Đầu ra
+
+**Vấn đề:** Đầu ra JSON bị lỗi định dạng
+
+**Giải pháp:**
+- Dùng `--json-schema` để ép cấu trúc
+- Thêm hướng dẫn JSON rõ ràng trong prompt
+- Dùng `--output-format json` (không chỉ yêu cầu JSON trong prompt)
+
+### Bị từ chối quyền
+
+**Vấn đề:** Thực thi tool bị chặn
+
+**Giải pháp:**
+- Kiểm tra cài đặt `--permission-mode`
+- Xem lại cờ `--allowedTools` và `--disallowedTools`
+- Dùng `--dangerously-skip-permissions` cho tự động hóa (cẩn thận)
+
+---
+
+## Tài nguyên bổ sung
+
+- **[Tài liệu CLI chính thức](https://code.claude.com/docs/en/cli-reference)** — Tham chiếu lệnh đầy đủ
+- **[Tài liệu Headless Mode](https://code.claude.com/docs/en/headless)** — Thực thi tự động
+- **[Slash Commands](../01-slash-commands/)** — Lệnh tắt tùy chỉnh trong Claude
+- **[Hướng dẫn Memory](../02-memory/)** — Ngữ cảnh bền vững qua CLAUDE.md
+- **[MCP Protocol](../05-mcp/)** — Tích hợp công cụ bên ngoài
+- **[Advanced Features](../09-advanced-features/)** — Chế độ lập kế hoạch, extended thinking
+- **[Hướng dẫn Subagents](../04-subagents/)** — Thực thi tác vụ được ủy thác
+
+---
+
+*Thuộc chuỗi hướng dẫn [Claude How To](../)*

--- a/LEARNING-ROADMAP.vi.md
+++ b/LEARNING-ROADMAP.vi.md
@@ -154,8 +154,8 @@ cp 02-memory/project-CLAUDE.md ./CLAUDE.md
 
 #### Bước tiếp theo
 Sau khi quen rồi, đọc thêm:
-- [01-slash-commands/README.md](01-slash-commands/README.md)
-- [02-memory/README.md](02-memory/README.md)
+- [01-slash-commands/README.vi.md](01-slash-commands/README.vi.md)
+- [02-memory/README.vi.md](02-memory/README.vi.md)
 
 > **Kiểm tra mức hiểu**: Chạy `/lesson-quiz slash-commands` hoặc `/lesson-quiz memory` trong Claude Code để kiểm tra kiến thức vừa học.
 
@@ -200,8 +200,8 @@ cat error.log | claude -p "explain this error"
 - [ ] Hiểu khi nào nên dùng checkpoint để thử nghiệm an toàn
 
 #### Bước tiếp theo
-- Đọc: [08-checkpoints/README.md](08-checkpoints/README.md)
-- Đọc: [10-cli/README.md](10-cli/README.md)
+- Đọc: [08-checkpoints/README.vi.md](08-checkpoints/README.vi.md)
+- Đọc: [10-cli/README.vi.md](10-cli/README.vi.md)
 - **Sẵn sàng lên Cấp 2!** Tiếp tục với [Milestone 2A](#milestone-2a-tự-động-hóa-skills--hooks)
 
 > **Kiểm tra mức hiểu**: Chạy `/lesson-quiz checkpoints` hoặc `/lesson-quiz cli` để xác nhận bạn sẵn sàng lên Cấp 2.
@@ -282,8 +282,8 @@ chmod +x ~/.claude/hooks/pre-tool-check.sh
 #### Bước tiếp theo
 - Tạo skill tùy chỉnh của riêng bạn
 - Thiết lập thêm hook cho workflow của bạn
-- Đọc: [03-skills/README.md](03-skills/README.md)
-- Đọc: [06-hooks/README.md](06-hooks/README.md)
+- Đọc: [03-skills/README.vi.md](03-skills/README.vi.md)
+- Đọc: [06-hooks/README.vi.md](06-hooks/README.vi.md)
 
 > **Kiểm tra mức hiểu**: Chạy `/lesson-quiz skills` hoặc `/lesson-quiz hooks` trước khi tiếp tục.
 
@@ -334,8 +334,8 @@ Thử workflow hoàn chỉnh này:
 #### Bước tiếp theo
 - Thiết lập thêm MCP server (database, Slack, v.v.)
 - Tạo subagent tùy chỉnh cho lĩnh vực của bạn
-- Đọc: [05-mcp/README.md](05-mcp/README.md)
-- Đọc: [04-subagents/README.md](04-subagents/README.md)
+- Đọc: [05-mcp/README.vi.md](05-mcp/README.vi.md)
+- Đọc: [04-subagents/README.vi.md](04-subagents/README.vi.md)
 - **Sẵn sàng lên Cấp 3!** Tiếp tục với [Milestone 3A](#milestone-3a-tính-năng-nâng-cao)
 
 > **Kiểm tra mức hiểu**: Chạy `/lesson-quiz mcp` hoặc `/lesson-quiz subagents` để xác nhận sẵn sàng lên Cấp 3.
@@ -434,7 +434,7 @@ export CLAUDE_AGENT_TEAMS=1
 - [ ] Đã dùng `/loop` cho tác vụ lặp lại hoặc giám sát định kỳ
 
 #### Bước tiếp theo
-- Đọc: [09-advanced-features/README.md](09-advanced-features/README.md)
+- Đọc: [09-advanced-features/README.vi.md](09-advanced-features/README.vi.md)
 
 > **Kiểm tra mức hiểu**: Chạy `/lesson-quiz advanced` để kiểm tra mức độ thành thạo tính năng power user.
 
@@ -503,8 +503,8 @@ Tạo một CI/CD script đơn giản:
 - **Xử lý dữ liệu**: Chuyển đổi và phân tích data file
 
 #### Bước tiếp theo
-- Đọc: [07-plugins/README.md](07-plugins/README.md)
-- Đọc: [10-cli/README.md](10-cli/README.md)
+- Đọc: [07-plugins/README.vi.md](07-plugins/README.vi.md)
+- Đọc: [10-cli/README.vi.md](10-cli/README.vi.md)
 - Tạo phím tắt CLI và plugin dùng chung cho cả team
 - Thiết lập các batch processing script
 
@@ -538,7 +538,7 @@ Repo này có hai skill tương tác bạn có thể dùng bất kỳ lúc nào 
 
 1. Copy một slash command: `cp 01-slash-commands/optimize.md .claude/commands/`
 2. Thử trong Claude Code: `/optimize`
-3. Đọc: [01-slash-commands/README.md](01-slash-commands/README.md)
+3. Đọc: [01-slash-commands/README.vi.md](01-slash-commands/README.vi.md)
 
 **Kết quả**: Bạn sẽ có một slash command hoạt động và hiểu cơ bản
 

--- a/LEARNING-ROADMAP.vi.md
+++ b/LEARNING-ROADMAP.vi.md
@@ -1,0 +1,757 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+</picture>
+
+# 📚 Lộ trình học Claude Code
+
+**Mới làm quen với Claude Code?** Hướng dẫn này giúp bạn làm chủ từng tính năng theo tốc độ của riêng bạn. Dù bạn là người mới hoàn toàn hay lập trình viên có kinh nghiệm, hãy bắt đầu bằng bài tự đánh giá dưới đây để tìm ra điểm xuất phát phù hợp.
+
+---
+
+## 🧭 Xác định trình độ của bạn
+
+Mỗi người bắt đầu từ một vị trí khác nhau. Làm bài tự đánh giá nhanh này để chọn đúng điểm vào.
+
+**Trả lời thật lòng:**
+
+- [ ] Tôi có thể khởi động Claude Code và chat (`claude`)
+- [ ] Tôi đã tạo hoặc chỉnh sửa file CLAUDE.md
+- [ ] Tôi đã dùng ít nhất 3 slash command có sẵn (ví dụ: /help, /compact, /model)
+- [ ] Tôi đã tạo slash command tùy chỉnh hoặc skill (SKILL.md)
+- [ ] Tôi đã cấu hình một MCP server (ví dụ: GitHub, database)
+- [ ] Tôi đã thiết lập hooks trong ~/.claude/settings.json
+- [ ] Tôi đã tạo hoặc dùng subagent tùy chỉnh (.claude/agents/)
+- [ ] Tôi đã dùng print mode (`claude -p`) cho scripting hoặc CI/CD
+
+**Trình độ của bạn:**
+
+| Số ô đã check | Trình độ | Bắt đầu tại | Thời gian hoàn thành |
+|---------------|---------|-------------|----------------------|
+| 0–2 | **Cấp 1: Người mới** — Làm quen | [Milestone 1A](#milestone-1a-lệnh-đầu-tiên--memory) | ~3 giờ |
+| 3–5 | **Cấp 2: Trung cấp** — Xây dựng Workflow | [Milestone 2A](#milestone-2a-tự-động-hóa-skills--hooks) | ~5 giờ |
+| 6–8 | **Cấp 3: Nâng cao** — Power User & Team Lead | [Milestone 3A](#milestone-3a-tính-năng-nâng-cao) | ~5 giờ |
+
+> **Mẹo**: Nếu bạn không chắc, hãy bắt đầu thấp hơn một cấp. Ôn lại kiến thức đã biết chỉ mất ít thời gian, nhưng bỏ qua nền tảng thì sẽ bị vấp sau này.
+
+> **Phiên bản tương tác**: Chạy `/self-assessment` trong Claude Code để làm quiz có hướng dẫn, chấm điểm kỹ năng trên cả 10 tính năng và tạo lộ trình học cá nhân hóa.
+
+---
+
+## 🎯 Triết lý học tập
+
+Các thư mục trong repo này được đánh số theo **thứ tự học khuyến nghị** dựa trên ba nguyên tắc:
+
+1. **Phụ thuộc** — Các khái niệm nền tảng học trước
+2. **Độ phức tạp** — Tính năng dễ học trước tính năng khó
+3. **Tần suất sử dụng** — Tính năng dùng nhiều nhất học sớm nhất
+
+Cách tiếp cận này giúp bạn xây dựng nền tảng vững chắc trong khi vẫn tăng năng suất ngay lập tức.
+
+---
+
+## 🗺️ Lộ trình học của bạn
+
+```mermaid
+graph TD
+    Q["🧭 Bài tự đánh giá<br/>Xác định trình độ"] --> L1
+    Q --> L2
+    Q --> L3
+
+    subgraph L1["🟢 Cấp 1: Người mới — Làm quen"]
+        direction LR
+        A["1A: Lệnh đầu tiên & Memory<br/>Slash Commands + Memory"] --> B["1B: Khám phá an toàn<br/>Checkpoints + CLI Basics"]
+    end
+
+    subgraph L2["🔵 Cấp 2: Trung cấp — Xây dựng Workflow"]
+        direction LR
+        C["2A: Tự động hóa<br/>Skills + Hooks"] --> D["2B: Tích hợp<br/>MCP + Subagents"]
+    end
+
+    subgraph L3["🔴 Cấp 3: Nâng cao — Power User"]
+        direction LR
+        E["3A: Tính năng nâng cao<br/>Planning + Permissions"] --> F["3B: Team & Phân phối<br/>Plugins + CLI Mastery"]
+    end
+
+    L1 --> L2
+    L2 --> L3
+
+    style Q fill:#6A1B9A,color:#fff,stroke:#9C27B0,stroke-width:2px
+    style A fill:#2E7D32,color:#fff
+    style B fill:#2E7D32,color:#fff
+    style C fill:#1565C0,color:#fff
+    style D fill:#F57C00,color:#fff
+    style E fill:#C62828,color:#fff
+    style F fill:#B71C1C,color:#fff
+```
+
+**Chú thích màu sắc:**
+- 💜 Tím: Bài tự đánh giá
+- 🟢 Xanh lá: Cấp 1 — Người mới
+- 🔵 Xanh dương / 🟡 Vàng: Cấp 2 — Trung cấp
+- 🔴 Đỏ: Cấp 3 — Nâng cao
+
+---
+
+## 📊 Bảng lộ trình đầy đủ
+
+| Bước | Tính năng | Độ khó | Thời gian | Cấp | Yêu cầu trước | Tại sao học | Lợi ích chính |
+|------|-----------|--------|-----------|-----|---------------|-------------|---------------|
+| **1** | [Slash Commands](01-slash-commands/) | ⭐ Người mới | 30 phút | Cấp 1 | Không có | Tăng năng suất ngay (55+ lệnh có sẵn + 5 skill đi kèm) | Tự động hóa tức thì, chuẩn hóa cho team |
+| **2** | [Memory](02-memory/) | ⭐⭐ Người mới+ | 45 phút | Cấp 1 | Không có | Nền tảng cho mọi tính năng khác | Ngữ cảnh lâu dài, lưu tùy chỉnh |
+| **3** | [Checkpoints](08-checkpoints/) | ⭐⭐ Trung cấp | 45 phút | Cấp 1 | Quản lý phiên | Khám phá an toàn | Thử nghiệm, phục hồi |
+| **4** | [CLI Basics](10-cli/) | ⭐⭐ Người mới+ | 30 phút | Cấp 1 | Không có | Dùng CLI cơ bản | Interactive & print mode |
+| **5** | [Skills](03-skills/) | ⭐⭐ Trung cấp | 1 giờ | Cấp 2 | Slash Commands | Kỹ năng tự động kích hoạt | Khả năng tái sử dụng, nhất quán |
+| **6** | [Hooks](06-hooks/) | ⭐⭐ Trung cấp | 1 giờ | Cấp 2 | Tools, Commands | Tự động hóa workflow (25 sự kiện, 4 loại) | Kiểm tra, cổng kiểm soát chất lượng |
+| **7** | [MCP](05-mcp/) | ⭐⭐⭐ Trung cấp+ | 1 giờ | Cấp 2 | Cấu hình | Truy cập dữ liệu thời gian thực | Tích hợp real-time, APIs |
+| **8** | [Subagents](04-subagents/) | ⭐⭐⭐ Trung cấp+ | 1.5 giờ | Cấp 2 | Memory, Commands | Xử lý nhiệm vụ phức tạp (6 agent có sẵn gồm Bash) | Ủy quyền, chuyên môn hóa |
+| **9** | [Advanced Features](09-advanced-features/) | ⭐⭐⭐⭐⭐ Nâng cao | 2–3 giờ | Cấp 3 | Tất cả phần trước | Công cụ power user | Planning, Auto Mode, Channels, Voice Dictation, permissions |
+| **10** | [Plugins](07-plugins/) | ⭐⭐⭐⭐ Nâng cao | 2 giờ | Cấp 3 | Tất cả phần trước | Giải pháp hoàn chỉnh | Onboarding team, phân phối |
+| **11** | [CLI Mastery](10-cli/) | ⭐⭐⭐ Nâng cao | 1 giờ | Cấp 3 | Khuyến nghị: Tất cả | Thành thạo command-line | Scripting, CI/CD, tự động hóa |
+
+**Tổng thời gian học**: ~11–13 giờ (hoặc nhảy thẳng vào cấp của bạn để tiết kiệm thời gian)
+
+---
+
+## 🟢 Cấp 1: Người mới — Làm quen
+
+**Dành cho**: Người check được 0–2 ô
+**Thời gian**: ~3 giờ
+**Trọng tâm**: Tăng năng suất ngay, hiểu các khái niệm căn bản
+**Kết quả**: Dùng thoải mái hàng ngày, sẵn sàng lên Cấp 2
+
+### Milestone 1A: Lệnh đầu tiên & Memory
+
+**Chủ đề**: Slash Commands + Memory
+**Thời gian**: 1–2 giờ
+**Độ khó**: ⭐ Người mới
+**Mục tiêu**: Tăng năng suất ngay với lệnh tùy chỉnh và ngữ cảnh lâu dài
+
+#### Bạn sẽ đạt được gì
+✅ Tạo slash command tùy chỉnh cho các việc lặp đi lặp lại
+✅ Thiết lập project memory để lưu chuẩn của team
+✅ Cấu hình tùy chỉnh cá nhân
+✅ Hiểu cách Claude tự động tải ngữ cảnh
+
+#### Bài tập thực hành
+
+```bash
+# Bài tập 1: Cài slash command đầu tiên
+mkdir -p .claude/commands
+cp 01-slash-commands/optimize.md .claude/commands/
+
+# Bài tập 2: Tạo project memory
+cp 02-memory/project-CLAUDE.md ./CLAUDE.md
+
+# Bài tập 3: Thử dùng
+# Trong Claude Code, gõ: /optimize
+```
+
+#### Tiêu chí hoàn thành
+- [ ] Gọi thành công lệnh `/optimize`
+- [ ] Claude nhớ chuẩn dự án của bạn từ CLAUDE.md
+- [ ] Bạn hiểu khi nào dùng slash commands, khi nào dùng memory
+
+#### Bước tiếp theo
+Sau khi quen rồi, đọc thêm:
+- [01-slash-commands/README.md](01-slash-commands/README.md)
+- [02-memory/README.md](02-memory/README.md)
+
+> **Kiểm tra mức hiểu**: Chạy `/lesson-quiz slash-commands` hoặc `/lesson-quiz memory` trong Claude Code để kiểm tra kiến thức vừa học.
+
+---
+
+### Milestone 1B: Khám phá an toàn
+
+**Chủ đề**: Checkpoints + CLI Basics
+**Thời gian**: 1 giờ
+**Độ khó**: ⭐⭐ Người mới+
+**Mục tiêu**: Học cách thử nghiệm an toàn và dùng các lệnh CLI cơ bản
+
+> **Ghi chú**: Checkpoints giống như nút "lưu game" — bạn có thể thử nghiệm mạnh tay mà không sợ mất dữ liệu, vì có thể quay lại bất kỳ lúc nào.
+
+#### Bạn sẽ đạt được gì
+✅ Tạo và khôi phục checkpoint để thử nghiệm an toàn
+✅ Hiểu sự khác biệt giữa interactive mode và print mode
+✅ Dùng các flags và tùy chọn CLI cơ bản
+✅ Xử lý file qua piping (truyền nội dung file vào Claude)
+
+#### Bài tập thực hành
+
+```bash
+# Bài tập 1: Thực hành checkpoint
+# Trong Claude Code:
+# Thực hiện một số thay đổi thử nghiệm, rồi nhấn Esc+Esc hoặc dùng /rewind
+# Chọn checkpoint trước khi thử nghiệm
+# Chọn "Restore code and conversation" để quay lại
+
+# Bài tập 2: Interactive vs Print mode
+claude "explain this project"           # Interactive mode — có hội thoại
+claude -p "explain this function"       # Print mode — chỉ in kết quả, không hội thoại
+
+# Bài tập 3: Truyền nội dung file vào Claude (piping)
+cat error.log | claude -p "explain this error"
+```
+
+#### Tiêu chí hoàn thành
+- [ ] Đã tạo và quay lại một checkpoint
+- [ ] Đã dùng cả interactive mode và print mode
+- [ ] Đã pipe một file để Claude phân tích
+- [ ] Hiểu khi nào nên dùng checkpoint để thử nghiệm an toàn
+
+#### Bước tiếp theo
+- Đọc: [08-checkpoints/README.md](08-checkpoints/README.md)
+- Đọc: [10-cli/README.md](10-cli/README.md)
+- **Sẵn sàng lên Cấp 2!** Tiếp tục với [Milestone 2A](#milestone-2a-tự-động-hóa-skills--hooks)
+
+> **Kiểm tra mức hiểu**: Chạy `/lesson-quiz checkpoints` hoặc `/lesson-quiz cli` để xác nhận bạn sẵn sàng lên Cấp 2.
+
+---
+
+## 🔵 Cấp 2: Trung cấp — Xây dựng Workflow
+
+**Dành cho**: Người check được 3–5 ô
+**Thời gian**: ~5 giờ
+**Trọng tâm**: Tự động hóa, tích hợp, ủy quyền nhiệm vụ
+**Kết quả**: Workflow tự động, tích hợp dịch vụ ngoài, sẵn sàng lên Cấp 3
+
+### Kiểm tra điều kiện tiên quyết
+
+Trước khi bắt đầu Cấp 2, hãy đảm bảo bạn đã nắm vững các khái niệm Cấp 1:
+
+- [ ] Có thể tạo và dùng slash commands ([01-slash-commands/](01-slash-commands/))
+- [ ] Đã thiết lập project memory qua CLAUDE.md ([02-memory/](02-memory/))
+- [ ] Biết cách tạo và khôi phục checkpoint ([08-checkpoints/](08-checkpoints/))
+- [ ] Có thể dùng `claude` và `claude -p` từ command line ([10-cli/](10-cli/))
+
+> **Còn thiếu?** Xem lại các hướng dẫn được liên kết ở trên trước khi tiếp tục.
+
+---
+
+### Milestone 2A: Tự động hóa (Skills + Hooks)
+
+**Chủ đề**: Skills + Hooks
+**Thời gian**: 2–3 giờ
+**Độ khó**: ⭐⭐ Trung cấp
+**Mục tiêu**: Tự động hóa các workflow thông thường và kiểm soát chất lượng
+
+> **Ghi chú**: Skills là "kỹ năng" bạn trang bị cho Claude — cài một lần, Claude tự biết khi nào nên dùng. Hooks là "bẫy sự kiện" — mỗi khi có điều gì đó xảy ra (như Claude chuẩn bị chạy lệnh), hook tự động kích hoạt.
+
+#### Bạn sẽ đạt được gì
+✅ Tự động kích hoạt khả năng chuyên biệt với YAML frontmatter (bao gồm các trường `effort` và `shell`)
+✅ Thiết lập tự động hóa theo sự kiện với 25 loại hook event
+✅ Dùng cả 4 loại hook (command, http, prompt, agent)
+✅ Áp dụng chuẩn chất lượng code tự động
+✅ Tạo hook tùy chỉnh cho workflow của bạn
+
+#### Bài tập thực hành
+
+```bash
+# Bài tập 1: Cài một skill
+cp -r 03-skills/code-review ~/.claude/skills/
+
+# Bài tập 2: Thiết lập hook
+mkdir -p ~/.claude/hooks
+cp 06-hooks/pre-tool-check.sh ~/.claude/hooks/
+chmod +x ~/.claude/hooks/pre-tool-check.sh
+
+# Bài tập 3: Cấu hình hook trong settings
+# Thêm vào ~/.claude/settings.json:
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pre-tool-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Tiêu chí hoàn thành
+- [ ] Skill code review tự động kích hoạt khi phù hợp
+- [ ] Hook PreToolUse chạy trước khi tool thực thi
+- [ ] Bạn hiểu sự khác nhau giữa skill auto-invocation và hook event trigger
+
+#### Bước tiếp theo
+- Tạo skill tùy chỉnh của riêng bạn
+- Thiết lập thêm hook cho workflow của bạn
+- Đọc: [03-skills/README.md](03-skills/README.md)
+- Đọc: [06-hooks/README.md](06-hooks/README.md)
+
+> **Kiểm tra mức hiểu**: Chạy `/lesson-quiz skills` hoặc `/lesson-quiz hooks` trước khi tiếp tục.
+
+---
+
+### Milestone 2B: Tích hợp (MCP + Subagents)
+
+**Chủ đề**: MCP + Subagents
+**Thời gian**: 2–3 giờ
+**Độ khó**: ⭐⭐⭐ Trung cấp+
+**Mục tiêu**: Kết nối dịch vụ bên ngoài và ủy quyền nhiệm vụ phức tạp
+
+> **Ghi chú**: MCP (Model Context Protocol) là cầu nối cho phép Claude lấy dữ liệu thực từ GitHub, database, API... Subagents là "nhân viên" chuyên biệt — Claude chính sẽ giao việc cho họ thay vì tự làm một mình.
+
+#### Bạn sẽ đạt được gì
+✅ Truy cập dữ liệu thời gian thực từ GitHub, database, v.v.
+✅ Ủy quyền công việc cho AI agent chuyên biệt
+✅ Hiểu khi nào dùng MCP, khi nào dùng subagent
+✅ Xây dựng workflow tích hợp hoàn chỉnh
+
+#### Bài tập thực hành
+
+```bash
+# Bài tập 1: Thiết lập GitHub MCP
+export GITHUB_TOKEN="your_github_token"
+claude mcp add github -- npx -y @modelcontextprotocol/server-github
+
+# Bài tập 2: Kiểm tra MCP integration
+# Trong Claude Code: /mcp__github__list_prs
+
+# Bài tập 3: Cài subagents
+mkdir -p .claude/agents
+cp 04-subagents/*.md .claude/agents/
+```
+
+#### Bài tập tích hợp
+Thử workflow hoàn chỉnh này:
+1. Dùng MCP để lấy một GitHub PR
+2. Để Claude ủy quyền review cho subagent code-reviewer
+3. Dùng hooks để tự động chạy tests
+
+#### Tiêu chí hoàn thành
+- [ ] Truy vấn thành công dữ liệu GitHub qua MCP
+- [ ] Claude ủy quyền nhiệm vụ phức tạp cho subagent
+- [ ] Bạn hiểu sự khác biệt giữa MCP và subagent
+- [ ] Đã kết hợp MCP + subagent + hooks trong một workflow
+
+#### Bước tiếp theo
+- Thiết lập thêm MCP server (database, Slack, v.v.)
+- Tạo subagent tùy chỉnh cho lĩnh vực của bạn
+- Đọc: [05-mcp/README.md](05-mcp/README.md)
+- Đọc: [04-subagents/README.md](04-subagents/README.md)
+- **Sẵn sàng lên Cấp 3!** Tiếp tục với [Milestone 3A](#milestone-3a-tính-năng-nâng-cao)
+
+> **Kiểm tra mức hiểu**: Chạy `/lesson-quiz mcp` hoặc `/lesson-quiz subagents` để xác nhận sẵn sàng lên Cấp 3.
+
+---
+
+## 🔴 Cấp 3: Nâng cao — Power User & Team Lead
+
+**Dành cho**: Người check được 6–8 ô
+**Thời gian**: ~5 giờ
+**Trọng tâm**: Công cụ cho team, CI/CD, tính năng doanh nghiệp, phát triển plugin
+**Kết quả**: Power user, có thể thiết lập workflow cho cả team và tích hợp CI/CD
+
+### Kiểm tra điều kiện tiên quyết
+
+Trước khi bắt đầu Cấp 3, hãy đảm bảo bạn nắm vững các khái niệm Cấp 2:
+
+- [ ] Có thể tạo và dùng skills với auto-invocation ([03-skills/](03-skills/))
+- [ ] Đã thiết lập hooks cho tự động hóa theo sự kiện ([06-hooks/](06-hooks/))
+- [ ] Có thể cấu hình MCP server để truy cập dữ liệu ngoài ([05-mcp/](05-mcp/))
+- [ ] Biết cách dùng subagent để ủy quyền nhiệm vụ ([04-subagents/](04-subagents/))
+
+> **Còn thiếu?** Xem lại các hướng dẫn được liên kết ở trên trước khi tiếp tục.
+
+---
+
+### Milestone 3A: Tính năng nâng cao
+
+**Chủ đề**: Advanced Features (Planning, Permissions, Extended Thinking, Auto Mode, Channels, Voice Dictation, Remote/Desktop/Web)
+**Thời gian**: 2–3 giờ
+**Độ khó**: ⭐⭐⭐⭐⭐ Nâng cao
+**Mục tiêu**: Làm chủ workflow nâng cao và công cụ power user
+
+#### Bạn sẽ đạt được gì
+✅ Planning mode cho các tính năng phức tạp (lập kế hoạch trước khi thực thi)
+✅ Kiểm soát quyền chi tiết với 6 chế độ (default, acceptEdits, plan, auto, dontAsk, bypassPermissions)
+✅ Extended thinking qua phím tắt Alt+T / Option+T
+✅ Quản lý background task (tác vụ chạy nền)
+✅ Auto Memory — Claude tự học từ thói quen của bạn
+✅ Auto Mode với bộ phân loại an toàn chạy nền
+✅ Channels để tổ chức workflow đa phiên có cấu trúc
+✅ Voice Dictation — nhập liệu bằng giọng nói
+✅ Remote control, desktop app và web session
+✅ Agent Teams để nhiều agent cộng tác với nhau
+
+#### Bài tập thực hành
+
+```bash
+# Bài tập 1: Dùng planning mode
+/plan Implement user authentication system
+
+# Bài tập 2: Thử các permission mode (6 loại: default, acceptEdits, plan, auto, dontAsk, bypassPermissions)
+claude --permission-mode plan "analyze this codebase"
+claude --permission-mode acceptEdits "refactor the auth module"
+claude --permission-mode auto "implement the feature"
+
+# Bài tập 3: Bật extended thinking
+# Nhấn Alt+T (Option+T trên macOS) trong phiên làm việc để bật/tắt
+
+# Bài tập 4: Workflow checkpoint nâng cao
+# 1. Tạo checkpoint "Clean state"
+# 2. Dùng planning mode để thiết kế tính năng
+# 3. Triển khai với subagent delegation
+# 4. Chạy tests trong background
+# 5. Nếu tests thất bại, tua lại checkpoint
+# 6. Thử hướng tiếp cận khác
+
+# Bài tập 5: Thử auto mode (có bộ phân loại an toàn nền)
+claude --permission-mode auto "implement user settings page"
+
+# Bài tập 6: Bật agent teams
+export CLAUDE_AGENT_TEAMS=1
+# Hỏi Claude: "Implement feature X using a team approach"
+
+# Bài tập 7: Tác vụ theo lịch
+/loop 5m /check-status
+# Hoặc dùng CronCreate cho tác vụ lặp lâu dài
+
+# Bài tập 8: Channels cho workflow đa phiên
+# Dùng channels để tổ chức công việc xuyên phiên
+
+# Bài tập 9: Voice Dictation
+# Dùng giọng nói để tương tác tay-free với Claude Code
+```
+
+#### Tiêu chí hoàn thành
+- [ ] Đã dùng planning mode cho một tính năng phức tạp
+- [ ] Đã cấu hình permission mode (plan, acceptEdits, auto, dontAsk)
+- [ ] Đã bật/tắt extended thinking bằng Alt+T / Option+T
+- [ ] Đã dùng auto mode với background safety classifier
+- [ ] Đã dùng background task cho tác vụ chạy lâu
+- [ ] Đã khám phá Channels cho workflow đa phiên
+- [ ] Đã thử Voice Dictation nhập liệu không cần tay
+- [ ] Hiểu Remote Control, Desktop App và Web sessions
+- [ ] Đã bật và dùng Agent Teams cho tác vụ cộng tác
+- [ ] Đã dùng `/loop` cho tác vụ lặp lại hoặc giám sát định kỳ
+
+#### Bước tiếp theo
+- Đọc: [09-advanced-features/README.md](09-advanced-features/README.md)
+
+> **Kiểm tra mức hiểu**: Chạy `/lesson-quiz advanced` để kiểm tra mức độ thành thạo tính năng power user.
+
+---
+
+### Milestone 3B: Team & Phân phối (Plugins + CLI Mastery)
+
+**Chủ đề**: Plugins + CLI Mastery + CI/CD
+**Thời gian**: 2–3 giờ
+**Độ khó**: ⭐⭐⭐⭐ Nâng cao
+**Mục tiêu**: Xây dựng công cụ cho team, tạo plugin, thành thạo tích hợp CI/CD
+
+#### Bạn sẽ đạt được gì
+✅ Cài đặt và tạo plugin đóng gói hoàn chỉnh
+✅ Thành thạo CLI cho scripting và tự động hóa
+✅ Thiết lập tích hợp CI/CD với `claude -p`
+✅ Xuất JSON output cho pipeline tự động
+✅ Quản lý phiên và xử lý batch
+
+#### Bài tập thực hành
+
+```bash
+# Bài tập 1: Cài một plugin hoàn chỉnh
+# Trong Claude Code: /plugin install pr-review
+
+# Bài tập 2: Print mode cho CI/CD
+claude -p "Run all tests and generate report"
+
+# Bài tập 3: JSON output cho scripts
+claude -p --output-format json "list all functions"
+
+# Bài tập 4: Quản lý và tiếp tục phiên
+claude -r "feature-auth" "continue implementation"
+
+# Bài tập 5: Tích hợp CI/CD với giới hạn
+claude -p --max-turns 3 --output-format json "review code"
+
+# Bài tập 6: Xử lý batch
+for file in *.md; do
+  claude -p --output-format json "summarize this: $(cat $file)" > ${file%.md}.summary.json
+done
+```
+
+#### Bài tập tích hợp CI/CD
+Tạo một CI/CD script đơn giản:
+1. Dùng `claude -p` để review các file đã thay đổi
+2. Xuất kết quả dạng JSON
+3. Xử lý với `jq` để lọc các vấn đề cụ thể
+4. Tích hợp vào GitHub Actions workflow
+
+#### Tiêu chí hoàn thành
+- [ ] Đã cài và dùng một plugin
+- [ ] Đã xây dựng hoặc chỉnh sửa plugin cho team
+- [ ] Đã dùng print mode (`claude -p`) trong CI/CD
+- [ ] Đã tạo JSON output cho scripting
+- [ ] Đã tiếp tục thành công một phiên trước đó
+- [ ] Đã tạo batch processing script
+- [ ] Đã tích hợp Claude vào CI/CD workflow
+
+#### Các trường hợp thực tế khi dùng CLI
+- **Tự động hóa Code Review**: Chạy code review trong CI/CD pipeline
+- **Phân tích Log**: Phân tích error log và system output
+- **Tạo tài liệu hàng loạt**: Tạo tài liệu theo batch
+- **Insights từ Tests**: Phân tích test failures
+- **Phân tích hiệu năng**: Xem xét performance metrics
+- **Xử lý dữ liệu**: Chuyển đổi và phân tích data file
+
+#### Bước tiếp theo
+- Đọc: [07-plugins/README.md](07-plugins/README.md)
+- Đọc: [10-cli/README.md](10-cli/README.md)
+- Tạo phím tắt CLI và plugin dùng chung cho cả team
+- Thiết lập các batch processing script
+
+> **Kiểm tra mức hiểu**: Chạy `/lesson-quiz plugins` hoặc `/lesson-quiz cli` để xác nhận mức độ thành thạo.
+
+---
+
+## 🧪 Kiểm tra kiến thức
+
+Repo này có hai skill tương tác bạn có thể dùng bất kỳ lúc nào trong Claude Code để tự đánh giá:
+
+| Skill | Lệnh | Mục đích |
+|-------|------|---------|
+| **Self-Assessment** | `/self-assessment` | Đánh giá toàn diện kỹ năng trên cả 10 tính năng. Chọn Quick (2 phút) hoặc Deep (5 phút) để nhận hồ sơ kỹ năng và lộ trình học cá nhân hóa. |
+| **Lesson Quiz** | `/lesson-quiz [bài học]` | Kiểm tra hiểu biết về một bài học cụ thể với 10 câu hỏi. Dùng trước bài học (pre-test), trong khi học (kiểm tra tiến độ), hoặc sau khi học (xác nhận đã nắm). |
+
+**Ví dụ:**
+```
+/self-assessment                  # Xác định trình độ tổng thể
+/lesson-quiz hooks                # Quiz bài 06: Hooks
+/lesson-quiz 03                   # Quiz bài 03: Skills
+/lesson-quiz advanced-features    # Quiz bài 09
+```
+
+---
+
+## ⚡ Lộ trình bắt đầu nhanh
+
+### Nếu bạn chỉ có 15 phút
+**Mục tiêu**: Có kết quả đầu tiên ngay
+
+1. Copy một slash command: `cp 01-slash-commands/optimize.md .claude/commands/`
+2. Thử trong Claude Code: `/optimize`
+3. Đọc: [01-slash-commands/README.md](01-slash-commands/README.md)
+
+**Kết quả**: Bạn sẽ có một slash command hoạt động và hiểu cơ bản
+
+---
+
+### Nếu bạn có 1 giờ
+**Mục tiêu**: Thiết lập công cụ năng suất thiết yếu
+
+1. **Slash commands** (15 phút): Copy và thử `/optimize` và `/pr`
+2. **Project memory** (15 phút): Tạo CLAUDE.md với chuẩn dự án của bạn
+3. **Cài một skill** (15 phút): Thiết lập skill code-review
+4. **Thử kết hợp chúng** (15 phút): Xem cách chúng hoạt động hài hòa với nhau
+
+**Kết quả**: Tăng năng suất cơ bản với lệnh, memory và skill tự động
+
+---
+
+### Nếu bạn có một cuối tuần
+**Mục tiêu**: Thành thạo hầu hết các tính năng
+
+**Sáng thứ Bảy** (3 giờ):
+- Hoàn thành Milestone 1A: Slash Commands + Memory
+- Hoàn thành Milestone 1B: Checkpoints + CLI Basics
+
+**Chiều thứ Bảy** (3 giờ):
+- Hoàn thành Milestone 2A: Skills + Hooks
+- Hoàn thành Milestone 2B: MCP + Subagents
+
+**Chủ Nhật** (4 giờ):
+- Hoàn thành Milestone 3A: Advanced Features
+- Hoàn thành Milestone 3B: Plugins + CLI Mastery + CI/CD
+- Xây dựng một plugin tùy chỉnh cho team của bạn
+
+**Kết quả**: Bạn sẽ là Claude Code power user, sẵn sàng đào tạo người khác và tự động hóa workflow phức tạp
+
+---
+
+## 💡 Mẹo học tập
+
+### ✅ Nên làm
+
+- **Làm quiz trước** để xác định điểm xuất phát
+- **Hoàn thành bài tập thực hành** cho mỗi milestone
+- **Bắt đầu đơn giản** rồi dần thêm độ phức tạp
+- **Kiểm tra từng tính năng** trước khi học tính năng tiếp theo
+- **Ghi chú** những gì phù hợp với workflow của bạn
+- **Quay lại** các khái niệm trước khi học chủ đề nâng cao
+- **Thử nghiệm an toàn** bằng cách dùng checkpoints
+- **Chia sẻ kiến thức** với team của bạn
+
+### ❌ Không nên làm
+
+- **Bỏ qua kiểm tra điều kiện tiên quyết** khi nhảy lên cấp cao hơn
+- **Cố học tất cả cùng một lúc** — sẽ bị quá tải
+- **Copy config mà không hiểu** — bạn sẽ không biết debug khi có vấn đề
+- **Quên kiểm tra** — luôn xác nhận tính năng hoạt động đúng
+- **Vội vàng qua các milestone** — dành thời gian để hiểu thật sự
+- **Bỏ qua tài liệu** — mỗi README đều có thông tin quan trọng
+- **Làm việc một mình** — thảo luận với đồng nghiệp
+
+---
+
+## 🎓 Phong cách học tập
+
+### Người học qua hình ảnh
+- Nghiên cứu kỹ các sơ đồ Mermaid trong từng README
+- Quan sát luồng thực thi lệnh
+- Tự vẽ sơ đồ workflow của bạn
+- Dùng lộ trình học trực quan ở trên
+
+### Người học qua thực hành
+- Hoàn thành mọi bài tập thực hành
+- Thử nghiệm các biến thể
+- Làm hỏng rồi sửa (dùng checkpoints!)
+- Tự tạo ví dụ của riêng bạn
+
+### Người học qua đọc
+- Đọc kỹ từng README
+- Nghiên cứu các đoạn code ví dụ
+- Xem xét các bảng so sánh
+- Đọc các bài blog được liên kết trong resources
+
+### Người học qua tương tác xã hội
+- Lập các buổi pair programming
+- Giải thích khái niệm cho đồng đội
+- Tham gia thảo luận cộng đồng Claude Code
+- Chia sẻ cấu hình tùy chỉnh của bạn
+
+---
+
+## 📈 Theo dõi tiến độ
+
+Dùng các checklist này để theo dõi tiến độ theo cấp. Chạy `/self-assessment` bất kỳ lúc nào để nhận hồ sơ kỹ năng cập nhật, hoặc `/lesson-quiz [bài học]` sau mỗi tutorial để xác nhận mức hiểu.
+
+### 🟢 Cấp 1: Người mới
+- [ ] Hoàn thành [01-slash-commands](01-slash-commands/)
+- [ ] Hoàn thành [02-memory](02-memory/)
+- [ ] Đã tạo slash command tùy chỉnh đầu tiên
+- [ ] Đã thiết lập project memory
+- [ ] **Milestone 1A đạt được**
+- [ ] Hoàn thành [08-checkpoints](08-checkpoints/)
+- [ ] Hoàn thành cơ bản [10-cli](10-cli/)
+- [ ] Đã tạo và quay lại checkpoint
+- [ ] Đã dùng interactive mode và print mode
+- [ ] **Milestone 1B đạt được**
+
+### 🔵 Cấp 2: Trung cấp
+- [ ] Hoàn thành [03-skills](03-skills/)
+- [ ] Hoàn thành [06-hooks](06-hooks/)
+- [ ] Đã cài skill đầu tiên
+- [ ] Đã thiết lập PreToolUse hook
+- [ ] **Milestone 2A đạt được**
+- [ ] Hoàn thành [05-mcp](05-mcp/)
+- [ ] Hoàn thành [04-subagents](04-subagents/)
+- [ ] Đã kết nối GitHub MCP
+- [ ] Đã tạo subagent tùy chỉnh
+- [ ] Đã kết hợp các tích hợp trong một workflow
+- [ ] **Milestone 2B đạt được**
+
+### 🔴 Cấp 3: Nâng cao
+- [ ] Hoàn thành [09-advanced-features](09-advanced-features/)
+- [ ] Đã dùng planning mode thành công
+- [ ] Đã cấu hình permission mode (6 chế độ kể cả auto)
+- [ ] Đã dùng auto mode với safety classifier
+- [ ] Đã dùng extended thinking toggle
+- [ ] Đã khám phá Channels và Voice Dictation
+- [ ] **Milestone 3A đạt được**
+- [ ] Hoàn thành [07-plugins](07-plugins/)
+- [ ] Hoàn thành [10-cli](10-cli/) nâng cao
+- [ ] Đã thiết lập print mode (`claude -p`) CI/CD
+- [ ] Đã tạo JSON output cho tự động hóa
+- [ ] Đã tích hợp Claude vào CI/CD pipeline
+- [ ] Đã tạo plugin cho team
+- [ ] **Milestone 3B đạt được**
+
+---
+
+## 🆘 Các thách thức học tập thường gặp
+
+### Thách thức 1: "Quá nhiều khái niệm cùng một lúc"
+**Giải pháp**: Tập trung vào một milestone tại một thời điểm. Hoàn thành tất cả bài tập trước khi tiến lên.
+
+### Thách thức 2: "Không biết nên dùng tính năng nào khi nào"
+**Giải pháp**: Tham khảo bảng [So sánh tính năng](README.vi.md) trong README để hiểu sự khác biệt.
+
+### Thách thức 3: "Cấu hình không hoạt động"
+**Giải pháp**: Kiểm tra phần Troubleshooting và xác nhận lại vị trí file.
+
+### Thách thức 4: "Các khái niệm có vẻ chồng chéo nhau"
+**Giải pháp**: Xem lại bảng So sánh tính năng để hiểu rõ sự khác biệt.
+
+### Thách thức 5: "Khó nhớ mọi thứ"
+**Giải pháp**: Tạo cheat sheet của riêng bạn. Dùng checkpoints để thử nghiệm an toàn.
+
+### Thách thức 6: "Tôi có kinh nghiệm nhưng không biết bắt đầu từ đâu"
+**Giải pháp**: Làm [bài Tự đánh giá](#-xác-định-trình-độ-của-bạn) ở trên. Nhảy thẳng vào cấp của bạn và dùng phần kiểm tra điều kiện tiên quyết để xác định còn thiếu gì.
+
+---
+
+## 🎯 Làm gì sau khi hoàn thành?
+
+Sau khi hoàn thành tất cả các milestone:
+
+1. **Tạo tài liệu cho team** — Ghi lại cách team bạn cài đặt Claude Code
+2. **Xây dựng plugin tùy chỉnh** — Đóng gói workflow của team
+3. **Khám phá Remote Control** — Điều khiển phiên Claude Code lập trình từ công cụ bên ngoài
+4. **Thử Web Sessions** — Dùng Claude Code qua giao diện browser cho remote development
+5. **Dùng Desktop App** — Truy cập tính năng Claude Code qua ứng dụng desktop native
+6. **Dùng Auto Mode** — Để Claude làm việc tự động với background safety classifier
+7. **Tận dụng Auto Memory** — Để Claude tự học từ thói quen của bạn
+8. **Thiết lập Agent Teams** — Điều phối nhiều agent cho các nhiệm vụ phức tạp, đa mặt
+9. **Dùng Channels** — Tổ chức công việc qua các workflow đa phiên có cấu trúc
+10. **Thử Voice Dictation** — Dùng giọng nói tay-free để tương tác với Claude Code
+11. **Dùng Scheduled Tasks** — Tự động hóa các kiểm tra định kỳ với `/loop` và cron tools
+12. **Đóng góp ví dụ** — Chia sẻ với cộng đồng
+13. **Hướng dẫn người khác** — Giúp đồng đội học
+14. **Tối ưu workflow** — Liên tục cải thiện dựa trên kinh nghiệm thực tế
+15. **Cập nhật thường xuyên** — Theo dõi các bản phát hành và tính năng mới của Claude Code
+
+---
+
+## 📚 Tài nguyên bổ sung
+
+### Tài liệu chính thức
+- [Claude Code Documentation](https://code.claude.com/docs/en/overview)
+- [Anthropic Documentation](https://docs.anthropic.com)
+- [MCP Protocol Specification](https://modelcontextprotocol.io)
+
+### Blog Posts
+- [Discovering Claude Code Slash Commands](https://medium.com/@luongnv89/discovering-claude-code-slash-commands-cdc17f0dfb29)
+
+### Cộng đồng
+- [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook)
+- [MCP Servers Repository](https://github.com/modelcontextprotocol/servers)
+
+---
+
+## 💬 Phản hồi & Hỗ trợ
+
+- **Phát hiện lỗi?** Tạo issue trong repository
+- **Có góp ý?** Gửi pull request
+- **Cần giúp đỡ?** Xem tài liệu hoặc hỏi cộng đồng
+
+---
+
+**Cập nhật lần cuối**: Tháng 3/2026
+**Duy trì bởi**: Claude How-To Contributors
+**Giấy phép**: Dùng cho mục đích giáo dục, miễn phí sử dụng và chỉnh sửa
+
+---
+
+[← Quay lại README chính](README.vi.md)
+
+---
+
+> **Ghi chú cho bản dịch tiếng Việt:** File này được dịch bởi cộng đồng. Bản gốc tiếng Anh luôn là nguồn chính xác nhất: [LEARNING-ROADMAP.md](LEARNING-ROADMAP.md).

--- a/LEARNING-ROADMAP.vi.md
+++ b/LEARNING-ROADMAP.vi.md
@@ -97,17 +97,17 @@ graph TD
 
 | Bước | Tính năng | Độ khó | Thời gian | Cấp | Yêu cầu trước | Tại sao học | Lợi ích chính |
 |------|-----------|--------|-----------|-----|---------------|-------------|---------------|
-| **1** | [Slash Commands](01-slash-commands/) | ⭐ Người mới | 30 phút | Cấp 1 | Không có | Tăng năng suất ngay (55+ lệnh có sẵn + 5 skill đi kèm) | Tự động hóa tức thì, chuẩn hóa cho team |
-| **2** | [Memory](02-memory/) | ⭐⭐ Người mới+ | 45 phút | Cấp 1 | Không có | Nền tảng cho mọi tính năng khác | Ngữ cảnh lâu dài, lưu tùy chỉnh |
-| **3** | [Checkpoints](08-checkpoints/) | ⭐⭐ Trung cấp | 45 phút | Cấp 1 | Quản lý phiên | Khám phá an toàn | Thử nghiệm, phục hồi |
-| **4** | [CLI Basics](10-cli/) | ⭐⭐ Người mới+ | 30 phút | Cấp 1 | Không có | Dùng CLI cơ bản | Interactive & print mode |
-| **5** | [Skills](03-skills/) | ⭐⭐ Trung cấp | 1 giờ | Cấp 2 | Slash Commands | Kỹ năng tự động kích hoạt | Khả năng tái sử dụng, nhất quán |
-| **6** | [Hooks](06-hooks/) | ⭐⭐ Trung cấp | 1 giờ | Cấp 2 | Tools, Commands | Tự động hóa workflow (25 sự kiện, 4 loại) | Kiểm tra, cổng kiểm soát chất lượng |
-| **7** | [MCP](05-mcp/) | ⭐⭐⭐ Trung cấp+ | 1 giờ | Cấp 2 | Cấu hình | Truy cập dữ liệu thời gian thực | Tích hợp real-time, APIs |
-| **8** | [Subagents](04-subagents/) | ⭐⭐⭐ Trung cấp+ | 1.5 giờ | Cấp 2 | Memory, Commands | Xử lý nhiệm vụ phức tạp (6 agent có sẵn gồm Bash) | Ủy quyền, chuyên môn hóa |
-| **9** | [Advanced Features](09-advanced-features/) | ⭐⭐⭐⭐⭐ Nâng cao | 2–3 giờ | Cấp 3 | Tất cả phần trước | Công cụ power user | Planning, Auto Mode, Channels, Voice Dictation, permissions |
-| **10** | [Plugins](07-plugins/) | ⭐⭐⭐⭐ Nâng cao | 2 giờ | Cấp 3 | Tất cả phần trước | Giải pháp hoàn chỉnh | Onboarding team, phân phối |
-| **11** | [CLI Mastery](10-cli/) | ⭐⭐⭐ Nâng cao | 1 giờ | Cấp 3 | Khuyến nghị: Tất cả | Thành thạo command-line | Scripting, CI/CD, tự động hóa |
+| **1** | [Slash Commands](01-slash-commands/README.vi.md) | ⭐ Người mới | 30 phút | Cấp 1 | Không có | Tăng năng suất ngay (55+ lệnh có sẵn + 5 skill đi kèm) | Tự động hóa tức thì, chuẩn hóa cho team |
+| **2** | [Memory](02-memory/README.vi.md) | ⭐⭐ Người mới+ | 45 phút | Cấp 1 | Không có | Nền tảng cho mọi tính năng khác | Ngữ cảnh lâu dài, lưu tùy chỉnh |
+| **3** | [Checkpoints](08-checkpoints/README.vi.md) | ⭐⭐ Trung cấp | 45 phút | Cấp 1 | Quản lý phiên | Khám phá an toàn | Thử nghiệm, phục hồi |
+| **4** | [CLI Basics](10-cli/README.vi.md) | ⭐⭐ Người mới+ | 30 phút | Cấp 1 | Không có | Dùng CLI cơ bản | Interactive & print mode |
+| **5** | [Skills](03-skills/README.vi.md) | ⭐⭐ Trung cấp | 1 giờ | Cấp 2 | Slash Commands | Kỹ năng tự động kích hoạt | Khả năng tái sử dụng, nhất quán |
+| **6** | [Hooks](06-hooks/README.vi.md) | ⭐⭐ Trung cấp | 1 giờ | Cấp 2 | Tools, Commands | Tự động hóa workflow (25 sự kiện, 4 loại) | Kiểm tra, cổng kiểm soát chất lượng |
+| **7** | [MCP](05-mcp/README.vi.md) | ⭐⭐⭐ Trung cấp+ | 1 giờ | Cấp 2 | Cấu hình | Truy cập dữ liệu thời gian thực | Tích hợp real-time, APIs |
+| **8** | [Subagents](04-subagents/README.vi.md) | ⭐⭐⭐ Trung cấp+ | 1.5 giờ | Cấp 2 | Memory, Commands | Xử lý nhiệm vụ phức tạp (6 agent có sẵn gồm Bash) | Ủy quyền, chuyên môn hóa |
+| **9** | [Advanced Features](09-advanced-features/README.vi.md) | ⭐⭐⭐⭐⭐ Nâng cao | 2–3 giờ | Cấp 3 | Tất cả phần trước | Công cụ power user | Planning, Auto Mode, Channels, Voice Dictation, permissions |
+| **10** | [Plugins](07-plugins/README.vi.md) | ⭐⭐⭐⭐ Nâng cao | 2 giờ | Cấp 3 | Tất cả phần trước | Giải pháp hoàn chỉnh | Onboarding team, phân phối |
+| **11** | [CLI Mastery](10-cli/README.vi.md) | ⭐⭐⭐ Nâng cao | 1 giờ | Cấp 3 | Khuyến nghị: Tất cả | Thành thạo command-line | Scripting, CI/CD, tự động hóa |
 
 **Tổng thời gian học**: ~11–13 giờ (hoặc nhảy thẳng vào cấp của bạn để tiết kiệm thời gian)
 
@@ -219,10 +219,10 @@ cat error.log | claude -p "explain this error"
 
 Trước khi bắt đầu Cấp 2, hãy đảm bảo bạn đã nắm vững các khái niệm Cấp 1:
 
-- [ ] Có thể tạo và dùng slash commands ([01-slash-commands/](01-slash-commands/))
-- [ ] Đã thiết lập project memory qua CLAUDE.md ([02-memory/](02-memory/))
-- [ ] Biết cách tạo và khôi phục checkpoint ([08-checkpoints/](08-checkpoints/))
-- [ ] Có thể dùng `claude` và `claude -p` từ command line ([10-cli/](10-cli/))
+- [ ] Có thể tạo và dùng slash commands ([01-slash-commands/](01-slash-commands/README.vi.md))
+- [ ] Đã thiết lập project memory qua CLAUDE.md ([02-memory/](02-memory/README.vi.md))
+- [ ] Biết cách tạo và khôi phục checkpoint ([08-checkpoints/](08-checkpoints/README.vi.md))
+- [ ] Có thể dùng `claude` và `claude -p` từ command line ([10-cli/](10-cli/README.vi.md))
 
 > **Còn thiếu?** Xem lại các hướng dẫn được liên kết ở trên trước khi tiếp tục.
 
@@ -353,10 +353,10 @@ Thử workflow hoàn chỉnh này:
 
 Trước khi bắt đầu Cấp 3, hãy đảm bảo bạn nắm vững các khái niệm Cấp 2:
 
-- [ ] Có thể tạo và dùng skills với auto-invocation ([03-skills/](03-skills/))
-- [ ] Đã thiết lập hooks cho tự động hóa theo sự kiện ([06-hooks/](06-hooks/))
-- [ ] Có thể cấu hình MCP server để truy cập dữ liệu ngoài ([05-mcp/](05-mcp/))
-- [ ] Biết cách dùng subagent để ủy quyền nhiệm vụ ([04-subagents/](04-subagents/))
+- [ ] Có thể tạo và dùng skills với auto-invocation ([03-skills/](03-skills/README.vi.md))
+- [ ] Đã thiết lập hooks cho tự động hóa theo sự kiện ([06-hooks/](06-hooks/README.vi.md))
+- [ ] Có thể cấu hình MCP server để truy cập dữ liệu ngoài ([05-mcp/](05-mcp/README.vi.md))
+- [ ] Biết cách dùng subagent để ủy quyền nhiệm vụ ([04-subagents/](04-subagents/README.vi.md))
 
 > **Còn thiếu?** Xem lại các hướng dẫn được liên kết ở trên trước khi tiếp tục.
 
@@ -634,40 +634,40 @@ Repo này có hai skill tương tác bạn có thể dùng bất kỳ lúc nào 
 Dùng các checklist này để theo dõi tiến độ theo cấp. Chạy `/self-assessment` bất kỳ lúc nào để nhận hồ sơ kỹ năng cập nhật, hoặc `/lesson-quiz [bài học]` sau mỗi tutorial để xác nhận mức hiểu.
 
 ### 🟢 Cấp 1: Người mới
-- [ ] Hoàn thành [01-slash-commands](01-slash-commands/)
-- [ ] Hoàn thành [02-memory](02-memory/)
+- [ ] Hoàn thành [01-slash-commands](01-slash-commands/README.vi.md)
+- [ ] Hoàn thành [02-memory](02-memory/README.vi.md)
 - [ ] Đã tạo slash command tùy chỉnh đầu tiên
 - [ ] Đã thiết lập project memory
 - [ ] **Milestone 1A đạt được**
-- [ ] Hoàn thành [08-checkpoints](08-checkpoints/)
-- [ ] Hoàn thành cơ bản [10-cli](10-cli/)
+- [ ] Hoàn thành [08-checkpoints](08-checkpoints/README.vi.md)
+- [ ] Hoàn thành cơ bản [10-cli](10-cli/README.vi.md)
 - [ ] Đã tạo và quay lại checkpoint
 - [ ] Đã dùng interactive mode và print mode
 - [ ] **Milestone 1B đạt được**
 
 ### 🔵 Cấp 2: Trung cấp
-- [ ] Hoàn thành [03-skills](03-skills/)
-- [ ] Hoàn thành [06-hooks](06-hooks/)
+- [ ] Hoàn thành [03-skills](03-skills/README.vi.md)
+- [ ] Hoàn thành [06-hooks](06-hooks/README.vi.md)
 - [ ] Đã cài skill đầu tiên
 - [ ] Đã thiết lập PreToolUse hook
 - [ ] **Milestone 2A đạt được**
-- [ ] Hoàn thành [05-mcp](05-mcp/)
-- [ ] Hoàn thành [04-subagents](04-subagents/)
+- [ ] Hoàn thành [05-mcp](05-mcp/README.vi.md)
+- [ ] Hoàn thành [04-subagents](04-subagents/README.vi.md)
 - [ ] Đã kết nối GitHub MCP
 - [ ] Đã tạo subagent tùy chỉnh
 - [ ] Đã kết hợp các tích hợp trong một workflow
 - [ ] **Milestone 2B đạt được**
 
 ### 🔴 Cấp 3: Nâng cao
-- [ ] Hoàn thành [09-advanced-features](09-advanced-features/)
+- [ ] Hoàn thành [09-advanced-features](09-advanced-features/README.vi.md)
 - [ ] Đã dùng planning mode thành công
 - [ ] Đã cấu hình permission mode (6 chế độ kể cả auto)
 - [ ] Đã dùng auto mode với safety classifier
 - [ ] Đã dùng extended thinking toggle
 - [ ] Đã khám phá Channels và Voice Dictation
 - [ ] **Milestone 3A đạt được**
-- [ ] Hoàn thành [07-plugins](07-plugins/)
-- [ ] Hoàn thành [10-cli](10-cli/) nâng cao
+- [ ] Hoàn thành [07-plugins](07-plugins/README.vi.md)
+- [ ] Hoàn thành [10-cli](10-cli/README.vi.md) nâng cao
 - [ ] Đã thiết lập print mode (`claude -p`) CI/CD
 - [ ] Đã tạo JSON output cho tự động hóa
 - [ ] Đã tích hợp Claude vào CI/CD pipeline

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,0 +1,304 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+</picture>
+
+[![GitHub Stars](https://img.shields.io/github/stars/luongnv89/claude-howto?style=flat&color=gold)](https://github.com/luongnv89/claude-howto/stargazers)
+[![GitHub Forks](https://img.shields.io/github/forks/luongnv89/claude-howto?style=flat)](https://github.com/luongnv89/claude-howto/network/members)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Version](https://img.shields.io/badge/version-2.2.0-brightgreen)](CHANGELOG.md)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-2.1+-purple)](https://code.claude.com)
+
+# Làm chủ Claude Code trong một cuối tuần
+
+Từ việc chỉ biết gõ lệnh `claude`, bạn sẽ tiến đến việc điều phối các agent, hooks, skills và MCP server — thông qua các hướng dẫn trực quan, template copy-paste sẵn và lộ trình học có hệ thống.
+
+**[Bắt đầu trong 15 phút](#-bắt-đầu-trong-15-phút)** | **[Xác định trình độ của bạn](#-chưa-biết-bắt-đầu-từ-đâu)** | **[Xem danh mục tính năng](CATALOG.md)**
+
+---
+
+## Mục lục
+
+- [Vấn đề](#vấn-đề)
+- [Claude How To giải quyết điều đó như thế nào](#claude-how-to-giải-quyết-điều-đó-như-thế-nào)
+- [Cách hoạt động](#cách-hoạt-động)
+- [Chưa biết bắt đầu từ đâu?](#-chưa-biết-bắt-đầu-từ-đâu)
+- [Bắt đầu trong 15 phút](#-bắt-đầu-trong-15-phút)
+- [Bạn có thể xây dựng gì với hướng dẫn này?](#bạn-có-thể-xây-dựng-gì-với-hướng-dẫn-này)
+- [Câu hỏi thường gặp](#câu-hỏi-thường-gặp)
+- [Đóng góp](#đóng-góp)
+- [Giấy phép](#giấy-phép)
+
+---
+
+## Vấn đề
+
+Bạn đã cài Claude Code. Bạn đã chạy thử vài lệnh. Và rồi thì sao?
+
+- **Tài liệu chính thức mô tả tính năng — nhưng không chỉ bạn cách kết hợp chúng.** Bạn biết slash commands tồn tại, nhưng không biết cách kết hợp chúng với hooks, memory và subagents thành một workflow thực sự tiết kiệm hàng giờ làm việc.
+- **Không có lộ trình học rõ ràng.** Nên học MCP trước hooks không? Skills trước subagents không? Bạn cứ lướt qua mọi thứ mà không thực sự nắm vững điều gì.
+- **Ví dụ quá đơn giản.** Một slash command "hello world" không giúp bạn xây dựng được một pipeline code review thực tế — thứ sử dụng memory, giao việc cho các agent chuyên biệt, và tự động chạy quét bảo mật.
+
+Bạn đang bỏ lãng 90% sức mạnh của Claude Code — và bạn không biết mình đang bỏ lỡ gì.
+
+---
+
+## Claude How To giải quyết điều đó như thế nào
+
+Đây không phải một tài liệu tham khảo tính năng thông thường. Đây là **hướng dẫn có cấu trúc, trực quan, học qua ví dụ thực tế** — dạy bạn sử dụng mọi tính năng của Claude Code với các template thực chiến có thể copy vào dự án của bạn ngay hôm nay.
+
+| | Tài liệu chính thức | Hướng dẫn này |
+|--|---------------------|---------------|
+| **Hình thức** | Tài liệu tham khảo | Hướng dẫn trực quan với sơ đồ Mermaid |
+| **Chiều sâu** | Mô tả tính năng | Giải thích cơ chế hoạt động bên trong |
+| **Ví dụ** | Đoạn code cơ bản | Template thực chiến dùng được ngay |
+| **Cấu trúc** | Phân loại theo tính năng | Lộ trình học tiến dần (từ cơ bản đến nâng cao) |
+| **Bắt đầu** | Tự định hướng | Có roadmap hướng dẫn kèm ước tính thời gian |
+| **Tự đánh giá** | Không có | Quiz tương tác để xác định điểm yếu và tạo lộ trình cá nhân hóa |
+
+### Bạn nhận được gì:
+
+- **10 module hướng dẫn** bao phủ mọi tính năng của Claude Code — từ slash commands đến đội agent tùy chỉnh
+- **Config copy-paste sẵn** — slash commands, CLAUDE.md template, hook scripts, MCP configs, subagent definitions và plugin bundle đầy đủ
+- **Sơ đồ Mermaid** minh họa cơ chế hoạt động bên trong từng tính năng, để bạn hiểu *tại sao*, không chỉ *như thế nào*
+- **Lộ trình học có hướng dẫn** đưa bạn từ người mới đến power user trong 11–13 giờ
+- **Tự đánh giá tích hợp** — chạy `/self-assessment` hoặc `/lesson-quiz hooks` ngay trong Claude Code để xác định điểm còn thiếu
+
+**[Bắt đầu lộ trình học ->](LEARNING-ROADMAP.md)**
+
+---
+
+## Cách hoạt động
+
+### 1. Xác định trình độ của bạn
+
+Làm [bài kiểm tra tự đánh giá](LEARNING-ROADMAP.md#-find-your-level) hoặc chạy `/self-assessment` trong Claude Code. Nhận roadmap cá nhân hóa dựa trên những gì bạn đã biết.
+
+### 2. Theo lộ trình có hướng dẫn
+
+Học lần lượt 10 module theo thứ tự — mỗi module xây dựng trên nền module trước. Copy template trực tiếp vào dự án của bạn trong khi học.
+
+### 3. Kết hợp các tính năng thành workflow
+
+Sức mạnh thực sự nằm ở việc kết hợp các tính năng lại với nhau. Học cách ghép slash commands + memory + subagents + hooks thành những pipeline tự động xử lý code review, triển khai, và tạo tài liệu.
+
+### 4. Kiểm tra mức độ hiểu biết
+
+Chạy `/lesson-quiz [chủ đề]` sau mỗi module. Quiz sẽ chỉ ra chính xác điều bạn còn thiếu để bạn bổ sung nhanh chóng.
+
+**[Bắt đầu trong 15 phút](#-bắt-đầu-trong-15-phút)**
+
+---
+
+## Được tin dùng bởi hơn 1.100 lập trình viên
+
+- **Hơn 1.100 GitHub stars** từ các lập trình viên sử dụng Claude Code hàng ngày
+- **78 forks** — các team đang tùy chỉnh hướng dẫn này cho workflow riêng của họ
+- **Được duy trì tích cực** — đồng bộ với mỗi bản phát hành Claude Code (phiên bản mới nhất: v2.2.0, tháng 3/2026)
+- **Được cộng đồng đóng góp** — đến từ các lập trình viên chia sẻ cấu hình thực tế của họ
+
+[![Star History Chart](https://api.star-history.com/svg?repos=luongnv89/claude-howto&type=Date)](https://star-history.com/#luongnv89/claude-howto&Date)
+
+---
+
+## Chưa biết bắt đầu từ đâu?
+
+Làm bài tự đánh giá hoặc chọn theo trình độ:
+
+| Trình độ | Bạn có thể... | Bắt đầu tại | Thời gian |
+|----------|--------------|-------------|-----------|
+| **Người mới** | Khởi động Claude Code và chat | [Slash Commands](01-slash-commands/) | ~2.5 giờ |
+| **Trung cấp** | Dùng CLAUDE.md và custom commands | [Skills](03-skills/) | ~3.5 giờ |
+| **Nâng cao** | Cấu hình MCP server và hooks | [Advanced Features](09-advanced-features/) | ~5 giờ |
+
+**Lộ trình đầy đủ với cả 10 module:**
+
+| Thứ tự | Module | Trình độ | Thời gian |
+|--------|--------|----------|-----------|
+| 1 | [Slash Commands](01-slash-commands/) | Người mới | 30 phút |
+| 2 | [Memory](02-memory/) | Người mới+ | 45 phút |
+| 3 | [Checkpoints](08-checkpoints/) | Trung cấp | 45 phút |
+| 4 | [CLI Basics](10-cli/) | Người mới+ | 30 phút |
+| 5 | [Skills](03-skills/) | Trung cấp | 1 giờ |
+| 6 | [Hooks](06-hooks/) | Trung cấp | 1 giờ |
+| 7 | [MCP](05-mcp/) | Trung cấp+ | 1 giờ |
+| 8 | [Subagents](04-subagents/) | Trung cấp+ | 1.5 giờ |
+| 9 | [Advanced Features](09-advanced-features/) | Nâng cao | 2–3 giờ |
+| 10 | [Plugins](07-plugins/) | Nâng cao | 2 giờ |
+
+**[Lộ trình học đầy đủ ->](LEARNING-ROADMAP.md)**
+
+---
+
+## Bắt đầu trong 15 phút
+
+```bash
+# 1. Clone hướng dẫn về máy
+git clone https://github.com/luongnv89/claude-howto.git
+cd claude-howto
+
+# 2. Copy slash command đầu tiên của bạn
+mkdir -p /path/to/your-project/.claude/commands
+cp 01-slash-commands/optimize.md /path/to/your-project/.claude/commands/
+
+# 3. Thử ngay — trong Claude Code, gõ:
+# /optimize
+
+# 4. Muốn thêm? Thiết lập project memory:
+cp 02-memory/project-CLAUDE.md /path/to/your-project/CLAUDE.md
+
+# 5. Cài đặt một skill:
+cp -r 03-skills/code-review ~/.claude/skills/
+```
+
+Muốn thiết lập đầy đủ hơn? Đây là **setup thiết yếu trong 1 giờ**:
+
+```bash
+# Slash commands (15 phút)
+cp 01-slash-commands/*.md .claude/commands/
+
+# Project memory (15 phút)
+cp 02-memory/project-CLAUDE.md ./CLAUDE.md
+
+# Cài một skill (15 phút)
+cp -r 03-skills/code-review ~/.claude/skills/
+
+# Mục tiêu cuối tuần: thêm hooks, subagents, MCP và plugins
+# Theo lộ trình học để được hướng dẫn từng bước
+```
+
+**[Xem hướng dẫn cài đặt đầy đủ](#tham-khảo-nhanh-cài-đặt)**
+
+---
+
+## Bạn có thể xây dựng gì với hướng dẫn này?
+
+| Trường hợp sử dụng | Tính năng bạn sẽ kết hợp |
+|--------------------|--------------------------|
+| **Code Review tự động** | Slash Commands + Subagents + Memory + MCP |
+| **Onboarding nhân viên mới** | Memory + Slash Commands + Plugins |
+| **Tự động hóa CI/CD** | CLI Reference + Hooks + Background Tasks |
+| **Tạo tài liệu tự động** | Skills + Subagents + Plugins |
+| **Kiểm tra bảo mật** | Subagents + Skills + Hooks (chế độ read-only) |
+| **Pipeline DevOps** | Plugins + MCP + Hooks + Background Tasks |
+| **Tái cấu trúc code phức tạp** | Checkpoints + Planning Mode + Hooks |
+
+---
+
+## Câu hỏi thường gặp
+
+**Có miễn phí không?**
+Có. Giấy phép MIT, miễn phí mãi mãi. Dùng cho dự án cá nhân, tại nơi làm việc, trong team — không có hạn chế nào ngoài việc đính kèm thông báo giấy phép.
+
+**Có được duy trì không?**
+Có và rất tích cực. Hướng dẫn được đồng bộ với mỗi bản phát hành Claude Code. Phiên bản hiện tại: v2.2.0 (tháng 3/2026), tương thích với Claude Code 2.1+.
+
+**Khác gì so với tài liệu chính thức?**
+Tài liệu chính thức là tài liệu tham khảo tính năng. Hướng dẫn này là tutorial kèm sơ đồ, template thực chiến và lộ trình học tiến dần. Hai thứ bổ trợ nhau — học tại đây trước, tra tài liệu chính thức khi cần chi tiết cụ thể.
+
+**Học hết mất bao lâu?**
+11–13 giờ cho toàn bộ lộ trình. Nhưng bạn sẽ thấy hiệu quả ngay trong 15 phút — chỉ cần copy một slash command template và thử dùng.
+
+**Có dùng được với Claude Sonnet / Haiku / Opus không?**
+Có. Tất cả template đều hoạt động với Claude Sonnet 4.6, Claude Opus 4.6 và Claude Haiku 4.5.
+
+**Có thể đóng góp không?**
+Hoàn toàn được. Xem [CONTRIBUTING.md](CONTRIBUTING.md) để biết hướng dẫn. Chúng tôi chào đón các ví dụ mới, sửa lỗi, cải thiện tài liệu và template từ cộng đồng.
+
+**Có đọc offline được không?**
+Có. Chạy `uv run scripts/build_epub.py` để tạo file EPUB với toàn bộ nội dung và sơ đồ đã được render.
+
+---
+
+## Bắt đầu làm chủ Claude Code ngay hôm nay
+
+Bạn đã cài Claude Code rồi. Điều duy nhất ngăn bạn tăng năng suất gấp 10 lần là biết cách dùng nó đúng cách. Hướng dẫn này cung cấp cho bạn lộ trình có cấu trúc, giải thích trực quan và template copy-paste để đạt được điều đó.
+
+Giấy phép MIT. Miễn phí mãi mãi. Clone về, fork ra, biến nó thành của bạn.
+
+**[Bắt đầu lộ trình học ->](LEARNING-ROADMAP.md)** | **[Xem danh mục tính năng](CATALOG.md)** | **[Bắt đầu trong 15 phút](#-bắt-đầu-trong-15-phút)**
+
+---
+
+<details>
+<summary>Điều hướng nhanh — Tất cả tính năng</summary>
+
+| Tính năng | Mô tả | Thư mục |
+|-----------|-------|---------|
+| **Feature Catalog** | Tham khảo đầy đủ kèm lệnh cài đặt | [CATALOG.md](CATALOG.md) |
+| **Slash Commands** | Phím tắt do người dùng gọi | [01-slash-commands/](01-slash-commands/) |
+| **Memory** | Bộ nhớ ngữ cảnh lâu dài | [02-memory/](02-memory/) |
+| **Skills** | Khả năng tái sử dụng | [03-skills/](03-skills/) |
+| **Subagents** | AI assistant chuyên biệt | [04-subagents/](04-subagents/) |
+| **MCP Protocol** | Truy cập công cụ bên ngoài | [05-mcp/](05-mcp/) |
+| **Hooks** | Tự động hóa theo sự kiện | [06-hooks/](06-hooks/) |
+| **Plugins** | Gói tính năng đóng gói sẵn | [07-plugins/](07-plugins/) |
+| **Checkpoints** | Snapshot phiên làm việc & tua lại | [08-checkpoints/](08-checkpoints/) |
+| **Advanced Features** | Planning, thinking, background tasks | [09-advanced-features/](09-advanced-features/) |
+| **CLI Reference** | Lệnh, flags và tùy chọn | [10-cli/](10-cli/) |
+| **Blog Posts** | Ví dụ sử dụng thực tế | [Blog Posts](https://medium.com/@luongnv89) |
+
+</details>
+
+<details>
+<summary>So sánh tính năng</summary>
+
+| Tính năng | Cách gọi | Lưu trữ | Phù hợp nhất cho |
+|-----------|----------|---------|-----------------|
+| **Slash Commands** | Thủ công (`/cmd`) | Chỉ trong phiên | Phím tắt nhanh |
+| **Memory** | Tự động tải | Xuyên phiên | Học dài hạn |
+| **Skills** | Tự động kích hoạt | Filesystem | Workflow tự động |
+| **Subagents** | Tự động ủy quyền | Context riêng biệt | Phân công nhiệm vụ |
+| **MCP Protocol** | Tự động truy vấn | Thời gian thực | Truy cập dữ liệu live |
+| **Hooks** | Kích hoạt theo sự kiện | Đã cấu hình | Tự động hóa & kiểm tra |
+| **Plugins** | Một lệnh | Tất cả tính năng | Giải pháp hoàn chỉnh |
+| **Checkpoints** | Thủ công/Tự động | Theo phiên | Thử nghiệm an toàn |
+| **Planning Mode** | Thủ công/Tự động | Giai đoạn lập kế hoạch | Triển khai phức tạp |
+| **Background Tasks** | Thủ công | Thời gian task | Tác vụ chạy dài |
+| **CLI Reference** | Lệnh terminal | Phiên/Script | Tự động hóa & scripting |
+
+</details>
+
+<details>
+<summary>Tham khảo nhanh cài đặt</summary>
+
+```bash
+# Slash Commands
+cp 01-slash-commands/*.md .claude/commands/
+
+# Memory
+cp 02-memory/project-CLAUDE.md ./CLAUDE.md
+
+# Skills
+cp -r 03-skills/code-review ~/.claude/skills/
+
+# Subagents
+cp 04-subagents/*.md .claude/agents/
+
+# MCP
+export GITHUB_TOKEN="token"
+claude mcp add github -- npx -y @modelcontextprotocol/server-github
+
+# Hooks
+mkdir -p ~/.claude/hooks
+cp 06-hooks/*.sh ~/.claude/hooks/
+chmod +x ~/.claude/hooks/*.sh
+
+# Plugins
+/plugin install pr-review
+
+# Checkpoints (tự động bật, cấu hình trong settings)
+# Xem 08-checkpoints/README.md
+
+# Advanced Features (cấu hình trong settings)
+# Xem 09-advanced-features/config-examples.json
+
+# CLI Reference (không cần cài đặt)
+# Xem 10-cli/README.md để biết ví dụ sử dụng
+```
+
+</details>
+
+---
+
+> **Ghi chú cho bản dịch tiếng Việt:** File này được dịch bởi cộng đồng. Nếu bạn thấy điểm nào chưa chính xác hoặc muốn cải thiện, vui lòng mở Pull Request. Bản gốc tiếng Anh luôn là nguồn chính xác nhất: [README.md](README.md).

--- a/README.vi.md
+++ b/README.vi.md
@@ -90,10 +90,10 @@ Chạy `/lesson-quiz [chủ đề]` sau mỗi module. Quiz sẽ chỉ ra chính 
 
 ---
 
-## Được tin dùng bởi hơn 1.100 lập trình viên
+## Được tin dùng bởi hơn 3.900 lập trình viên
 
-- **Hơn 1.100 GitHub stars** từ các lập trình viên sử dụng Claude Code hàng ngày
-- **78 forks** — các team đang tùy chỉnh hướng dẫn này cho workflow riêng của họ
+- **Hơn 3.900 GitHub stars** từ các lập trình viên sử dụng Claude Code hàng ngày
+- **Hơn 460 forks** — các team đang tùy chỉnh hướng dẫn này cho workflow riêng của họ
 - **Được duy trì tích cực** — đồng bộ với mỗi bản phát hành Claude Code (phiên bản mới nhất: v2.2.0, tháng 3/2026)
 - **Được cộng đồng đóng góp** — đến từ các lập trình viên chia sẻ cấu hình thực tế của họ
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -107,24 +107,24 @@ Làm bài tự đánh giá hoặc chọn theo trình độ:
 
 | Trình độ | Bạn có thể... | Bắt đầu tại | Thời gian |
 |----------|--------------|-------------|-----------|
-| **Người mới** | Khởi động Claude Code và chat | [Slash Commands](01-slash-commands/) | ~2.5 giờ |
-| **Trung cấp** | Dùng CLAUDE.md và custom commands | [Skills](03-skills/) | ~3.5 giờ |
-| **Nâng cao** | Cấu hình MCP server và hooks | [Advanced Features](09-advanced-features/) | ~5 giờ |
+| **Người mới** | Khởi động Claude Code và chat | [Slash Commands](01-slash-commands/README.vi.md) | ~2.5 giờ |
+| **Trung cấp** | Dùng CLAUDE.md và custom commands | [Skills](03-skills/README.vi.md) | ~3.5 giờ |
+| **Nâng cao** | Cấu hình MCP server và hooks | [Advanced Features](09-advanced-features/README.vi.md) | ~5 giờ |
 
 **Lộ trình đầy đủ với cả 10 module:**
 
 | Thứ tự | Module | Trình độ | Thời gian |
 |--------|--------|----------|-----------|
-| 1 | [Slash Commands](01-slash-commands/) | Người mới | 30 phút |
-| 2 | [Memory](02-memory/) | Người mới+ | 45 phút |
-| 3 | [Checkpoints](08-checkpoints/) | Trung cấp | 45 phút |
-| 4 | [CLI Basics](10-cli/) | Người mới+ | 30 phút |
-| 5 | [Skills](03-skills/) | Trung cấp | 1 giờ |
-| 6 | [Hooks](06-hooks/) | Trung cấp | 1 giờ |
-| 7 | [MCP](05-mcp/) | Trung cấp+ | 1 giờ |
-| 8 | [Subagents](04-subagents/) | Trung cấp+ | 1.5 giờ |
-| 9 | [Advanced Features](09-advanced-features/) | Nâng cao | 2–3 giờ |
-| 10 | [Plugins](07-plugins/) | Nâng cao | 2 giờ |
+| 1 | [Slash Commands](01-slash-commands/README.vi.md) | Người mới | 30 phút |
+| 2 | [Memory](02-memory/README.vi.md) | Người mới+ | 45 phút |
+| 3 | [Checkpoints](08-checkpoints/README.vi.md) | Trung cấp | 45 phút |
+| 4 | [CLI Basics](10-cli/README.vi.md) | Người mới+ | 30 phút |
+| 5 | [Skills](03-skills/README.vi.md) | Trung cấp | 1 giờ |
+| 6 | [Hooks](06-hooks/README.vi.md) | Trung cấp | 1 giờ |
+| 7 | [MCP](05-mcp/README.vi.md) | Trung cấp+ | 1 giờ |
+| 8 | [Subagents](04-subagents/README.vi.md) | Trung cấp+ | 1.5 giờ |
+| 9 | [Advanced Features](09-advanced-features/README.vi.md) | Nâng cao | 2–3 giờ |
+| 10 | [Plugins](07-plugins/README.vi.md) | Nâng cao | 2 giờ |
 
 **[Lộ trình học đầy đủ ->](LEARNING-ROADMAP.vi.md)**
 
@@ -226,16 +226,16 @@ Giấy phép MIT. Miễn phí mãi mãi. Clone về, fork ra, biến nó thành 
 | Tính năng | Mô tả | Thư mục |
 |-----------|-------|---------|
 | **Feature Catalog** | Tham khảo đầy đủ kèm lệnh cài đặt | [CATALOG.md](CATALOG.md) |
-| **Slash Commands** | Phím tắt do người dùng gọi | [01-slash-commands/](01-slash-commands/) |
-| **Memory** | Bộ nhớ ngữ cảnh lâu dài | [02-memory/](02-memory/) |
-| **Skills** | Khả năng tái sử dụng | [03-skills/](03-skills/) |
-| **Subagents** | AI assistant chuyên biệt | [04-subagents/](04-subagents/) |
-| **MCP Protocol** | Truy cập công cụ bên ngoài | [05-mcp/](05-mcp/) |
-| **Hooks** | Tự động hóa theo sự kiện | [06-hooks/](06-hooks/) |
-| **Plugins** | Gói tính năng đóng gói sẵn | [07-plugins/](07-plugins/) |
-| **Checkpoints** | Snapshot phiên làm việc & tua lại | [08-checkpoints/](08-checkpoints/) |
-| **Advanced Features** | Planning, thinking, background tasks | [09-advanced-features/](09-advanced-features/) |
-| **CLI Reference** | Lệnh, flags và tùy chọn | [10-cli/](10-cli/) |
+| **Slash Commands** | Phím tắt do người dùng gọi | [01-slash-commands/](01-slash-commands/README.vi.md) |
+| **Memory** | Bộ nhớ ngữ cảnh lâu dài | [02-memory/](02-memory/README.vi.md) |
+| **Skills** | Khả năng tái sử dụng | [03-skills/](03-skills/README.vi.md) |
+| **Subagents** | AI assistant chuyên biệt | [04-subagents/](04-subagents/README.vi.md) |
+| **MCP Protocol** | Truy cập công cụ bên ngoài | [05-mcp/](05-mcp/README.vi.md) |
+| **Hooks** | Tự động hóa theo sự kiện | [06-hooks/](06-hooks/README.vi.md) |
+| **Plugins** | Gói tính năng đóng gói sẵn | [07-plugins/](07-plugins/README.vi.md) |
+| **Checkpoints** | Snapshot phiên làm việc & tua lại | [08-checkpoints/](08-checkpoints/README.vi.md) |
+| **Advanced Features** | Planning, thinking, background tasks | [09-advanced-features/](09-advanced-features/README.vi.md) |
+| **CLI Reference** | Lệnh, flags và tùy chọn | [10-cli/](10-cli/README.vi.md) |
 | **Blog Posts** | Ví dụ sử dụng thực tế | [Blog Posts](https://medium.com/@luongnv89) |
 
 </details>

--- a/README.vi.md
+++ b/README.vi.md
@@ -64,7 +64,7 @@ Bạn đang bỏ lãng 90% sức mạnh của Claude Code — và bạn không b
 - **Lộ trình học có hướng dẫn** đưa bạn từ người mới đến power user trong 11–13 giờ
 - **Tự đánh giá tích hợp** — chạy `/self-assessment` hoặc `/lesson-quiz hooks` ngay trong Claude Code để xác định điểm còn thiếu
 
-**[Bắt đầu lộ trình học ->](LEARNING-ROADMAP.md)**
+**[Bắt đầu lộ trình học ->](LEARNING-ROADMAP.vi.md)**
 
 ---
 
@@ -126,7 +126,7 @@ Làm bài tự đánh giá hoặc chọn theo trình độ:
 | 9 | [Advanced Features](09-advanced-features/) | Nâng cao | 2–3 giờ |
 | 10 | [Plugins](07-plugins/) | Nâng cao | 2 giờ |
 
-**[Lộ trình học đầy đủ ->](LEARNING-ROADMAP.md)**
+**[Lộ trình học đầy đủ ->](LEARNING-ROADMAP.vi.md)**
 
 ---
 
@@ -216,7 +216,7 @@ Bạn đã cài Claude Code rồi. Điều duy nhất ngăn bạn tăng năng su
 
 Giấy phép MIT. Miễn phí mãi mãi. Clone về, fork ra, biến nó thành của bạn.
 
-**[Bắt đầu lộ trình học ->](LEARNING-ROADMAP.md)** | **[Xem danh mục tính năng](CATALOG.md)** | **[Bắt đầu trong 15 phút](#-bắt-đầu-trong-15-phút)**
+**[Bắt đầu lộ trình học ->](LEARNING-ROADMAP.vi.md)** | **[Xem danh mục tính năng](CATALOG.md)** | **[Bắt đầu trong 15 phút](#-bắt-đầu-trong-15-phút)**
 
 ---
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -9,7 +9,7 @@
 [![Version](https://img.shields.io/badge/version-2.2.0-brightgreen)](CHANGELOG.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-2.1+-purple)](https://code.claude.com)
 
-# Làm chủ Claude Code trong một cuối tuần
+# Nắm vững Claude Code trong vòng một cuối tuần
 
 Từ việc chỉ biết gõ lệnh `claude`, bạn sẽ tiến đến việc điều phối các agent, hooks, skills và MCP server — thông qua các hướng dẫn trực quan, template copy-paste sẵn và lộ trình học có hệ thống.
 


### PR DESCRIPTION
## Description
Complete Vietnamese translation for the entire claude-howto repository. All 10 modules + main README + LEARNING-ROADMAP have been translated.

## Type of Change
- [x] Documentation improvement

## Changes Made
- `README.vi.md` — Main page
- `LEARNING-ROADMAP.vi.md` — Learning roadmap
- `01-slash-commands/README.vi.md`
- `02-memory/README.vi.md`
- `03-skills/README.vi.md`
- `04-subagents/README.vi.md`
- `05-mcp/README.vi.md`
- `06-hooks/README.vi.md`
- `07-plugins/README.vi.md`
- `08-checkpoints/README.vi.md` + `checkpoint-examples.vi.md`
- `09-advanced-features/README.vi.md` + `planning-mode-examples.vi.md`
- `10-cli/README.vi.md`

## What to Review
- Vietnamese translation quality and terminology consistency
- All internal links point to `.vi.md` files (not English versions)
- Mermaid diagrams render correctly

## Testing
- [x] Verified examples work
- [x] Checked links and references
- [x] Reviewed for typos and clarity

## Checklist
- [x] Follows project structure and conventions
- [x] Includes clear documentation/examples
- [x] All links are verified and working
- [x] No sensitive information included
- [x] Updated relevant README files
- [x] Commit message follows conventional commit format

## Additional Notes
- Technical terms kept in English (e.g. hooks, skills, subagents, MCP)
- Explanations and descriptions translated to Vietnamese
- All folder links updated to point directly to `README.vi.md` instead of folder paths (prevents GitHub defaulting to English README)
