### PR TITLE
docs: sync to Claude Code v2.1.110 (TUI, push notifications, session recap)

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -43,6 +43,7 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/extra-usage` | Configure extra usage for rate limits |
 | `/fast [on\|off]` | Toggle fast mode |
 | `/feedback` | Submit feedback (alias: `/bug`) |
+| `/focus` | Toggle focus view (added v2.1.110; replaces `Ctrl+O` for focus toggle) |
 | `/help` | Show help |
 | `/hooks` | View hook configurations |
 | `/ide` | Manage IDE integrations |
@@ -61,9 +62,11 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/permissions` | View/update permissions (alias: `/allowed-tools`) |
 | `/plan [description]` | Enter plan mode |
 | `/plugin` | Manage plugins |
+| `/proactive` | Alias for `/loop` (added v2.1.105) |
 | `/powerup` | Discover features through interactive lessons with animated demos |
 | `/privacy-settings` | Privacy settings (Pro/Max only) |
 | `/release-notes` | View changelog |
+| `/recap` | Show session recap / summary when returning to a session (added v2.1.108) |
 | `/reload-plugins` | Reload active plugins |
 | `/remote-control` | Remote control from claude.ai (alias: `/rc`) |
 | `/remote-env` | Configure default remote environment |
@@ -83,7 +86,9 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/team-onboarding` | Generate a teammate ramp-up guide from the project's Claude Code setup (new in v2.1.101) |
 | `/terminal-setup` | Configure terminal keybindings |
 | `/theme` | Change color theme |
+| `/tui` | Toggle fullscreen TUI (text user interface) mode with flicker-free rendering (added v2.1.110) |
 | `/ultraplan <prompt>` | Draft plan in ultraplan session, review in browser |
+| `/undo` | Alias for `/rewind` (added v2.1.108) |
 | `/upgrade` | Open upgrade page for higher plan tier |
 | `/usage` | Show plan usage limits and rate limit status |
 | `/voice` | Toggle push-to-talk voice dictation |
@@ -128,6 +133,11 @@ These skills ship with Claude Code and are invoked like slash commands:
 - `/resume` supports `/continue` alias
 - MCP prompts are available as `/mcp__<server>__<prompt>` commands (see [MCP Prompts as Commands](#mcp-prompts-as-commands))
 - `/team-onboarding` added for auto-generating teammate ramp-up guides (v2.1.101)
+- `/tui` command added for flicker-free fullscreen TUI rendering (v2.1.110)
+- `/focus` command added for focus view toggle; `Ctrl+O` now only toggles verbose transcript (v2.1.110)
+- `/recap` command added to manually trigger session context recap (v2.1.108)
+- `/undo` added as alias for `/rewind` (v2.1.108)
+- `/proactive` added as alias for `/loop` (v2.1.105)
 
 ### `/team-onboarding` — Teammate Ramp-Up Guide
 
@@ -584,8 +594,8 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 - [CLI Reference](https://code.claude.com/docs/en/cli-reference) - Command-line options
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/commands

--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -1151,8 +1151,8 @@ For the most up-to-date information, refer to the official Claude Code documenta
 - [Official Memory Docs](https://code.claude.com/docs/en/memory) - Anthropic documentation
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/memory
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -806,8 +806,8 @@ Once you start building skills seriously, two things become essential: a library
 - [Hooks Guide](../06-hooks/) - Event-driven automation
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/skills
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/04-subagents/README.md
+++ b/04-subagents/README.md
@@ -1137,8 +1137,8 @@ graph TD
 - [Hooks Guide](../06-hooks/) - For event-driven automation
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/sub-agents
 - https://code.claude.com/docs/en/agent-teams

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -1108,8 +1108,8 @@ export GITHUB_TOKEN="your_token"
 - [Claude API Documentation](https://docs.anthropic.com)
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/mcp
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/06-hooks/README.md
+++ b/06-hooks/README.md
@@ -1165,8 +1165,8 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 - **[Memory Guide](../02-memory/)** - Persistent context configuration
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/hooks
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/07-plugins/README.md
+++ b/07-plugins/README.md
@@ -251,6 +251,29 @@ Plugins have access to a persistent state directory via the `${CLAUDE_PLUGIN_DAT
 
 The directory is created automatically when the plugin is installed. Files stored here persist until the plugin is uninstalled.
 
+### Background Monitors (v2.1.105)
+
+Plugins can register background monitors that auto-arm when a session starts or when the plugin's skill is invoked. Add a top-level `monitors` key to your plugin manifest:
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "monitors": [
+    {
+      "command": "tail -f /var/log/app.log",
+      "trigger": "session_start"
+    }
+  ]
+}
+```
+
+The `trigger` field accepts:
+- `"session_start"` — arm the monitor automatically when a session begins
+- `"skill_invoke"` — arm the monitor when the plugin's skill is invoked
+
+Monitors use the same Monitor tool under the hood, streaming stdout lines as events Claude can react to.
+
 ## Inline Plugin via Settings (`source: 'settings'`) (v2.1.80+)
 
 Plugins can be defined inline in settings files as marketplace entries using the `source: 'settings'` field. This allows embedding a plugin definition directly without requiring a separate repository or marketplace:
@@ -944,8 +967,8 @@ The following Claude Code features work together with plugins:
 - [Hook System Reference](../06-hooks/README.md)
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/plugins
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/08-checkpoints/README.md
+++ b/08-checkpoints/README.md
@@ -315,8 +315,8 @@ Key benefits:
 Remember: checkpoints are not a replacement for git. Use checkpoints for rapid experimentation and git for permanent code changes.
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/checkpointing
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -21,21 +21,22 @@ Comprehensive guide to Claude Code's advanced capabilities including planning mo
 10. [Headless Mode](#headless-mode)
 11. [Session Management](#session-management)
 12. [Interactive Features](#interactive-features)
-13. [Voice Dictation](#voice-dictation)
-14. [Channels](#channels)
-15. [Chrome Integration](#chrome-integration)
-16. [Remote Control](#remote-control)
-17. [Web Sessions](#web-sessions)
-18. [Desktop App](#desktop-app)
-19. [Task List](#task-list)
-20. [Prompt Suggestions](#prompt-suggestions)
-21. [Git Worktrees](#git-worktrees)
-22. [Sandboxing](#sandboxing)
-23. [Managed Settings (Enterprise)](#managed-settings-enterprise)
-24. [Configuration and Settings](#configuration-and-settings)
-25. [Agent Teams](#agent-teams)
-26. [Best Practices](#best-practices)
-27. [Additional Resources](#additional-resources)
+13. [TUI Mode (Fullscreen)](#tui-mode-fullscreen)
+14. [Voice Dictation](#voice-dictation)
+15. [Channels](#channels)
+16. [Chrome Integration](#chrome-integration)
+17. [Remote Control](#remote-control)
+18. [Web Sessions](#web-sessions)
+19. [Desktop App](#desktop-app)
+20. [Task List](#task-list)
+21. [Prompt Suggestions](#prompt-suggestions)
+22. [Git Worktrees](#git-worktrees)
+23. [Sandboxing](#sandboxing)
+24. [Managed Settings (Enterprise)](#managed-settings-enterprise)
+25. [Configuration and Settings](#configuration-and-settings)
+26. [Agent Teams](#agent-teams)
+27. [Best Practices](#best-practices)
+28. [Additional Resources](#additional-resources)
 
 ---
 
@@ -1030,6 +1031,23 @@ claude -r "auth-refactor"
 claude --resume auth-refactor --fork-session "alternative approach"
 ```
 
+### Session Recap (v2.1.108)
+
+When you return to a session after being away, Claude can show a brief recap of what was accomplished. This is enabled by default for users with telemetry disabled (Bedrock, Vertex, Foundry users).
+
+**Control recap behavior:**
+
+```bash
+/recap                                 # manually trigger a recap
+/config                                # toggle auto-recap on/off
+```
+
+Or via environment variable:
+```bash
+CLAUDE_CODE_ENABLE_AWAY_SUMMARY=0 claude   # disable recap
+CLAUDE_CODE_ENABLE_AWAY_SUMMARY=1 claude   # force enable recap
+```
+
 ---
 
 ## Interactive Features
@@ -1238,6 +1256,41 @@ Use this for quick command execution without switching contexts.
 
 ---
 
+## TUI Mode (Fullscreen)
+
+> **New in v2.1.110**
+
+TUI (Text User Interface) mode renders Claude Code in fullscreen with flicker-free output — ideal for terminal multiplexers like tmux or iTerm2 split panes.
+
+### Enabling TUI Mode
+
+Toggle TUI mode with the `/tui` command or launch with the `--tui` flag:
+
+```bash
+/tui          # toggle from within a session
+claude --tui  # start directly in TUI mode
+```
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `autoScrollEnabled` | Auto-scroll to latest message | `true` |
+
+Disable auto-scroll via `/config` or `settings.json`:
+
+```json
+{
+  "autoScrollEnabled": false
+}
+```
+
+### Focus View
+
+The `/focus` command toggles focus view — a distraction-free display showing only the most relevant output. `Ctrl+O` now toggles between normal and verbose transcript only (focus view is `/focus`).
+
+---
+
 ## Voice Dictation
 
 Voice Dictation provides push-to-talk voice input for Claude Code, allowing you to speak your prompts instead of typing them.
@@ -1425,6 +1478,16 @@ Three ways to connect from another device:
 - Control Claude Code from a mobile device or tablet while away from your desk
 - Use the richer claude.ai UI while maintaining local tool execution
 - Quick code reviews on the go with your full local development environment
+
+### Push Notifications (v2.1.110)
+
+When Remote Control is active and "Push when Claude decides" is enabled in `/config`, Claude can send mobile push notifications to your phone — for example, when a long task completes or needs your input.
+
+To enable:
+1. Activate Remote Control: `/remote-control` or `claude --rc`
+2. Open `/config` and enable **Push when Claude decides**
+
+Push notifications require a Claude subscription and the Claude mobile app.
 
 ---
 
@@ -1856,6 +1919,9 @@ export CLAUDE_CODE_SIMPLE=true              # Set by --bare flag
 export MAX_MCP_OUTPUT_TOKENS=50000
 export ENABLE_TOOL_SEARCH=true
 
+# Prompt caching
+export ENABLE_PROMPT_CACHING_1H=1      # Use 1-hour prompt cache TTL (default is 5 min)
+
 # Task management
 export CLAUDE_CODE_TASK_LIST_ID=my-project-tasks
 
@@ -1874,6 +1940,8 @@ export CLAUDE_STREAM_IDLE_TIMEOUT_MS=30000
 export ANTHROPIC_CUSTOM_MODEL_OPTION=my-custom-model
 export SLASH_COMMAND_TOOL_CHAR_BUDGET=50000
 ```
+
+> **v2.1.108**: `ENABLE_PROMPT_CACHING_1H=1` — use a 1-hour prompt cache TTL instead of the default 5-minute TTL. Reduces cache misses in long, stable sessions.
 
 ### Configuration Management Commands
 
@@ -2029,12 +2097,14 @@ For more information about Claude Code and related features:
 - [Official Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/ultraplan
 - https://code.claude.com/docs/en/tools-reference
 - https://code.claude.com/docs/en/scheduled-tasks
 - https://code.claude.com/docs/en/remote-control
 - https://code.claude.com/docs/en/agent-teams
+- https://code.claude.com/docs/en/changelog
+- https://code.claude.com/docs/en/settings
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.6, Claude Haiku 4.5

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -70,6 +70,7 @@ graph TD
 | `--maintenance` | Run maintenance hooks and exit | `claude --maintenance` |
 | `--disable-slash-commands` | Disable all skills and slash commands | `claude --disable-slash-commands` |
 | `--no-session-persistence` | Disable session saving (print mode) | `claude -p --no-session-persistence "query"` |
+| `--exclude-dynamic-system-prompt-sections` | Exclude dynamic sections from the system prompt for better prompt cache hit rates | `claude -p --exclude-dynamic-system-prompt-sections "query"` |
 
 ### Interactive vs Print Mode
 
@@ -728,6 +729,7 @@ The "ultrathink" keyword in prompts activates deep reasoning. The `max` effort l
 | `SLASH_COMMAND_TOOL_CHAR_BUDGET` | Character budget for slash command tools |
 | `ENABLE_TOOL_SEARCH` | Enable tool search capability |
 | `MAX_MCP_OUTPUT_TOKENS` | Maximum tokens for MCP tool output |
+| `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce mode — treats files as read-only by default (for Perforce/P4 version control workflows) (added v2.1.98) |
 
 ---
 
@@ -832,8 +834,8 @@ claude -p --output-format json "query"
 *Part of the [Claude How To](../) guide series*
 
 ---
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/cli-reference
 - https://code.claude.com/docs/en/commands

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -15,7 +15,7 @@
 
 | Feature | Built-in | Examples | Total | Reference |
 |---------|----------|----------|-------|-----------|
-| **Slash Commands** | 55+ | 8 | 63+ | [01-slash-commands/](01-slash-commands/) |
+| **Slash Commands** | 60+ | 8 | 68+ | [01-slash-commands/](01-slash-commands/) |
 | **Subagents** | 6 | 11 | 17 | [04-subagents/](04-subagents/) |
 | **Skills** | 5 bundled | 4 | 9 | [03-skills/](03-skills/) |
 | **Plugins** | - | 3 | 3 | [07-plugins/](07-plugins/) |
@@ -53,6 +53,8 @@ Commands are user-invoked shortcuts that execute specific actions.
 | `/passes` | View usage passes | Subscription info |
 | `/plugin` | Manage plugins | Install/remove extensions |
 | `/plan` | Enter planning mode | Complex implementations |
+| `/proactive` | Alias for `/loop` | Same as `/loop` |
+| `/recap` | Show session recap when returning to a session | After being away, get context on what was done |
 | `/rewind` | Rewind to checkpoint | Undo changes, explore alternatives |
 | `/checkpoint` | Manage checkpoints | Save/restore states |
 | `/cost` | Show token usage costs | Monitor spending |
@@ -72,18 +74,21 @@ Commands are user-invoked shortcuts that execute specific actions.
 | `/rename` | Rename current session | Organize sessions |
 | `/resume` | Resume previous session | Continue work |
 | `/todo` | View/manage todo list | Track tasks |
+| `/tui` | Toggle fullscreen TUI (text user interface) mode | Flicker-free rendering in fullscreen/tmux |
 | `/tasks` | View background tasks | Monitor async operations |
 | `/copy` | Copy last response to clipboard | Share output quickly |
 | `/teleport` | Transfer session to another machine | Continue work remotely |
 | `/desktop` | Open Claude Desktop app | Switch to desktop interface |
 | `/theme` | Change color theme | Customize appearance |
 | `/usage` | Show API usage statistics | Monitor quota and costs |
+| `/focus` | Toggle focus view (distraction-free output display) | Reduce visual noise during long tasks |
 | `/fork` | Fork current conversation | Explore alternatives |
 | `/stats` | Show session statistics | Review session metrics |
 | `/statusline` | Configure status line | Customize status display |
 | `/stickers` | View session stickers | Fun rewards |
 | `/fast` | Toggle fast output mode | Speed up responses |
 | `/terminal-setup` | Configure terminal integration | Setup terminal features |
+| `/undo` | Alias for `/rewind` | Same as `/rewind` |
 | `/upgrade` | Check for updates | Version management |
 | `/team-onboarding` | Generate a teammate ramp-up guide from this project's Claude Code usage | Onboarding new teammates (v2.1.101) |
 | `/ultraplan` | Hand a planning task to a Claude Code web session in plan mode | Heavy planning offload (Research Preview, v2.1.91+) |
@@ -435,6 +440,11 @@ cp 02-memory/personal-CLAUDE.md ~/.claude/CLAUDE.md
 
 | Feature | Description | How to Use |
 |---------|-------------|------------|
+| **/focus** | Toggle focus view for distraction-free output display (v2.1.110) | Run `/focus` to reduce visual noise during long tasks |
+| **/proactive** | Alias for `/loop` — same recurring-task behavior (v2.1.110) | Use `/proactive` interchangeably with `/loop` |
+| **/recap** | Show a session recap when returning to an existing session (v2.1.110) | Run `/recap` after being away to get context on what was done |
+| **/tui** | Toggle fullscreen TUI (text user interface) mode for flicker-free rendering (v2.1.110) | Use `/tui` in fullscreen terminals or tmux |
+| **/undo** | Alias for `/rewind` — reverts to the previous checkpoint (v2.1.110) | Use `/undo` interchangeably with `/rewind` |
 | **Monitor Tool** | Watch a background command's stdout stream and react to events instead of polling (v2.1.98+) | Use the Monitor tool via [Advanced Features](09-advanced-features/) |
 | **/team-onboarding** | Auto-generate a teammate ramp-up guide from the project's Claude Code setup (v2.1.101) | Run `/team-onboarding` in your project |
 | **Ultraplan auto-create** | Cloud environment created automatically on first `/ultraplan` invocation — no manual setup required (v2.1.101) | Use `/ultraplan <prompt>` |
@@ -518,8 +528,8 @@ chmod +x ~/.claude/hooks/*.sh
 
 ---
 
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/commands

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -441,10 +441,10 @@ cp 02-memory/personal-CLAUDE.md ~/.claude/CLAUDE.md
 | Feature | Description | How to Use |
 |---------|-------------|------------|
 | **/focus** | Toggle focus view for distraction-free output display (v2.1.110) | Run `/focus` to reduce visual noise during long tasks |
-| **/proactive** | Alias for `/loop` — same recurring-task behavior (v2.1.110) | Use `/proactive` interchangeably with `/loop` |
-| **/recap** | Show a session recap when returning to an existing session (v2.1.110) | Run `/recap` after being away to get context on what was done |
+| **/proactive** | Alias for `/loop` — same recurring-task behavior (v2.1.105) | Use `/proactive` interchangeably with `/loop` |
+| **/recap** | Show a session recap when returning to an existing session (v2.1.108) | Run `/recap` after being away to get context on what was done |
 | **/tui** | Toggle fullscreen TUI (text user interface) mode for flicker-free rendering (v2.1.110) | Use `/tui` in fullscreen terminals or tmux |
-| **/undo** | Alias for `/rewind` — reverts to the previous checkpoint (v2.1.110) | Use `/undo` interchangeably with `/rewind` |
+| **/undo** | Alias for `/rewind` — reverts to the previous checkpoint (v2.1.108) | Use `/undo` interchangeably with `/rewind` |
 | **Monitor Tool** | Watch a background command's stdout stream and react to events instead of polling (v2.1.98+) | Use the Monitor tool via [Advanced Features](09-advanced-features/) |
 | **/team-onboarding** | Auto-generate a teammate ramp-up guide from the project's Claude Code setup (v2.1.101) | Run `/team-onboarding` in your project |
 | **Ultraplan auto-create** | Cloud environment created automatically on first `/ultraplan` invocation — no manual setup required (v2.1.101) | Use `/ultraplan <prompt>` |

--- a/README.md
+++ b/README.md
@@ -869,8 +869,8 @@ MIT License - see [LICENSE](LICENSE). Free to use, modify, and distribute. The o
 
 ---
 
-**Last Updated**: April 11, 2026
-**Claude Code Version**: 2.1.101
+**Last Updated**: April 16, 2026
+**Claude Code Version**: 2.1.110
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/commands


### PR DESCRIPTION
## Summary

Syncs all 10 tutorial module READMEs and root reference docs to Claude Code **v2.1.110** (April 15, 2026), covering changes from v2.1.102 through v2.1.110.

- **5 new commands/aliases documented** in `01-slash-commands` and `CATALOG.md`: `/tui`, `/focus`, `/recap`, `/undo`, `/proactive`
- **Background monitors** (`monitors` manifest key) documented in `07-plugins` (v2.1.105)
- **4 new sections** in `09-advanced-features`: TUI Mode, Push Notifications, Session Recap, `ENABLE_PROMPT_CACHING_1H` env var
- **2 new entries** in `10-cli`: `--exclude-dynamic-system-prompt-sections` flag and `CLAUDE_CODE_PERFORCE_MODE` env var
- **All 12 files** stamped with `Last Updated: April 16, 2026` / `Claude Code Version: 2.1.110`

## Files changed

| File | Changes |
|------|---------|
| `01-slash-commands/README.md` | +5 commands in table + recent changes entries |
| `07-plugins/README.md` | +`monitors` manifest key section |
| `09-advanced-features/README.md` | +TUI mode, push notifications, session recap, prompt cache TTL env var |
| `10-cli/README.md` | +`--exclude-dynamic-system-prompt-sections`, +`CLAUDE_CODE_PERFORCE_MODE` |
| `CATALOG.md` | Command count 55+→60+, 63+→68+; +5 new command rows; +New Features entries |
| `README.md`, `02-memory`, `03-skills`, `04-subagents`, `05-mcp`, `06-hooks`, `08-checkpoints` | Footer-only updates |

## Test plan

- [x] All pre-commit hooks passed (markdown-lint, cross-references, mermaid-syntax ✅ 216 diagrams, link-check, build-epub)
- [x] No broken internal links
- [x] No Mermaid syntax errors introduced
- [x] Footer format consistent across all modified files