### PR TITLE
fix(docs): MCP tools are not slash commands

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -12,7 +12,7 @@ Slash commands are shortcuts that control Claude's behavior during an interactiv
 - **Built-in commands**: Provided by Claude Code (`/help`, `/clear`, `/model`)
 - **Skills**: User-defined commands created as `SKILL.md` files (`/optimize`, `/pr`)
 - **Plugin commands**: Commands from installed plugins (`/frontend-design:frontend-design`)
-- **MCP prompts**: Commands from MCP servers (`/mcp__github__list_prs`)
+- **MCP prompts**: Commands from MCP servers that expose prompts (`/mcp__<server>__<prompt>`). Note: most MCP servers (including GitHub) expose *tools* that Claude calls internally — not slash command prompts.
 
 > **Note**: Custom slash commands have been merged into skills. Files in `.claude/commands/` still work, but skills (`.claude/skills/`) are now the recommended approach. Both create `/command-name` shortcuts. See the [Skills Guide](../03-skills/) for the full reference.
 
@@ -280,10 +280,12 @@ MCP servers can expose prompts as slash commands:
 
 **Examples:**
 ```bash
-/mcp__github__list_prs
-/mcp__github__pr_review 456
-/mcp__jira__create_issue "Bug title" high
+# Only works if the MCP server exposes prompts (not just tools)
+/mcp__myserver__summarize
+/mcp__myserver__analyze --verbose
 ```
+
+> **Important**: Most MCP servers (like GitHub, Jira) expose **tools**, not prompts. MCP tools are called by Claude internally when you ask in natural language (e.g., "list my open PRs"). They do NOT appear as `/` slash commands.
 
 ### MCP Permission Syntax
 

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -481,7 +481,7 @@ claude mcp add --transport stdio database -- npx @modelcontextprotocol/server-da
 ## Workflow
 
 ### Step 1: Fetch GitHub Data
-/mcp__github__list_prs completed:true last:7days
+Ask Claude: "list pull requests merged in the last 7 days"
 
 Output:
 - Total PRs: 42
@@ -1020,10 +1020,10 @@ export GITHUB_TOKEN="your_github_personal_access_token"
 claude /mcp
 ```
 
-4. **Use MCP tools:**
-```bash
-/mcp__github__list_prs
-/mcp__github__create_issue "Title" "Description"
+4. **Use MCP tools** (ask Claude in natural language):
+```
+list my open pull requests
+create a GitHub issue titled "Title" with body "Description"
 ```
 
 ### Installation for Specific Services

--- a/INDEX.md
+++ b/INDEX.md
@@ -194,7 +194,7 @@ External tool and API integrations.
 
 **Installation Path**: `.mcp.json` (project scope) or `~/.claude.json` (user scope)
 
-**Usage**: `/mcp__github__list_prs`, etc.
+**Usage**: Ask Claude naturally (e.g., "list my open pull requests")
 
 ---
 

--- a/LEARNING-ROADMAP.md
+++ b/LEARNING-ROADMAP.md
@@ -306,7 +306,7 @@ export GITHUB_TOKEN="your_github_token"
 claude mcp add github -- npx -y @modelcontextprotocol/server-github
 
 # Exercise 2: Test MCP integration
-# In Claude Code: /mcp__github__list_prs
+# Ask Claude: "list my open pull requests"
 
 # Exercise 3: Install subagents
 mkdir -p .claude/agents

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -356,8 +356,8 @@ cp 04-subagents/code-reviewer.md .claude/agents/
 export GITHUB_TOKEN="your_token"
 cp 05-mcp/github-mcp.json .mcp.json
 
-# Try MCP commands
-/mcp__github__list_prs
+# Try MCP integration — ask Claude naturally:
+# "list my open pull requests"
 ```
 
 ### Week 2

--- a/claude_concepts_guide.md
+++ b/claude_concepts_guide.md
@@ -69,7 +69,7 @@ graph LR
 | File references | `@path/to/file.js` | ✅ Yes |
 | Bash integration | `$(git log --oneline)` | ✅ Yes |
 | Arguments | `/pr --verbose` | ✅ Yes |
-| MCP commands | `/mcp__github__list_prs` | ✅ Yes |
+| MCP tools (natural language) | `list my open PRs` | ✅ Yes |
 
 ### Practical Examples
 
@@ -1135,7 +1135,7 @@ ORDER BY order_count DESC;
 ## Workflow
 
 ### Step 1: Fetch GitHub Data
-/mcp__github__list_prs completed:true last:7days
+Ask Claude: "list pull requests merged in the last 7 days"
 
 Output:
 - Total PRs: 42


### PR DESCRIPTION
## Summary
- MCP tools (e.g., `mcp__github__list_pull_requests`) are internal tools called by Claude, **not** user-facing slash commands
- The documentation incorrectly shows `/mcp__github__list_prs` as a command users can type — this produces an `Unknown skill` error
- Updated all 6 affected files to use natural language examples instead (e.g., "list my open pull requests")

## Files Changed
- `01-slash-commands/README.md` — Clarified MCP prompts vs tools distinction
- `05-mcp/README.md` — Fixed "Use MCP tools" section and workflow example
- `INDEX.md` — Fixed usage description
- `LEARNING-ROADMAP.md` — Fixed exercise instruction
- `QUICK_REFERENCE.md` — Fixed quick start example
- `claude_concepts_guide.md` — Fixed table entry and workflow example

## Test plan
- [x] Searched for all occurrences of `mcp__github__list_prs` and fixed each one
- [x] Verified the corrected instructions match actual Claude Code behavior
- [ ] Review rendered markdown for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)