### PR TITLE
fix: remove non-existent autoCheckpoint config from docs

### DIFF
--- a/.claude/skills/lesson-quiz/references/question-bank.md
+++ b/.claude/skills/lesson-quiz/references/question-bank.md
@@ -621,7 +621,7 @@
 ### Q4
 - **Category**: practical
 - **Question**: You used `rm -rf temp/` via Bash in Claude Code, then want to rewind. Will the checkpoint restore those files?
-- **Options**: A) Yes, checkpoints capture everything | B) No, Bash filesystem operations (rm, mv, cp) are not tracked by checkpoints | C) Only if you used the Edit tool instead | D) Only if autoCheckpoint was enabled
+- **Options**: A) Yes, checkpoints capture everything | B) No, Bash filesystem operations (rm, mv, cp) are not tracked by checkpoints | C) Only if you used the Edit tool instead | D) Only if the session is still within the retention period
 - **Correct**: B
 - **Explanation**: Checkpoints only track file changes made by Claude's tools (Write, Edit). Bash commands like rm, mv, cp operate outside checkpoint tracking.
 - **Review**: Limitations section
@@ -652,10 +652,10 @@
 
 ### Q8
 - **Category**: practical
-- **Question**: How do you disable automatic checkpoint creation?
-- **Options**: A) Use `--no-checkpoints` flag | B) Set `autoCheckpoint: false` in settings | C) Delete the checkpoints directory | D) Checkpoints cannot be disabled
-- **Correct**: B
-- **Explanation**: Set `autoCheckpoint: false` in your configuration to disable automatic checkpoint creation (default is true).
+- **Question**: Can you disable automatic checkpoint creation?
+- **Options**: A) Use `--no-checkpoints` flag | B) Set `autoCheckpoint: false` in settings | C) Delete the checkpoints directory | D) Checkpoints cannot be disabled - they are always created on every user prompt
+- **Correct**: D
+- **Explanation**: Automatic checkpoints are a built-in feature that cannot be disabled. They are created before every user prompt to ensure you can always rewind.
 - **Review**: Configuration section
 
 ### Q9

--- a/08-checkpoints/README.md
+++ b/08-checkpoints/README.md
@@ -207,15 +207,9 @@ Since checkpoints are created automatically, you can focus on your work without 
 
 ## Configuration
 
-You can toggle automatic checkpoints in your settings:
+Checkpoints are created automatically before every user prompt. This behavior is built-in and cannot be disabled via settings.
 
-```json
-{
-  "autoCheckpoint": true
-}
-```
-
-- `autoCheckpoint`: Enable or disable automatic checkpoint creation on every user prompt (default: `true`)
+The `cleanupPeriodDays` setting controls how long sessions and their checkpoints are retained (default: 30 days).
 
 ## Limitations
 
@@ -233,7 +227,7 @@ Checkpoints have the following limitations:
 
 **Solution**:
 - Check if checkpoints were cleared
-- Verify that `autoCheckpoint` is enabled in your settings
+- Verify that the session has not exceeded `cleanupPeriodDays` retention
 - Check disk space
 
 ### Rewind Failed


### PR DESCRIPTION
## Problem

The checkpoints documentation (chapter 08) references an `autoCheckpoint` setting that does not actually exist in Claude Code:

```json
{
  "autoCheckpoint": true
}
```

Users following this guide will add this setting and wonder why it doesnt do anything. Claude Code creates checkpoints automatically on every user prompt and there is no way to disable this.

## What I changed

**`08-checkpoints/README.md`:**
- Removed the `autoCheckpoint` JSON config block and its description
- Replaced with accurate text: checkpoints are built-in and cannot be disabled
- Mentioned `cleanupPeriodDays` which IS a real setting
- Updated troubleshooting section to remove reference to checking `autoCheckpoint`

**`.claude/skills/lesson-quiz/references/question-bank.md`:**
- Q4: Removed `autoCheckpoint` from answer option D (replaced with retention period reference)
- Q8: Changed correct answer from B ("set autoCheckpoint: false") to D ("cannot be disabled") since the setting doesnt exist
- Updated explanation to match reality

## Why

The `autoCheckpoint` setting does not exist in Claude Code's settings schema. Checkpoints are always created automatically and there is no toggle for this. Having this in the docs confuses users who try to configure it.

Closes #18