### PR TITLE
fix(extended-thinking): correct fictional /think command to valid ultrathink keyword

### DIFF
--- a/.claude/skills/lesson-quiz/references/question-bank.md
+++ b/.claude/skills/lesson-quiz/references/question-bank.md
@@ -704,18 +704,18 @@
 
 ### Q4
 - **Category**: practical
-- **Question**: How do you toggle extended thinking during a session?
-- **Options**: A) Type `/think` | B) Press `Option+T` (macOS) or `Alt+T` | C) Use `--thinking` flag | D) It's always enabled and cannot be toggled
+- **Question**: How do you toggle extended thinking visibility during a session?
+- **Options**: A) Type `/effort max` | B) Press `Option+T` (macOS) or `Alt+T` | C) Include "ultrathink" in prompt | D) It's always visible and cannot be toggled
 - **Correct**: B
-- **Explanation**: Option+T (macOS) or Alt+T toggles extended thinking. It's enabled by default for all models. Opus 4.6 supports adaptive effort levels.
+- **Explanation**: Option+T (macOS) or Alt+T toggles extended thinking visibility. For one-off deep reasoning, include "ultrathink" in your prompt; for session-level control, use `/effort` command.
 - **Review**: Extended Thinking section
 
 ### Q5
 - **Category**: conceptual
-- **Question**: Are "think" or "ultrathink" special keywords that activate enhanced thinking?
-- **Options**: A) Yes, they activate deeper reasoning | B) No, they are treated as regular prompt text with no special behavior | C) Only "ultrathink" is special | D) They work only with Opus
-- **Correct**: B
-- **Explanation**: The documentation explicitly states these are regular prompt instructions, not special activation keywords. Extended thinking is controlled via Alt+T toggle and environment variables.
+- **Question**: Does the "ultrathink" keyword trigger deep reasoning?
+- **Options**: A) Yes, it triggers deep reasoning for one response without changing session settings | B) No, it's treated as regular prompt text | C) Yes, but only on Opus 4.6 | D) Yes, and it permanently changes the effort level
+- **Correct**: A
+- **Explanation**: Including "ultrathink" in your prompt adds an in-context instruction for the model to reason more on that turn. It does not change the effort level sent to the API—use `/effort max` for session-level deep reasoning.
 - **Review**: Extended Thinking section
 
 ### Q6

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -315,7 +315,7 @@ claude --effort high "complex architectural review"
 ### Example: Architectural Decision
 
 ```
-User: /think Should we use microservices or a monolith for our e-commerce platform?
+User: ultrathink Should we use microservices or a monolith for our e-commerce platform?
 
 Claude: Let me think through this architectural decision carefully...
 

--- a/uk/09-advanced-features/README.md
+++ b/uk/09-advanced-features/README.md
@@ -262,7 +262,7 @@ claude --effort high "complex architectural review"
 ### Приклад: Архітектурне рішення
 
 ```
-User: /think Should we use microservices or a monolith for our e-commerce platform?
+User: ultrathink Should we use microservices or a monolith for our e-commerce platform?
 
 Claude: Let me think through this architectural decision carefully...
 

--- a/vi/09-advanced-features/README.md
+++ b/vi/09-advanced-features/README.md
@@ -257,7 +257,7 @@ claude --effort high "complex architectural review"
 ### Example: Architectural Decision
 
 ```
-User: /think Should we use microservices or a monolith for our e-commerce platform?
+User: ultrathink Should we use microservices or a monolith for our e-commerce platform?
 
 Claude: Let me think through this architectural decision carefully...
 


### PR DESCRIPTION
## Background

While reviewing the extended thinking documentation, I discovered that the example uses a fictional `/think` slash command that does not exist in Claude Code.

**Verification**: 
- Checked official commands reference: https://code.claude.com/docs/en/commands — **no `/think` command exists**
- Confirmed via `claude --help` — no mention of `/think`
- The official documentation states that including "ultrathink" in your prompt triggers deep reasoning for one response

## Changes

### Example Correction (3 files)
Replace fictional `/think` with valid `ultrathink` keyword:

| File | Change |
|------|--------|
| `09-advanced-features/README.md:318` | `/think` → `ultrathink` |
| `uk/09-advanced-features/README.md:265` | `/think` → `ultrathink` |
| `vi/09-advanced-features/README.md:260` | `/think` → `ultrathink` |

### Quiz Questions Correction
Fix incorrect quiz answers in `question-bank.md`:

**Q4** - Options corrected:
- Old: `A) Type /think | B) Alt+T | C) --thinking flag | D) always enabled`
- New: `A) /effort max | B) Alt+T | C) ultrathink | D) always visible`
- Updated explanation to clarify the distinction between visibility toggle and deep reasoning trigger

**Q5** - Answer corrected:
- Old question implied "ultrathink" has no special behavior (incorrect)
- New question: Does "ultrathink" trigger deep reasoning?
- Correct answer: **Yes**, it triggers deep reasoning for one response without changing session settings
- Explanation: "ultrathink" is an in-context instruction; for session-level control, use `/effort max`

## Reasoning

Per official documentation (https://code.claude.com/docs/en/model-config):

> "For one-off deep reasoning without changing your session setting, include 'ultrathink' in your prompt."

This is distinct from:
- **Effort levels** (`/effort` command, `--effort` flag) — session-level reasoning control
- **Extended thinking visibility** (`Alt+T` toggle) — shows/hides reasoning blocks

## Sources

- https://code.claude.com/docs/en/commands
- https://code.claude.com/docs/en/model-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)