### PR TITLE
fix: constrain cross-reference resolution to repo root

### DIFF
--- a/scripts/check_cross_references.py
+++ b/scripts/check_cross_references.py
@@ -61,6 +61,7 @@ def strip_code_blocks(content: str) -> str:
 
 def main() -> int:
     errors: list[str] = []
+    repo_root = Path().resolve()
 
     for file_path in iter_md_files():
         content = file_path.read_text(encoding="utf-8")
@@ -68,12 +69,13 @@ def main() -> int:
         # from documentation examples inside code fences.
         scannable = strip_code_blocks(content)
 
-        # Relative .md links must resolve
-        errors.extend(
-            f"{file_path}: broken cross-reference → '{link_path}'"
-            for link_path in re.findall(r"\[[^\]]+\]\(([^)#]+\.md)[^)]*\)", scannable)
-            if not (file_path.parent / link_path).resolve().exists()
-        )
+        # Relative .md links must resolve and must stay within the repo root
+        for link_path in re.findall(r"\[[^\]]+\]\(([^)#]+\.md)[^)]*\)", scannable):
+            resolved = (file_path.parent / link_path).resolve()
+            if not resolved.is_relative_to(repo_root):
+                continue
+            if not resolved.exists():
+                errors.append(f"{file_path}: broken cross-reference → '{link_path}'")
 
         # In-page anchors must match a real heading
         anchors = re.findall(r"\[[^\]]+\]\(#([^)]+)\)", scannable)


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `scripts/check_cross_references.py`, relative markdown links are resolved using:

```python
if not (file_path.parent / link_path).resolve().exists()
```

`Path.resolve()` follows `..` segments without any boundary check. A crafted link like `[text](../../../../../../etc/passwd)` in any tracked markdown file would resolve to a path outside the repository root. While the script only calls `.exists()` (not `.read()`), silently probing arbitrary filesystem paths is unintended behavior.

## Fix

Compute `repo_root = Path().resolve()` once before the loop, then skip any resolved path that is not relative to the repo root:

```python
repo_root = Path().resolve()
for link_path in re.findall(...):
    resolved = (file_path.parent / link_path).resolve()
    if not resolved.is_relative_to(repo_root):
        continue
    if not resolved.exists():
        errors.append(...)
```

This preserves all existing cross-reference checking behavior for normal in-repo links while ignoring any that escape the repository boundary.

## Why it matters

The practical risk in a local pre-commit context is low, but the principle of constraining filesystem access to the repo root is important hygiene — especially if this script is ever run in a server-side CI context where the host filesystem contains sensitive paths.