### PR TITLE
fix: replace invalid `diff` tool with `bash` in security-reviewer agents

### DIFF
--- a/07-plugins/pr-review/agents/security-reviewer.md
+++ b/07-plugins/pr-review/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Security-focused code review
-tools: read, grep, diff
+tools: read, grep, bash
 ---
 
 # Security Reviewer

--- a/uk/07-plugins/pr-review/agents/security-reviewer.md
+++ b/uk/07-plugins/pr-review/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Код-рев'ю з фокусом на безпеці
-tools: read, grep, diff
+tools: read, grep, bash
 ---
 
 # Рецензент безпеки

--- a/vi/07-plugins/pr-review/agents/security-reviewer.md
+++ b/vi/07-plugins/pr-review/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Security-focused code review
-tools: read, grep, diff
+tools: read, grep, bash
 ---
 
 # Security Reviewer

--- a/zh/07-plugins/pr-review/agents/security-reviewer.md
+++ b/zh/07-plugins/pr-review/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: 面向安全的代码审查
-tools: read, grep, diff
+tools: read, grep, bash
 ---
 
 # 安全审查员


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All four `security-reviewer.md` agent files (English, Vietnamese, Chinese, Ukrainian locales) declare `tools: read, grep, diff` in their YAML frontmatter.

`diff` is **not a valid Claude Code tool name**. The valid built-in tools are `read`, `write`, `edit`, `bash`, `grep`, `glob`, `ls`, and a few others — but not `diff`. At runtime, Claude Code will silently ignore the unknown `diff` entry, meaning the security reviewer loses the ability to compare file contents (which is its primary function).

## Fix

Replace `diff` with `bash` across all four locale files. The `bash` tool allows the agent to invoke `diff`, `git diff`, or any other diff utility as needed.

**Files changed:**
- `07-plugins/pr-review/agents/security-reviewer.md`
- `vi/07-plugins/pr-review/agents/security-reviewer.md`
- `zh/07-plugins/pr-review/agents/security-reviewer.md`
- `uk/07-plugins/pr-review/agents/security-reviewer.md`

## Why it matters

A security reviewer that cannot compare file versions (e.g., `git diff HEAD~1`) is missing its core capability. This is a silent failure — no error is raised, the agent simply lacks the tool it needs.