### PR TITLE
fix: correct autoCheckpoint config docs in 08-checkpoints

### DIFF
--- a/08-checkpoints/README.md
+++ b/08-checkpoints/README.md
@@ -207,15 +207,17 @@ Since checkpoints are created automatically, you can focus on your work without 
 
 ## Configuration
 
-You can toggle automatic checkpoints in your settings:
+Checkpoints are a built-in default behavior in Claude Code and do not require any configuration to enable. Every user prompt automatically creates a checkpoint.
+
+The only checkpoint-related setting is `cleanupPeriodDays`, which controls how long sessions and checkpoints are retained:
 
 ```json
 {
-  "autoCheckpoint": true
+  "cleanupPeriodDays": 30
 }
 ```
 
-- `autoCheckpoint`: Enable or disable automatic checkpoint creation on every user prompt (default: `true`)
+- `cleanupPeriodDays`: Number of days to retain session history and checkpoints (default: `30`)
 
 ## Limitations
 
@@ -233,8 +235,8 @@ Checkpoints have the following limitations:
 
 **Solution**:
 - Check if checkpoints were cleared
-- Verify that `autoCheckpoint` is enabled in your settings
 - Check disk space
+- Ensure `cleanupPeriodDays` is set high enough (default: 30 days)
 
 ### Rewind Failed
 


### PR DESCRIPTION
## Summary

- Removes the non-existent `autoCheckpoint` setting from the Configuration section
- Replaces it with the actual `cleanupPeriodDays` setting that controls checkpoint retention
- Updates the Troubleshooting section to remove the incorrect reference to `autoCheckpoint`

## Problem

The `08-checkpoints/README.md` documented an `autoCheckpoint: true` config option that does not exist in Claude Code's settings schema. This could mislead users trying to control checkpoint behavior via settings.

As noted in issue #18, checkpointing is a built-in default behavior — every user prompt automatically creates a checkpoint, and there is no config switch to control it. The `cleanupPeriodDays` setting (default: 30) is the actual relevant configuration option.

## Changes

- **`08-checkpoints/README.md`**: Corrected Configuration section to explain that checkpoints are automatic and built-in, replaced `autoCheckpoint` example with `cleanupPeriodDays`, and updated the Troubleshooting section accordingly.

Closes #18