### PR TITLE
fix(skills): reference templates and scripts from code-review SKILL.md

### DIFF
--- a/03-skills/code-review/SKILL.md
+++ b/03-skills/code-review/SKILL.md
@@ -35,6 +35,15 @@ This skill provides comprehensive code review capabilities focusing on:
    - Dependency management
    - Type safety
 
+## Reference Files
+
+This skill includes supporting files that you should read when performing reviews:
+
+- **`templates/review-checklist.md`** — Structured checklist covering security, performance, quality, and testing. Read this file and use it as a guide to ensure no category is missed during review.
+- **`templates/finding-template.md`** — Standard template for documenting individual findings with severity, location, code examples, and impact analysis. Read this file and use its format when reporting issues.
+- **`scripts/analyze-metrics.py`** — Python script that calculates code metrics (function count, class count, average line length, complexity score). Run this on the file under review to gather quantitative data.
+- **`scripts/compare-complexity.py`** — Python script that compares cyclomatic and cognitive complexity between two versions of a file. Run this with the before and after versions when reviewing refactoring changes.
+
 ## Review Template
 
 For each piece of code reviewed, provide:


### PR DESCRIPTION
## Summary

- Adds a **Reference Files** section to `03-skills/code-review/SKILL.md` that explicitly references the `templates/` and `scripts/` directories
- Each file is described with its purpose and when to use it, so Claude loads and uses them during reviews

## Why

As noted in #43, Claude Code only loads `SKILL.md` when a skill is invoked. The `templates/` (review-checklist, finding-template) and `scripts/` (analyze-metrics, compare-complexity) were present but never referenced, making them effectively unused. The [official skill docs](https://code.claude.com/docs/en/skills) confirm that supporting files must be explicitly referenced from SKILL.md.

Closes #43

## Test plan

- [ ] Invoke the code-review skill and verify Claude reads the referenced template and script files
- [ ] Confirm the checklist and finding template format appear in review output

🤖 Generated with [Claude Code](https://claude.com/claude-code)