### PR TITLE
docs: sync to Claude Code v2.1.101 with /team-onboarding, /ultraplan, Monitor tool

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -151,7 +151,7 @@ The generated guide summarizes:
 - [Hooks](../06-hooks/README.md) that run on common events
 - Common workflows newcomers should know about
 
-**Availability:** Shipped in Claude Code v2.1.101 (April 10, 2026).
+**Availability:** Shipped in Claude Code v2.1.101 (April 11, 2026).
 
 ## Custom Commands (Now Skills)
 

--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -80,6 +80,7 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/status` | Show version, model, account |
 | `/statusline` | Configure status line |
 | `/tasks` | List/manage background tasks |
+| `/team-onboarding` | Generate a teammate ramp-up guide from the project's Claude Code setup (new in v2.1.101) |
 | `/terminal-setup` | Configure terminal keybindings |
 | `/theme` | Change color theme |
 | `/ultraplan <prompt>` | Draft plan in ultraplan session, review in browser |
@@ -126,6 +127,31 @@ These skills ship with Claude Code and are invoked like slash commands:
 - `/model` picker now shows human-readable labels (e.g., "Sonnet 4.6") instead of raw model IDs
 - `/resume` supports `/continue` alias
 - MCP prompts are available as `/mcp__<server>__<prompt>` commands (see [MCP Prompts as Commands](#mcp-prompts-as-commands))
+- `/team-onboarding` added for auto-generating teammate ramp-up guides (v2.1.101)
+
+### `/team-onboarding` — Teammate Ramp-Up Guide
+
+> **New in v2.1.101**
+
+Use `/team-onboarding` to generate a teammate ramp-up guide from your project's local Claude Code usage. The command inspects your `CLAUDE.md`, installed skills, subagents, hooks, and recent workflows, then produces an onboarding document that helps new developers become productive quickly.
+
+It's a built-in command — nothing to install.
+
+**Usage:**
+
+```bash
+claude /team-onboarding
+```
+
+The generated guide summarizes:
+
+- Project purpose and key conventions from [`CLAUDE.md`](../02-memory/README.md)
+- Available [skills](../03-skills/README.md) and when they are auto-invoked
+- Configured [subagents](../04-subagents/README.md) and their responsibilities
+- [Hooks](../06-hooks/README.md) that run on common events
+- Common workflows newcomers should know about
+
+**Availability:** Shipped in Claude Code v2.1.101 (April 10, 2026).
 
 ## Custom Commands (Now Skills)
 
@@ -558,8 +584,11 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 - [CLI Reference](https://code.claude.com/docs/en/cli-reference) - Command-line options
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/skills
+- https://code.claude.com/docs/en/commands
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5
 
 *Part of the [Claude How To](../) guide series*

--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -1151,6 +1151,8 @@ For the most up-to-date information, refer to the official Claude Code documenta
 - [Official Memory Docs](https://code.claude.com/docs/en/memory) - Anthropic documentation
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/memory
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -806,6 +806,8 @@ Once you start building skills seriously, two things become essential: a library
 - [Hooks Guide](../06-hooks/) - Event-driven automation
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/skills
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/04-subagents/README.md
+++ b/04-subagents/README.md
@@ -1137,6 +1137,9 @@ graph TD
 - [Hooks Guide](../06-hooks/) - For event-driven automation
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/sub-agents
+- https://code.claude.com/docs/en/agent-teams
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -1108,6 +1108,8 @@ export GITHUB_TOKEN="your_token"
 - [Claude API Documentation](https://docs.anthropic.com)
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/mcp
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/06-hooks/README.md
+++ b/06-hooks/README.md
@@ -1165,6 +1165,8 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 - **[Memory Guide](../02-memory/)** - Persistent context configuration
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/hooks
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/07-plugins/README.md
+++ b/07-plugins/README.md
@@ -944,6 +944,8 @@ The following Claude Code features work together with plugins:
 - [Hook System Reference](../06-hooks/README.md)
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/plugins
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/08-checkpoints/README.md
+++ b/08-checkpoints/README.md
@@ -315,6 +315,8 @@ Key benefits:
 Remember: checkpoints are not a replacement for git. Use checkpoints for rapid experimentation and git for permanent code changes.
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/checkpointing
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -11,29 +11,31 @@ Comprehensive guide to Claude Code's advanced capabilities including planning mo
 
 1. [Overview](#overview)
 2. [Planning Mode](#planning-mode)
-3. [Extended Thinking](#extended-thinking)
-4. [Auto Mode](#auto-mode)
-5. [Background Tasks](#background-tasks)
-6. [Scheduled Tasks](#scheduled-tasks)
-7. [Permission Modes](#permission-modes)
-8. [Headless Mode](#headless-mode)
-9. [Session Management](#session-management)
-10. [Interactive Features](#interactive-features)
-11. [Voice Dictation](#voice-dictation)
-12. [Channels](#channels)
-13. [Chrome Integration](#chrome-integration)
-14. [Remote Control](#remote-control)
-15. [Web Sessions](#web-sessions)
-16. [Desktop App](#desktop-app)
-17. [Task List](#task-list)
-18. [Prompt Suggestions](#prompt-suggestions)
-19. [Git Worktrees](#git-worktrees)
-20. [Sandboxing](#sandboxing)
-21. [Managed Settings (Enterprise)](#managed-settings-enterprise)
-22. [Configuration and Settings](#configuration-and-settings)
-23. [Agent Teams](#agent-teams)
-24. [Best Practices](#best-practices)
-25. [Additional Resources](#additional-resources)
+3. [Ultraplan (Cloud Plan Drafting)](#ultraplan-cloud-plan-drafting)
+4. [Extended Thinking](#extended-thinking)
+5. [Auto Mode](#auto-mode)
+6. [Background Tasks](#background-tasks)
+7. [Monitor Tool (Event-Driven Streams)](#monitor-tool-event-driven-streams)
+8. [Scheduled Tasks](#scheduled-tasks)
+9. [Permission Modes](#permission-modes)
+10. [Headless Mode](#headless-mode)
+11. [Session Management](#session-management)
+12. [Interactive Features](#interactive-features)
+13. [Voice Dictation](#voice-dictation)
+14. [Channels](#channels)
+15. [Chrome Integration](#chrome-integration)
+16. [Remote Control](#remote-control)
+17. [Web Sessions](#web-sessions)
+18. [Desktop App](#desktop-app)
+19. [Task List](#task-list)
+20. [Prompt Suggestions](#prompt-suggestions)
+21. [Git Worktrees](#git-worktrees)
+22. [Sandboxing](#sandboxing)
+23. [Managed Settings (Enterprise)](#managed-settings-enterprise)
+24. [Configuration and Settings](#configuration-and-settings)
+25. [Agent Teams](#agent-teams)
+26. [Best Practices](#best-practices)
+27. [Additional Resources](#additional-resources)
 
 ---
 
@@ -197,9 +199,59 @@ claude --model opusplan "design and implement the new API"
 
 **Edit plan externally**: Press `Ctrl+G` to open the current plan in your external editor for detailed modifications.
 
-### Ultraplan
+---
 
-Use `/ultraplan <prompt>` for an end-to-end planning workflow: Claude drafts a detailed plan, opens it in the browser for review, then executes the plan either remotely or sends it back to your terminal for local execution.
+## Ultraplan (Cloud Plan Drafting)
+
+> **New in v2.1.101**: Ultraplan now auto-creates a Claude Code on the web cloud environment the first time you invoke it — no manual setup, no waiting for a container to warm up before the draft starts.
+
+> **Note**: Ultraplan is a research preview and requires Claude Code v2.1.91 or newer.
+
+`/ultraplan` hands a planning task from your local CLI to a Claude Code on the web session running in plan mode. Claude drafts the plan in the cloud while your terminal stays free for other work, then you review the draft in the browser and choose where to execute — in the same cloud session or teleported back to your terminal.
+
+### When to Use Ultraplan
+
+- You want a richer review surface than the terminal: inline comments, emoji reactions, an outline sidebar, and persistent history.
+- You want hands-off drafting while you keep coding locally — the cloud session researches the repo and writes the plan without blocking your CLI.
+- The plan needs stakeholder review before execution — a shareable web URL beats pasting terminal scrollback.
+
+### Requirements
+
+- A Claude Code on the web account.
+- A GitHub repository (the cloud session clones your repo to draft against real code).
+- **Not available** on Amazon Bedrock, Google Cloud Vertex AI, or Microsoft Foundry.
+
+### Three Ways to Launch
+
+- **Command**: `/ultraplan <prompt>` — explicit invocation.
+- **Keyword**: include the word `ultraplan` anywhere in a normal prompt and Claude routes the request to the cloud.
+- **From a local plan**: after Claude finishes a plan locally, pick "No, refine with Ultraplan on Claude Code on the web" in the approval dialog to hand the draft off for deeper research.
+
+### Usage Example
+
+```bash
+/ultraplan migrate the auth service from sessions to JWTs
+```
+
+Claude acknowledges, spins up the cloud environment (auto-created on first run in v2.1.101+), and returns a session link you can open in your browser.
+
+### Status Indicators
+
+| Status | Meaning |
+|---|---|
+| `◇ ultraplan` | Claude is researching your codebase and drafting the plan |
+| `◇ ultraplan needs your input` | Claude has a clarifying question; open the session link to respond |
+| `◆ ultraplan ready` | The plan is ready to review in your browser |
+
+### Execution Options
+
+Once the plan is ready, you have two execution paths. Approve the plan in the browser to execute in the same cloud session — Claude implements the changes remotely and opens a pull request from the web UI. Or choose "Approve plan and teleport back to terminal" to implement locally. The terminal teleport dialog offers three choices:
+
+- **Implement here** — run the approved plan in your current terminal session.
+- **Start new session** — open a fresh session in the same working directory and implement there.
+- **Cancel** — saves the plan to a file so you can pick it up later.
+
+> **Warning**: Remote Control disconnects when ultraplan starts. Both features share the claude.ai/code interface, so only one can be active at a time.
 
 ---
 
@@ -588,6 +640,38 @@ Claude: [Shows linter output from bg-5002]
   }
 }
 ```
+
+---
+
+## Monitor Tool (Event-Driven Streams)
+
+> **New in v2.1.98**: The Monitor tool lets Claude watch a background command's stdout and react the moment a matching event appears — replacing polling loops and `sleep` for waiting on long-running processes.
+
+Monitor attaches to any shell command that writes to stdout. Each stdout line from the command becomes a notification that wakes the session. Claude specifies the command; the harness streams output and delivers events as they fire. See the related [Background Tasks](#background-tasks) section for launching the underlying processes.
+
+### Why It Matters
+
+Polling with `/loop` or `sleep` burns a full API round-trip every cycle, whether or not anything changed. Monitor stays silent until an event fires, consuming **zero tokens** while the command is quiet. When an event does occur, Claude reacts immediately — no delayed discovery waiting for the next poll tick. For anything that runs longer than a few minutes, this is both cheaper and faster than poll loops.
+
+### Two Common Patterns
+
+**Stream filters** watch continuous output from a long-running source. The command runs forever; every matching line is an event.
+
+```bash
+tail -f /var/log/app.log | grep --line-buffered "ERROR"
+```
+
+**Poll-and-emit filters** check a source periodically and only emit when something changes. Use this for APIs, databases, or anything without a native stream.
+
+```bash
+while true; do gh api repos/owner/repo/issues/123/comments?since=$last; sleep 30; done
+```
+
+### Concrete Example
+
+"Start my dev server and monitor it for errors." Claude launches the server as a background task, attaches a Monitor filter (`tail -F server.log | grep --line-buffered -E "ERROR|FATAL"`), and the session goes quiet. The moment an error line appears in the log, Claude wakes up, reads the error, and can react — restart the server, fix the bug, or surface it to you — without you having to check in.
+
+> **Warning**: When piping into `grep`, **always** use `grep --line-buffered`. Without it, grep buffers stdout in 4KB chunks, which can delay events by minutes on low-traffic streams. This is the #1 way Monitor breaks in practice — if your filter seems silent when it shouldn't be, check for the `--line-buffered` flag first.
 
 ---
 
@@ -1940,6 +2024,12 @@ For more information about Claude Code and related features:
 - [Official Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/ultraplan
+- https://code.claude.com/docs/en/tools-reference
+- https://code.claude.com/docs/en/scheduled-tasks
+- https://code.claude.com/docs/en/remote-control
+- https://code.claude.com/docs/en/agent-teams
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -664,7 +664,12 @@ tail -f /var/log/app.log | grep --line-buffered "ERROR"
 **Poll-and-emit filters** check a source periodically and only emit when something changes. Use this for APIs, databases, or anything without a native stream.
 
 ```bash
-while true; do gh api repos/owner/repo/issues/123/comments?since=$last; sleep 30; done
+last=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+while true; do
+  gh api "repos/owner/repo/issues/123/comments?since=$last" || true
+  last=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  sleep 30
+done
 ```
 
 ### Concrete Example

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -832,6 +832,10 @@ claude -p --output-format json "query"
 *Part of the [Claude How To](../) guide series*
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/cli-reference
+- https://code.claude.com/docs/en/commands
+- https://code.claude.com/docs/en/headless
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -85,6 +85,8 @@ Commands are user-invoked shortcuts that execute specific actions.
 | `/fast` | Toggle fast output mode | Speed up responses |
 | `/terminal-setup` | Configure terminal integration | Setup terminal features |
 | `/upgrade` | Check for updates | Version management |
+| `/team-onboarding` | Generate a teammate ramp-up guide from this project's Claude Code usage | Onboarding new teammates (v2.1.101) |
+| `/ultraplan` | Hand a planning task to a Claude Code web session in plan mode | Heavy planning offload (Research Preview, v2.1.91+) |
 
 ### Custom Commands (Examples)
 
@@ -513,5 +515,8 @@ chmod +x ~/.claude/hooks/*.sh
 
 ---
 
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/commands

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@
 
 > Quick reference guide to all Claude Code features: commands, agents, skills, plugins, and hooks.
 
-**Navigation**: [Commands](#slash-commands) | [Permission Modes](#permission-modes) | [Subagents](#subagents) | [Skills](#skills) | [Plugins](#plugins) | [MCP Servers](#mcp-servers) | [Hooks](#hooks) | [Memory](#memory-files) | [New Features](#new-features-march-2026)
+**Navigation**: [Commands](#slash-commands) | [Permission Modes](#permission-modes) | [Subagents](#subagents) | [Skills](#skills) | [Plugins](#plugins) | [MCP Servers](#mcp-servers) | [Hooks](#hooks) | [Memory](#memory-files) | [New Features](#new-features-april-2026)
 
 ---
 
@@ -431,10 +431,13 @@ cp 02-memory/personal-CLAUDE.md ~/.claude/CLAUDE.md
 
 ---
 
-## New Features (March 2026)
+## New Features (April 2026)
 
 | Feature | Description | How to Use |
 |---------|-------------|------------|
+| **Monitor Tool** | Watch a background command's stdout stream and react to events instead of polling (v2.1.98+) | Use the Monitor tool via [Advanced Features](09-advanced-features/) |
+| **/team-onboarding** | Auto-generate a teammate ramp-up guide from the project's Claude Code setup (v2.1.101) | Run `/team-onboarding` in your project |
+| **Ultraplan auto-create** | Cloud environment created automatically on first `/ultraplan` invocation — no manual setup required (v2.1.101) | Use `/ultraplan <prompt>` |
 | **Remote Control** | Control Claude Code sessions remotely via API | Use the remote control API to send prompts and receive responses programmatically |
 | **Web Sessions** | Run Claude Code in a browser-based environment | Access via `claude web` or through the Anthropic Console |
 | **Desktop App** | Native desktop application for Claude Code | Use `/desktop` or download from Anthropic website |

--- a/INDEX.md
+++ b/INDEX.md
@@ -874,8 +874,10 @@ Want to add more examples? Follow the structure:
 
 ---
 
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/overview
 **Total Examples**: 100+ files
 **Categories**: 10 features
 **Hooks**: 8 automation scripts

--- a/LEARNING-ROADMAP.md
+++ b/LEARNING-ROADMAP.md
@@ -738,8 +738,11 @@ Once you've completed all milestones:
 
 ---
 
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/quickstart
 **Maintained by**: Claude How-To Contributors
 **License**: Educational purposes, free to use and adapt
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -505,5 +505,8 @@ Getting started checklist:
 **This Card**: Keep it handy for quick reference!
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/commands
+- https://code.claude.com/docs/en/cli-reference

--- a/README.md
+++ b/README.md
@@ -869,6 +869,9 @@ MIT License - see [LICENSE](LICENSE). Free to use, modify, and distribute. The o
 
 ---
 
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/commands
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/claude_concepts_guide.md
+++ b/claude_concepts_guide.md
@@ -3126,10 +3126,14 @@ Complete configuration example:
 
 ---
 
-*Last updated: April 2026*
+*Last updated: April 11, 2026*
 *For Claude Haiku 4.5, Sonnet 4.6, and Opus 4.6*
 *Now includes: Hooks, Checkpoints, Planning Mode, Extended Thinking, Background Tasks, Permission Modes (6 modes), Headless Mode, Session Management, Auto Memory, Agent Teams, Scheduled Tasks, Chrome Integration, Channels, Voice Dictation, and Bundled Skills*
 
 ---
-**Last Updated**: April 9, 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/memory
+- https://code.claude.com/docs/en/skills

--- a/resources.md
+++ b/resources.md
@@ -246,6 +246,10 @@ These steps capture the core recommendations for smooth workflows with Claude Co
 | **Scheduled Tasks** | Set up recurring tasks with `/loop` and cron tools | [Advanced Features](09-advanced-features/) |
 | **Chrome Integration** | Browser automation with headless Chromium | [Advanced Features](09-advanced-features/) |
 | **Keyboard Customization** | Customize keybindings including chord sequences | [Advanced Features](09-advanced-features/) |
+| **Monitor Tool** | Watch a background command's stdout stream and react to events instead of polling (v2.1.98+) | [Advanced Features](09-advanced-features/) |
 
 ---
-**Last Updated**: April 9, 2026
+**Last Updated**: April 11, 2026
+**Claude Code Version**: 2.1.101
+**Sources**:
+- https://code.claude.com/docs/en/overview


### PR DESCRIPTION
## Summary

- **Version bump**: all English docs refreshed from v2.1.97 to **v2.1.101** (released April 10, 2026), dated April 11, 2026
- **Mandatory `Sources` footer block** added to all 17 touched files — this field was previously missing from every footer
- **Three new feature sections** written for features shipped between v2.1.98 and v2.1.101

## New features documented

| Feature | Version | Where |
|---|---|---|
| `/team-onboarding` — built-in command that generates a teammate ramp-up guide from local Claude Code usage | v2.1.101 | `01-slash-commands/README.md` (full section + commands table row), `CATALOG.md` |
| `/ultraplan` — hands a planning task from the local CLI to a Claude Code on the web session running in plan mode | research preview, v2.1.91+ (cloud-env auto-creation in v2.1.101) | `09-advanced-features/README.md` (new top-level section, replaces prior 3-line stub), `CATALOG.md` |
| **Monitor tool** — lets Claude watch a background command's stdout and react to events instead of polling | v2.1.98 | `09-advanced-features/README.md` (new top-level section with stream-filter and poll-emit patterns, `grep --line-buffered` warning), `resources.md` feature table |

## Scope

- English only. Vietnamese (`vi/`) and Chinese (`zh/`) translations are intentionally not touched in this sync and will need a follow-up PR to match.
- No content rewrites outside the three new feature sections and the footer refresh — existing tutorials were already accurate against current docs.

## Files changed

17 files, +221 / -59:
- 10 module READMEs (`01-slash-commands` through `10-cli`)
- 7 cross-cutting reference docs (`README.md`, `CATALOG.md`, `LEARNING-ROADMAP.md`, `QUICK_REFERENCE.md`, `INDEX.md`, `claude_concepts_guide.md`, `resources.md`)

## Sources consulted

- https://github.com/anthropics/claude-code/releases (v2.1.97 → v2.1.101 changelogs)
- https://code.claude.com/docs/en/ultraplan
- https://code.claude.com/docs/en/commands
- https://code.claude.com/docs/en/skills
- https://code.claude.com/docs/en/tools-reference

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass locally (markdown-lint, cross-references, 146 Mermaid diagrams, 119 external URLs, EPUB build)
- [ ] CI green on this PR
- [ ] Spot-check rendered `/team-onboarding`, `/ultraplan`, and Monitor tool sections on GitHub
- [ ] Confirm every touched file ends with the mandatory `Last Updated` / `Claude Code Version` / `Sources` footer