### PR TITLE
Fixed a configuration error in the hooks Chinese guide

### DIFF
--- a/zh/06-hooks/README.md
+++ b/zh/06-hooks/README.md
@@ -42,15 +42,29 @@ chmod +x ~/.claude/hooks/*.sh
 ```json
 {
   "hooks": {
-    "PreToolUse": [{
-      "matcher": "Write",
-      "hooks": ["~/.claude/hooks/format-code.sh"]
-    }],
-    "PostToolUse": [{
-      "matcher": "Write",
-      "hooks": ["~/.claude/hooks/security-scan.sh"]
-    }]
-  }
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/format-code.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/security-scan.sh"
+          }
+        ]
+      }
+    ]
+  },
 }
 ```
 

--- a/zh/06-hooks/README.md
+++ b/zh/06-hooks/README.md
@@ -64,7 +64,7 @@ chmod +x ~/.claude/hooks/*.sh
         ]
       }
     ]
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
## Description
Fixed a configuration error in the hooks Chinese guide (zh/06-hooks/README.md). The `hooks` field was incorrectly defined as a string array instead of an object array, 
causing Claude Code to throw an error when users applied this configuration.

## Type of Change
- [ ] New example or template
- [ ] Documentation improvement
- [x] Bug fix
- [ ] Feature guide
- [ ] Other (please describe)

## Related Issues

## Changes Made
- Changed `hooks` field from string array to object array in `PreToolUse` example
- Fixed configuration structure to match the schema: `hooks: [{ type, command}]`

## What to Review
- The `hooks` field now contains proper object structure
- Is the Chinese guide outdated compared to the English version?（Need help?)
- No other similar type errors exist in the Chinese guide

## Files Changed
- `zh/06-hooks/README.md`

## Testing
How have you tested this?
- [x] Tested locally with Claude Code
- [ ] Verified examples work
- [x] Checked links and references
- [x] Reviewed for typos and clarity

## Checklist
- [x] Follows project structure and conventions
- [x] Includes clear documentation/examples
- [x] Code/examples are copy-paste ready
- [x] All links are verified and working
- [x] No sensitive information included (keys, tokens, credentials)
- [ ] Updated relevant README files
- [x] Commit message follows conventional commit format
- [x] No large files (>1MB) added

## Screenshots or Examples
**Before (incorrect):**
```json
{
"PreToolUse": [{
      "matcher": "Write",
      "hooks": ["~/.claude/hooks/format-code.sh"]
    }]
}
```
**After (correct)**
```json
{
"PreToolUse": [
      {
        "matcher": "Write",
        "hooks": [
          {
            "type": "command",
            "command": "~/.claude/hooks/format-code.sh"
          }
        ]
      }
    ]
}
```


## Breaking Changes
Does this change any existing content or behavior?
- [x] No breaking changes
- [ ] Yes, and it's documented below

If yes, please describe:

## Additional Notes
Thanks for your open source spirit！
