### PR TITLE
fix(docs): Fix nested code fence breaking Example 3 heading in skills README

### DIFF
--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -406,7 +406,7 @@ A skill that generates interactive HTML visualizations:
 
 **File:** `~/.claude/skills/codebase-visualizer/SKILL.md`
 
-```yaml
+````yaml
 ---
 name: codebase-visualizer
 description: Generate an interactive collapsible tree visualization of your codebase. Use when exploring a new repo, understanding project structure, or identifying large files.
@@ -433,7 +433,7 @@ This creates `codebase-map.html` and opens it in your default browser.
 - **File sizes**: Displayed next to each file
 - **Colors**: Different colors for different file types
 - **Directory totals**: Shows aggregate size of each folder
-```
+````
 
 The bundled Python script does the heavy lifting while Claude handles orchestration.
 


### PR DESCRIPTION
## Summary
- The `codebase-visualizer` SKILL.md example in `03-skills/README.md` contains nested code fences (` ```bash ` inside ` ```yaml `), which causes the outer block to close prematurely
- This makes the `### Example 3: Deploy Skill (User-Invoked Only)` heading render inside a code block instead of as markdown
- Fixed by using 4-backtick fences (``````) for the outer code block, so the inner 3-backtick fences don't break it

## Type of Change
- [x] Bug fix

## Files Changed
- `03-skills/README.md`

## Testing
- [x] Verified the markdown renders correctly after the fix
- [x] Confirmed no other code blocks in the file are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)