### PR TITLE
docs(CLAUDE.md): Fix inaccuracies and expand build/hook documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,25 +10,6 @@ Claude How To is a tutorial repository for Claude Code features. This is **docum
 
 ## Common Commands
 
-### Pre-commit Quality Checks
-
-All documentation must pass four quality checks before commits (these run automatically via pre-commit hooks):
-
-```bash
-# Install pre-commit hooks (runs on every commit)
-pre-commit install
-
-# Run all checks manually
-pre-commit run --all-files
-```
-
-The four checks are:
-1. **markdown-lint** — Markdown structure and formatting via `markdownlint`
-2. **cross-references** — Internal links, anchors, code fence syntax (Python script)
-3. **mermaid-syntax** — Validates all Mermaid diagrams parse correctly (Python script)
-4. **link-check** — External URLs are reachable (Python script)
-5. **build-epub** — EPUB generates without errors (on `.md` changes)
-
 ### Development Environment Setup
 
 ```bash
@@ -49,9 +30,26 @@ uv pip install pre-commit
 pre-commit install
 ```
 
-### Testing
+### Pre-commit Quality Checks
 
-Python scripts in `scripts/` have unit tests:
+```bash
+# Run all checks manually
+pre-commit run --all-files
+```
+
+Pre-commit runs these hooks in order:
+1. **ruff-lint / ruff-format** — Python linting and formatting (`scripts/` only)
+2. **bandit** — Python security scan (`scripts/` only, excludes `scripts/tests/`)
+3. **mypy** — Python type checking (`scripts/` only)
+4. **markdown-lint** — Markdown structure and formatting via `markdownlint`
+5. **cross-references** — Internal links, anchors, code fence language tags
+6. **mermaid-syntax** — Validates all Mermaid diagrams parse correctly
+7. **link-check** — External URLs are reachable (non-strict by default; set `LINK_CHECK_STRICT=1` to fail on dead links)
+8. **build-epub** — EPUB generates without errors (runs only on `.md` changes)
+
+Steps 1-3 apply only when Python files change; steps 4-8 apply to markdown changes. Vietnamese docs (`vi/**/*.md`) have a parallel set of hooks 5-8.
+
+### Testing
 
 ```bash
 # Run all tests
@@ -60,9 +58,11 @@ pytest scripts/tests/ -v
 # Run with coverage
 pytest scripts/tests/ -v --cov=scripts --cov-report=html
 
-# Run specific test
+# Run specific test file
 pytest scripts/tests/test_build_epub.py -v
 ```
+
+Run `pytest` before `pre-commit` when modifying Python scripts; run `pre-commit run --all-files` when modifying markdown.
 
 ### Code Quality
 
@@ -71,7 +71,7 @@ pytest scripts/tests/test_build_epub.py -v
 ruff check scripts/
 ruff format scripts/
 
-# Security scan
+# Security scan (B101 and B113 are suppressed; tests/ excluded)
 bandit -c scripts/pyproject.toml -r scripts/ --exclude scripts/tests/
 
 # Type checking
@@ -81,12 +81,19 @@ mypy scripts/ --ignore-missing-imports
 ### EPUB Build
 
 ```bash
-# Generate ebook (renders Mermaid diagrams via Kroki.io API)
+# Generate ebook (renders Mermaid diagrams via local mmdc binary)
 uv run scripts/build_epub.py
 
-# With options
-uv run scripts/build_epub.py --verbose --output custom-name.epub --max-concurrent 5
+# Key options
+uv run scripts/build_epub.py --verbose
+uv run scripts/build_epub.py --output custom-name.epub
+uv run scripts/build_epub.py --lang vi          # Vietnamese edition
+uv run scripts/build_epub.py --lang zh          # Chinese edition
+uv run scripts/build_epub.py --mmdc-path /path/to/mmdc   # custom mmdc binary
+uv run scripts/build_epub.py --puppeteer-config puppeteer.json  # CI sandbox config
 ```
+
+Mermaid rendering uses the local `mmdc` binary (installed via `npm install -g @mermaid-js/mermaid-cli`) — no internet required. Build failures are typically due to invalid Mermaid syntax or `mmdc` not being on `PATH`.
 
 ## Directory Structure
 
@@ -101,10 +108,12 @@ uv run scripts/build_epub.py --verbose --output custom-name.epub --max-concurren
 ├── 08-checkpoints/         # Session snapshots
 ├── 09-advanced-features/   # Planning, thinking, backgrounds
 ├── 10-cli/                 # CLI reference
+├── vi/                     # Vietnamese translations (mirrors root structure)
+├── zh/                     # Chinese translations
 ├── scripts/
-│   ├── build_epub.py           # EPUB generator (renders Mermaid via Kroki API)
-│   ├── check_cross_references.py   # Validates internal links
-│   ├── check_links.py          # Checks external URLs
+│   ├── build_epub.py           # EPUB generator (local mmdc rendering)
+│   ├── check_cross_references.py   # Validates internal links and code fence langs
+│   ├── check_links.py          # Checks external URLs (strict mode via env var)
 │   ├── check_mermaid.py        # Validates Mermaid syntax
 │   └── tests/                  # Unit tests for scripts
 ├── .pre-commit-config.yaml    # Quality check definitions
@@ -117,41 +126,37 @@ uv run scripts/build_epub.py --verbose --output custom-name.epub --max-concurren
 Each numbered folder follows the pattern:
 - **README.md** — Overview of the feature with examples
 - **Example files** — Copy-paste templates (`.md` for commands, `.json` for configs, `.sh` for hooks)
-- Files are organized by feature complexity and dependencies
-
-### Mermaid Diagrams
-- All diagrams must parse successfully (checked by pre-commit hook)
-- EPUB build renders diagrams via Kroki.io API (requires internet)
-- Use Mermaid for flowcharts, sequence diagrams, and architecture visuals
 
 ### Cross-References
 - Use relative paths for internal links (e.g., `(01-slash-commands/README.md)`)
-- Code fences must specify language (e.g., ` ```bash `, ` ```python `)
+- Code fences must specify language (e.g., ` ```bash `, ` ```python `) — enforced by `check_cross_references.py`
 - Anchor links use `#heading-name` format
 
+### Mermaid Diagrams
+- All diagrams must parse successfully (checked by `check_mermaid.py`)
+- Use Mermaid for flowcharts, sequence diagrams, and architecture visuals
+
 ### Link Validation
-- External URLs must be reachable (checked by pre-commit hook)
-- Avoid linking to ephemeral content
-- Use permalinks where possible
+- External URLs are checked by `check_links.py` on every commit (non-strict)
+- CI enforces strict mode (`LINK_CHECK_STRICT=1`) — dead links fail the pipeline
+- Use permalinks where possible; avoid linking to ephemeral content
 
 ## Key Architecture Points
 
-1. **Numbered folders indicate learning order** — The 01-10 prefix represents the recommended sequence for learning Claude Code features. This numbering is intentional; do not reorganize alphabetically.
+1. **Numbered folders indicate learning order** — The 01-10 prefix is the recommended learning sequence. Do not reorganize alphabetically.
 
-2. **Scripts are utilities, not the product** — The Python scripts in `scripts/` support documentation quality and EPUB generation. The actual content is in the numbered module folders.
+2. **Scripts are utilities, not the product** — Python scripts in `scripts/` support quality and EPUB generation. Content lives in the numbered module folders.
 
-3. **Pre-commit is the gatekeeper** — All four quality checks must pass before a PR is accepted. The CI pipeline runs these same checks as a second pass.
+3. **Pre-commit is the gatekeeper** — All hooks must pass before a PR is accepted. CI runs the same checks with strict link validation.
 
-4. **Mermaid rendering requires network** — The EPUB build calls Kroki.io API to render diagrams. Build failures here are typically network issues or invalid Mermaid syntax.
+4. **`--lang` flag cascades** — The `--lang` option works across `build_epub.py`, `check_cross_references.py`, `check_mermaid.py`, and `check_links.py` to target translated docs in `vi/` or `zh/`.
 
-5. **This is a tutorial, not a library** — When adding content, focus on clear explanations, copy-paste examples, and visual diagrams. The value is in teaching concepts, not providing reusable code.
+5. **This is a tutorial, not a library** — Focus on clear explanations, copy-paste examples, and visual diagrams. The value is in teaching concepts.
 
 ## Commit Conventions
 
-Follow conventional commit format:
+Follow conventional commit format with folder name as scope:
 - `feat(slash-commands): Add API documentation generator`
 - `docs(memory): Improve personal preferences example`
 - `fix(README): Correct table of contents link`
 - `refactor(hooks): Simplify hook configuration examples`
-
-Scope should match the folder name when applicable.


### PR DESCRIPTION
## Summary

- Removes non-existent `--max-concurrent` flag from `build_epub.py` examples
- Corrects Mermaid rendering: uses local `mmdc` binary, not Kroki.io API
- Fixes pre-commit hook count and adds full execution order (ruff → bandit → mypy → markdown → validation → epub)
- Documents `--lang`, `--mmdc-path`, `--puppeteer-config` flags for `build_epub.py`
- Documents `LINK_CHECK_STRICT=1` env var for strict link validation in CI
- Adds `vi/` and `zh/` translation directories to the structure overview
- Clarifies `--lang` flag cascades across all validation scripts
- Adds workflow guidance for when to run `pytest` vs `pre-commit`

## Test plan

- [ ] Verify `build_epub.py --help` matches documented flags
- [ ] Confirm pre-commit hook order matches `.pre-commit-config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)