### PR TITLE
fix: nested code fence rendering in memory README

### DIFF
--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -641,7 +641,7 @@ Claude will load CLAUDE.md from the specified additional directory alongside the
 
 **File:** `./src/api/CLAUDE.md`
 
-```markdown
+````markdown
 # API Module Standards
 
 This file overrides root CLAUDE.md for everything in /src/api/
@@ -703,7 +703,7 @@ Error responses:
 - Cache duration: 5 minutes default
 - Invalidate on write operations
 - Tag cache keys with resource type
-```
+````
 
 ### Example 3: Personal Memory
 

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -406,7 +406,7 @@ A skill that generates interactive HTML visualizations:
 
 **File:** `~/.claude/skills/codebase-visualizer/SKILL.md`
 
-```yaml
+````yaml
 ---
 name: codebase-visualizer
 description: Generate an interactive collapsible tree visualization of your codebase. Use when exploring a new repo, understanding project structure, or identifying large files.
@@ -433,7 +433,7 @@ This creates `codebase-map.html` and opens it in your default browser.
 - **File sizes**: Displayed next to each file
 - **Colors**: Different colors for different file types
 - **Directory totals**: Shows aggregate size of each folder
-```
+````
 
 The bundled Python script does the heavy lifting while Claude handles orchestration.
 


### PR DESCRIPTION
## Summary
- Example 2 in `02-memory/README.md` uses nested code fences (` ```json ` inside ` ```markdown `)
- The inner fence prematurely closes the outer one, breaking rendering for the rest of the file
- Fixed by using 4-backtick fences for the outer block