### PR TITLE
feat(release): build and publish EPUB artifacts per language

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,14 @@ on:
 
 jobs:
   build:
+    name: Build EPUB (${{ matrix.lang }})
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    strategy:
+      # Don't cancel other languages if one fails — we still want to release
+      # whichever languages built successfully.
+      fail-fast: false
+      matrix:
+        lang: [en, vi, zh]
 
     steps:
       - uses: actions/checkout@v4
@@ -25,11 +30,51 @@ jobs:
       - name: Install Mermaid CLI
         run: npm install -g @mermaid-js/mermaid-cli
 
+      - name: Install Python dependencies
+        run: |
+          uv venv
+          uv pip install -r scripts/requirements-dev.txt
+
       - name: Build EPUB
-        run: uv run scripts/build_epub.py
+        run: |
+          echo '{"args":["--no-sandbox","--disable-setuid-sandbox"]}' > /tmp/puppeteer-ci.json
+          uv run scripts/build_epub.py \
+            --lang ${{ matrix.lang }} \
+            --puppeteer-config /tmp/puppeteer-ci.json
+
+      - name: Upload EPUB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: epub-${{ matrix.lang }}
+          path: claude-howto-guide*.epub
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    # Release even if some language builds failed — we still publish the
+    # artifacts that did build. `needs.build.result != 'cancelled'` guards
+    # against manually cancelled runs.
+    if: ${{ always() && needs.build.result != 'cancelled' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all EPUB artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: epub-*
+          merge-multiple: true
+
+      - name: List built artifacts
+        run: ls -lh dist/
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: claude-howto-guide.epub
+          files: dist/*.epub
           generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/scripts/build_epub.py
+++ b/scripts/build_epub.py
@@ -113,6 +113,8 @@ class EPUBConfig:
     vi_subtitle: str = "Làm chủ Claude Code trong một cuối tuần"
     en_title: str = "Claude Code How-To Guide"
     en_subtitle: str = "Master Claude Code in a Weekend"
+    zh_title: str = "Claude Code 使用指南"
+    zh_subtitle: str = "一个周末掌握 Claude Code"
 
     # Cover Settings
     cover_width: int = 600
@@ -1057,8 +1059,11 @@ def main() -> int:
         "--lang",
         type=str,
         default="en",
-        choices=["en", "vi"],
-        help="Language code: 'en' for English, 'vi' for Vietnamese (default: en)",
+        choices=["en", "vi", "zh"],
+        help=(
+            "Language code: 'en' for English, 'vi' for Vietnamese, "
+            "'zh' for Chinese (default: en)"
+        ),
     )
     parser.add_argument(
         "--puppeteer-config",
@@ -1073,17 +1078,16 @@ def main() -> int:
     repo_root = args.root if args.root else Path(__file__).parent.parent
     repo_root = repo_root.resolve()
 
-    # Set language-specific paths and metadata
-    if args.lang == "vi":
-        root = repo_root / "vi"
-        output = args.output or (repo_root / "claude-howto-guide-vi.epub")
-        title = EPUBConfig.vi_title
-        language = "vi"
-    else:
-        root = repo_root
-        output = args.output or (repo_root / "claude-howto-guide.epub")
-        title = EPUBConfig.en_title
-        language = "en"
+    # Set language-specific paths and metadata.
+    # Each entry: (source root, default output filename, title)
+    lang_map: dict[str, tuple[Path, str, str]] = {
+        "en": (repo_root, "claude-howto-guide.epub", EPUBConfig.en_title),
+        "vi": (repo_root / "vi", "claude-howto-guide-vi.epub", EPUBConfig.vi_title),
+        "zh": (repo_root / "zh", "claude-howto-guide-zh.epub", EPUBConfig.zh_title),
+    }
+    root, default_output_name, title = lang_map[args.lang]
+    output = args.output or (repo_root / default_output_name)
+    language = args.lang
 
     root = root.resolve()
     output = output.resolve()


### PR DESCRIPTION
## Summary

- Release workflow now builds **separate EPUB artifacts for `en`, `vi`, and `zh`** in parallel via a matrix job, then publishes all built files under a **single GitHub Release**.
- `scripts/build_epub.py` refactored so language-specific paths, filenames, and titles are driven from a mapping — adding a new language is a one-line change.
- Added `zh` (Chinese) support: `zh_title` / `zh_subtitle` constants and `--lang zh` choice.

## Motivation

Previously the release workflow only built the English EPUB. Vietnamese content has been in `vi/` since #42 and Chinese content in `zh/` has grown to 99 markdown files, but neither was being shipped as a release artifact. Users reading in `vi`/`zh` had no downloadable ebook.

## Changes

### `scripts/build_epub.py`

- Added `zh_title` (`Claude Code 使用指南`) and `zh_subtitle` to `EPUBConfig`.
- Extended `--lang` argparse choices from `["en", "vi"]` to `["en", "vi", "zh"]`.
- Replaced the `if args.lang == "vi" / else` branch with a `lang_map` dict keyed by language code, mapping to `(source_root, default_output_filename, title)`. Adding future languages (e.g. `ja`, `fr`) is now a one-line change.

### `.github/workflows/release.yml`

- Split the single job into two jobs:
  - **`build`** — runs `strategy.matrix.lang: [en, vi, zh]` with `fail-fast: false`, so a build failure in one language does not cancel the others. Each language uploads its EPUB as a named artifact (`epub-en`, `epub-vi`, `epub-zh`).
  - **`release`** — `needs: build`, runs `if: always() && needs.build.result != 'cancelled'`, downloads all `epub-*` artifacts and publishes a single GitHub Release containing every successfully-built EPUB.
- Moved `permissions: contents: write` to the `release` job only (least privilege — the `build` jobs do not need write access to the repo).
- Added `--puppeteer-config` with `--no-sandbox` (mirroring the pattern already used in `test.yml`) so `mmdc` can launch Chromium inside the CI container.
- `fail_on_unmatched_files: true` on the release step catches the edge case where all language builds fail.

## Release output

When pushing a tag `v1.2.3`, the resulting GitHub Release will contain:

```
claude-howto-guide.epub          ← en
claude-howto-guide-vi.epub       ← vi
claude-howto-guide-zh.epub       ← zh
```

## Test plan

- [x] `uv run scripts/build_epub.py --lang zh` builds successfully locally (1.2 MB EPUB, `dc:language=zh`, `dc:title=Claude Code 使用指南`, cover + chapters + mermaid PNGs verified via `unzip -l` and `content.opf` inspection).
- [x] `uv run scripts/build_epub.py --help` shows updated `--lang {en,vi,zh}` choices.
- [x] `ruff check`, `ruff format --check`, and `mypy` all pass on `scripts/build_epub.py`.
- [ ] Push a release candidate tag (e.g. `v0.0.0-rc1`) on this branch to verify the matrix job + single-release publish end-to-end on GitHub Actions runners.
- [ ] Delete the test release/tag before tagging the production version.

## Notes

- The `zh/` tree currently lacks a `claude-howto-logo.png`, so the zh EPUB is generated with a text-only cover. Adding the logo later is a follow-up — it is not a blocker since `build_epub.py` already handles the missing-logo case gracefully with a warning.