### PR TITLE
docs(skills): improve skill loading process diagram clarity

### DIFF
--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -66,19 +66,20 @@ This means you can install many Skills without context penalty—Claude only kno
 ```mermaid
 sequenceDiagram
     participant User
-    participant Claude as Claude
-    participant System as System
-    participant Skill as Skill
+    participant Claude
+    participant System
+    participant SkillInst as Skill Instructions
+    participant SkillRes as Skill Resources
 
     User->>Claude: "Review this code for security issues"
     Claude->>System: Check available skills (metadata)
     System-->>Claude: Skill descriptions loaded at startup
     Claude->>Claude: Match request to skill description
-    Claude->>Skill: bash: read code-review/SKILL.md
-    Skill-->>Claude: Instructions loaded into context
+    Claude->>SkillInst: Read code-review/SKILL.md
+    SkillInst-->>Claude: Level 2: Instructions loaded
     Claude->>Claude: Determine: Need templates?
-    Claude->>Skill: bash: read templates/checklist.md
-    Skill-->>Claude: Template loaded
+    Claude->>SkillRes: Read templates/checklist.md
+    SkillRes-->>Claude: Level 3: Template loaded
     Claude->>Claude: Execute skill instructions
     Claude->>User: Comprehensive code review
 ```


### PR DESCRIPTION
## Summary

Improved the Skill Loading Process sequence diagram to better illustrate the three-level progressive disclosure architecture.

**Changes:**
- Split the single "Skill" participant into two distinct entities:
  - `Skill Instructions` (Level 2) - represents the SKILL.md body
  - `Skill Resources` (Level 3) - represents bundled files (templates, scripts, etc.)
- Fixed inaccurate `bash: read` notation - Claude uses the `Read` tool, not bash commands
- Added explicit "Level 2" and "Level 3" labels on response messages for clarity
- Kept concrete file names in the diagram for beginner-friendliness

**Why:**
The original diagram conflated Level 2 (SKILL.md instructions) and Level 3 (bundled resources) under a single "Skill" entity, which could confuse readers trying to understand the three-level loading architecture. The split makes the distinction explicit and aligns with the terminology used in the preceding table.

**Before:**
```mermaid
sequenceDiagram
    participant Skill as Skill
    Claude->>Skill: bash: read code-review/SKILL.md
    Skill-->>Claude: Instructions loaded into context
    Claude->>Skill: bash: read templates/checklist.md
    Skill-->>Claude: Template loaded
```

**After:**
```mermaid
sequenceDiagram
    participant SkillInst as Skill Instructions
    participant SkillRes as Skill Resources
    Claude->>SkillInst: Read code-review/SKILL.md
    SkillInst-->>Claude: Level 2: Instructions loaded
    Claude->>SkillRes: Read templates/checklist.md
    SkillRes-->>Claude: Level 3: Template loaded
```

## Test plan

- [x] Mermaid diagram syntax validated (passes pre-commit hooks)
- [x] Diagram renders correctly in VSCode with Markdown Preview Mermaid Support extension
- [x] Cross-references and formatting unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)