### PR TITLE
docs: fix README heading and installation anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Go from typing `claude` to orchestrating agents, hooks, skills, and MCP servers 
 ## Table of Contents
 
 - [The Problem](#the-problem)
-- [How Claude How To Fixes This](#how-claude-how-to-fixes-this)
+- [How This Guide Helps](#how-this-guide-helps)
 - [How It Works](#how-it-works)
 - [Not Sure Where to Start?](#-not-sure-where-to-start)
 - [Get Started in 15 Minutes](#-get-started-in-15-minutes)
@@ -43,7 +43,7 @@ You're leaving 90% of Claude Code's power on the table — and you don't know wh
 
 ---
 
-## How Claude How To Fixes This
+## How This Guide Helps
 
 This isn't another feature reference. It's a **structured, visual, example-driven guide** that teaches you to use every Claude Code feature with real-world templates you can copy into your project today.
 
@@ -258,6 +258,8 @@ MIT licensed. Free forever. Clone it, fork it, make it yours.
 | **CLI Reference** | Terminal commands | Session/Script | Automation & scripting |
 
 </details>
+
+<a id="installation-quick-reference"></a>
 
 <details>
 <summary>Installation Quick Reference</summary>


### PR DESCRIPTION
## Description
Refines the top-level README by fixing two high-impact documentation issues: an awkward section title and a broken internal anchor link.

## Type of Change
- [ ] New example or template
- [x] Documentation improvement
- [ ] Bug fix
- [ ] Feature guide
- [ ] Other (please describe)

## Related Issues
Closes #N/A

## Changes Made
- Renamed the section heading from `How Claude How To Fixes This` to `How This Guide Helps`
- Updated the matching Table of Contents entry to point to the new heading anchor
- Added an explicit `installation-quick-reference` anchor so the existing internal link works correctly

## What to Review
Reviewers should focus on whether the new section title reads better and whether the internal installation reference link now resolves correctly.

## Files Changed
- `README.md`

## Testing
How have you tested this?
- [x] Tested locally with Claude Code
- [x] Verified examples work
- [x] Checked links and references
- [x] Reviewed for typos and clarity

## Checklist
- [x] Follows project structure and conventions
- [x] Includes clear documentation/examples
- [x] Code/examples are copy-paste ready
- [x] All links are verified and working
- [x] No sensitive information included (keys, tokens, credentials)
- [x] Updated relevant README files
- [x] Commit message follows conventional commit format
- [x] No large files (>1MB) added

## Screenshots or Examples
N/A

## Breaking Changes
N/A

If yes, please describe:

## Additional Notes
This PR intentionally keeps the scope narrow. Earlier wording-only cleanup was removed so the final diff includes only the most important documentation fixes.