### PR TITLE
fix(skills): Remove stray code fence in README

### DIFF
--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -433,7 +433,7 @@ This creates `codebase-map.html` and opens it in your default browser.
 - **File sizes**: Displayed next to each file
 - **Colors**: Different colors for different file types
 - **Directory totals**: Shows aggregate size of each folder
-```
+
 
 The bundled Python script does the heavy lifting while Claude handles orchestration.
 


### PR DESCRIPTION
## Summary
- Remove extra closing code fence (```) that breaks markdown rendering in the **Codebase Map** section of `03-skills/README.md`

## What changed
`03-skills/README.md` line 436: replaced stray ``` with a blank line to fix an incorrectly closed code block.

## Test plan
- [x] Verified the markdown renders correctly after the fix
- [ ] Confirm no other code blocks in the file are affected"