### PR TITLE
docs(plugins): clarify marketplace update vs plugin update and add auto-update documentation

### DIFF
--- a/07-plugins/README.md
+++ b/07-plugins/README.md
@@ -559,6 +559,18 @@ GitHub and git sources support optional `ref` (branch/tag) and `sha` (commit has
 
 **Official marketplace submission**: Submit plugins to the Anthropic-curated marketplace for broader distribution via [claude.ai/settings/plugins/submit](https://claude.ai/settings/plugins/submit) or [platform.claude.com/plugins/submit](https://platform.claude.com/plugins/submit).
 
+### Managing Marketplaces
+
+```bash
+# Marketplace CLI commands
+claude plugin marketplace add <source>       # Add marketplace (GitHub, URL, local)
+claude plugin marketplace update [name]      # Refresh catalog index
+claude plugin marketplace remove <name>      # Remove marketplace
+claude plugin marketplace list               # List configured marketplaces
+```
+
+> **Important**: `marketplace update` only refreshes the plugin catalog (what's available to install). It does NOT update installed plugins. Use `plugin update <name>` to update specific installed plugins.
+
 ### Strict mode
 
 Control how marketplace definitions interact with local `plugin.json` files:
@@ -625,6 +637,7 @@ All plugin operations are available as CLI commands:
 ```bash
 claude plugin install <name>@<marketplace>   # Install from a marketplace
 claude plugin uninstall <name>               # Remove a plugin
+claude plugin update <name>                  # Update installed plugin to latest version
 claude plugin list                           # List installed plugins
 claude plugin enable <name>                  # Enable a disabled plugin
 claude plugin disable <name>                 # Disable a plugin
@@ -656,6 +669,36 @@ claude --plugin-dir ./plugin-a --plugin-dir ./plugin-b
 ### From Git Repository
 ```bash
 /plugin install github:username/repo
+```
+
+## Auto-Update
+
+Claude Code can automatically update marketplaces and their installed plugins at startup.
+
+| Marketplace Type | Auto-Update Default | How to Toggle |
+|------------------|---------------------|---------------|
+| Official (`claude-plugins-official`) | ✅ Enabled | `/plugin` → Marketplaces → Select |
+| Third-party / Local | ❌ Disabled | Same UI path |
+
+When auto-update runs, Claude Code:
+1. Refreshes marketplace catalog
+2. Updates installed plugins to latest versions
+3. Shows notification prompting `/reload-plugins`
+
+### Environment Variables
+
+| Variable | Effect |
+|----------|--------|
+| `DISABLE_AUTOUPDATER=1` | Disable all auto-updates (Claude Code + plugins) |
+| `DISABLE_AUTOUPDATER=1` + `FORCE_AUTOUPDATE_PLUGINS=1` | Keep plugin updates, disable Claude Code updates |
+
+```bash
+# Disable all auto-updates
+export DISABLE_AUTOUPDATER=1
+
+# Keep plugin auto-updates only
+export DISABLE_AUTOUPDATER=1
+export FORCE_AUTOUPDATE_PLUGINS=1
 ```
 
 ## When to Create a Plugin


### PR DESCRIPTION
## Summary

This PR adds documentation to clarify two commonly confused concepts in the plugin system:
1. The distinction between `marketplace update` (refreshes catalog) and `plugin update` (updates installed plugins)
2. The auto-update mechanism behavior for official vs third-party marketplaces

## Background

Users were confused about:
- What `marketplace update` actually does (refreshes the catalog index, does NOT update installed plugins)
- Why official marketplaces auto-refresh at startup while third-party ones don't
- How to control auto-update behavior via environment variables

## Changes

### 1. Managing Marketplaces section (Plugin Marketplace chapter)
Added after "Distribution methods" subsection:
- Marketplace CLI commands (`add`, `update`, `remove`, `list`)
- Important note clarifying the marketplace/plugin update distinction

### 2. Plugin CLI Commands section
- Added `plugin update` command (was missing from the list)

### 3. Auto-Update section (new)
Added after "Installation Methods" section:
- Comparison table: official vs third-party default behavior
- Auto-update workflow steps
- Environment variables table (`DISABLE_AUTOUPDATER`, `FORCE_AUTOUPDATE_PLUGINS`)
- Example bash commands

## Structure Rationale

| Content | Placement | Reason |
|---------|-----------|--------|
| Marketplace commands | Plugin Marketplace chapter | Concept + commands together for cohesive reading |
| Auto-Update | After Installation Methods | Logical flow: install → maintain/update |
| Plugin CLI Commands | Simplified (no marketplace) | Focus on plugin management only |

## Sources

- [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) - auto-update documentation
- [Create and distribute a plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) - marketplace commands

## Test Plan

- [x] Cross-reference check passed (374 files)
- [x] Mermaid validation skipped (mmdc not installed, but no new diagrams added)
- [x] Manual review of changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)