### PR TITLE
docs: sync to Claude Code v2.1.119

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -25,7 +25,7 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/add-dir <path>` | Add working directory |
 | `/agents` | Manage agent configurations |
 | `/branch [name]` | Branch conversation into a new session (alias: `/fork`). Note: `/fork` renamed to `/branch` in v2.1.77 |
-| `/btw <question>` | Side question without adding to history |
+| `/btw <question>` | Ask an ephemeral side question while Claude is working on the main task; doesn't pollute the main conversation context |
 | `/chrome` | Configure Chrome browser integration |
 | `/clear` | Clear conversation (aliases: `/reset`, `/new`) |
 | `/color [color\|default]` | Set prompt bar color |
@@ -33,10 +33,10 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/config` | Open Settings (alias: `/settings`) |
 | `/context` | Visualize context usage as colored grid |
 | `/copy [N]` | Copy assistant response to clipboard; `w` writes to file |
-| `/cost` | Show token usage statistics |
+| `/cost` | Typing-shortcut alias for `/usage` — opens the cost tab (v2.1.118+) |
 | `/desktop` | Continue in Desktop app (alias: `/app`) |
 | `/diff` | Interactive diff viewer for uncommitted changes |
-| `/doctor` | Diagnose installation health |
+| `/doctor` | Diagnose installation health — openable while Claude is responding; shows status icons; press `f` to auto-fix issues (enhanced in v2.1.116) |
 | `/effort [low\|medium\|high\|xhigh\|max\|auto]` | Set effort level via interactive arrow-key slider. Levels: `low` → `medium` → `high` → `xhigh` (new in v2.1.111) → `max`. Default is `xhigh` on Opus 4.7; `max` requires Opus 4.7 |
 | `/exit` | Exit the REPL (alias: `/quit`) |
 | `/export [filename]` | Export the current conversation to a file or clipboard |
@@ -79,20 +79,20 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/schedule [description]` | Create/manage Cloud scheduled tasks |
 | `/security-review` | Analyze branch for security vulnerabilities |
 | `/skills` | List available skills |
-| `/stats` | Visualize daily usage, sessions, streaks |
+| `/stats` | Typing-shortcut alias for `/usage` — opens the stats tab (daily usage, sessions, streaks) (v2.1.118+) |
 | `/stickers` | Order Claude Code stickers |
 | `/status` | Show version, model, account |
 | `/statusline` | Configure status line |
 | `/tasks` | List/manage background tasks |
 | `/team-onboarding` | Generate a teammate ramp-up guide from the project's Claude Code setup (new in v2.1.101) |
 | `/terminal-setup` | Configure terminal keybindings |
-| `/theme` | Change color theme |
+| `/theme` | Open theme picker / manage custom themes (v2.1.118). Define custom themes via JSON in `~/.claude/themes/<name>.json` |
 | `/tui` | Toggle fullscreen TUI (text user interface) mode with flicker-free rendering (added v2.1.110) |
 | `/ultraplan <prompt>` | Draft plan in ultraplan session, review in browser |
 | `/ultrareview` | Comprehensive cloud-based code review with multi-agent analysis (added v2.1.111) |
 | `/undo` | Alias for `/rewind` (added v2.1.108) |
 | `/upgrade` | Open upgrade page for higher plan tier |
-| `/usage` | Show plan usage limits and rate limit status |
+| `/usage` | Canonical usage dashboard (v2.1.118) — combines plan usage limits, rate limits, cost, and daily session stats. `/cost` and `/stats` are typing-shortcut aliases that open specific tabs |
 | `/voice` | Toggle push-to-talk voice dictation |
 
 ### Bundled Skills
@@ -601,12 +601,14 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code/slash-commands
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/slash-commands
+- https://code.claude.com/docs/en/interactive-mode
+- https://code.claude.com/docs/en/changelog
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.118
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.116
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 
 *Part of the [Claude How To](../) guide series*

--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -310,6 +310,53 @@ Settings can also be configured via:
 
 These platform-native mechanisms are read alongside JSON settings files and follow the same precedence rules.
 
+> **Note (v2.1.119)**: `/config` changes now persist to `~/.claude/settings.json`. Values written via `/config` participate in the normal project/local/policy precedence chain described above — they are no longer session-only. Use `/config` for interactive edits and edit `settings.json` files directly for scripted or managed configuration.
+
+### Retention and Cleanup Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `cleanupPeriodDays` | integer (days) | 30 | Retention window for on-disk artifacts. **As of v2.1.117**, it applies to all four of: checkpoints (`~/.claude/checkpoints/`), tasks (`~/.claude/tasks/`), shell-snapshots (`~/.claude/shell-snapshots/`), and backups (`~/.claude/backups/`). Files older than the window are pruned at startup. |
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "cleanupPeriodDays": 14
+}
+```
+
+### Attribution, Voice, and PR URL Settings
+
+| Setting | Type | Description |
+|---------|------|-------------|
+| `attribution.commit` | boolean | Adds the `Co-Authored-By: Claude` trailer to commits Claude creates. Replaces the deprecated `includeCoAuthoredBy` flag. |
+| `attribution.pr` | boolean | Adds Claude attribution to pull request descriptions. Replaces the deprecated `includeCoAuthoredBy` flag for PRs. |
+| `voice.enabled` | boolean | Enables push-to-talk voice dictation (`/voice`). Replaces the deprecated `voiceEnabled` flag. |
+| `prUrlTemplate` | string | **New in v2.1.119.** Custom URL template for the footer PR badge; useful for GitLab, Bitbucket, or internal code-review platforms. Supports `{{owner}}`, `{{repo}}`, and `{{number}}` placeholders. |
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "attribution": {
+    "commit": false,
+    "pr": true
+  },
+  "voice": {
+    "enabled": true
+  },
+  "prUrlTemplate": "https://gitlab.internal/{{owner}}/{{repo}}/-/merge_requests/{{number}}"
+}
+```
+
+#### Deprecated setting names
+
+The following legacy setting keys still work but are deprecated. Prefer the replacements above.
+
+| Deprecated key | Replacement | Notes |
+|----------------|-------------|-------|
+| `includeCoAuthoredBy` | `attribution.commit` / `attribution.pr` | The old single flag is split into separate commit and PR switches. Users on older installs can keep the legacy key; new projects should use the nested form. |
+| `voiceEnabled` | `voice.enabled` | Grouped under the `voice` namespace alongside future voice-related options. |
+
 ## Modular Rules System
 
 Create organized, path-specific rules using the `.claude/rules/` directory structure. Rules can be defined at both the project level and user level:
@@ -1151,11 +1198,11 @@ For the most up-to-date information, refer to the official Claude Code documenta
 - [Official Memory Docs](https://code.claude.com/docs/en/memory) - Anthropic documentation
 
 ---
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
-- https://docs.anthropic.com/en/docs/claude-code/memory
+- https://code.claude.com/docs/en/memory
+- https://code.claude.com/docs/en/settings
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.117
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -739,6 +739,19 @@ Skill descriptions are loaded at **1% of the context window** (fallback: **8,000
 - **Tool misuse**: Malicious Skills can invoke tools in harmful ways
 - **Treat like installing software**: Only use Skills from trusted sources
 
+### Disabling shell substitution in skills
+
+Skills support the `` !`command` `` syntax to inject the output of shell commands into the prompt before Claude sees it. In security-sensitive environments (shared enterprise deployments, locked-down CI runners) you can disable this substitution entirely via the `disableSkillShellExecution` setting (added in **v2.1.91**):
+
+```jsonc
+// ~/.claude/settings.json or managed policy
+{
+  "disableSkillShellExecution": true
+}
+```
+
+When `disableSkillShellExecution` is `true`, any `` !`command` `` markers in a skill are left as literal text instead of being executed — removing the skill-level shell-injection attack surface without disabling skills themselves. Consider combining this with an `allowedTools` allowlist for defense in depth.
+
 ## Skills vs Other Features
 
 | Feature | Invocation | Best For |
@@ -806,11 +819,10 @@ Once you start building skills seriously, two things become essential: a library
 - [Hooks Guide](../06-hooks/) - Event-driven automation
 
 ---
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
-- https://docs.anthropic.com/en/docs/claude-code/skills
+- https://code.claude.com/docs/en/skills
+- https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/changelog
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/04-subagents/README.md
+++ b/04-subagents/README.md
@@ -133,6 +133,44 @@ to solving problems.
 | `isolation` | No | Set to `worktree` to give the subagent its own git worktree |
 | `initialPrompt` | No | Auto-submitted first turn when the subagent runs as the main agent |
 
+### Main-Thread Agent Frontmatter Honoring (v2.1.117+/v2.1.119+)
+
+When an agent is invoked as the main-thread agent (via `claude --agent <name>` or `--print` mode), these frontmatter fields are honored:
+
+| Field | Version | Notes |
+|-------|---------|-------|
+| `mcpServers` | v2.1.117+ | Loaded when agent is invoked as main-thread agent via `claude --agent <name>` |
+| `permissionMode` | v2.1.119+ | Honored for built-in agents via `--agent <name>` |
+| `tools` / `disallowedTools` | v2.1.119+ | Honored in `--print` mode (non-interactive/scripted usage) |
+
+**Example — agent with `mcpServers` and `permissionMode`:**
+
+```yaml
+---
+name: secure-researcher
+description: Research agent with scoped MCP access and restricted permissions
+permissionMode: acceptEdits
+mcpServers:
+  notion:
+    type: http
+    url: https://mcp.notion.com/mcp
+  github:
+    type: http
+    url: https://api.github.com/mcp
+tools: Read, Grep, Glob
+---
+
+You are a research agent. You may query Notion and GitHub through the
+configured MCP servers, and read local files, but you cannot write or
+execute commands outside of accepted edits.
+```
+
+Run with:
+
+```bash
+claude --agent secure-researcher
+```
+
 ### Tool Configuration Options
 
 **Option 1: Inherit All Tools (omit the field)**
@@ -151,6 +189,8 @@ description: Agent with specific tools only
 tools: Read, Grep, Glob, Bash
 ---
 ```
+
+> **Note on Glob/Grep (v2.1.113+):** On native macOS/Linux builds, Glob and Grep are provided as `bfs`/`ugrep` through the Bash tool rather than as separate tools. Windows and npm-JS builds still expose them as standalone tools. Authors can still reference Glob/Grep in `allowedTools`; the backend substitution is transparent.
 
 **Option 3: Conditional Tool Access**
 ```yaml
@@ -526,6 +566,45 @@ graph TB
 - The subagent operates in its own git worktree on a separate branch
 - If the subagent makes no changes, the worktree is automatically cleaned up
 - If changes exist, the worktree path and branch name are returned to the main agent for review or merging
+
+---
+
+## Forked Subagents
+
+Forked subagents (`context: fork`) inherit the parent agent's full conversation context at the moment of forking, rather than starting with a clean slate. This is useful for exploring alternative paths without losing the work done so far.
+
+> **Availability**: GA in v2.1.117. On external builds (non-first-party distributions), set `CLAUDE_CODE_FORK_SUBAGENT=1` to enable forking.
+
+### Configuration
+
+```yaml
+---
+name: alternative-explorer
+description: Explore an alternative implementation path while preserving parent context
+context: fork
+tools: Read, Edit, Bash, Grep, Glob
+---
+
+You are a forked subagent. You inherit the parent's full conversation and
+may explore an alternative approach. Return your findings and the parent
+will decide whether to adopt them.
+```
+
+### Enabling on External Builds
+
+```bash
+export CLAUDE_CODE_FORK_SUBAGENT=1
+claude
+```
+
+### When to Use Fork vs Clean Context
+
+| Scenario | `context: fork` | Clean context (default) |
+|----------|-----------------|-------------------------|
+| Explore alternative implementations | Yes | No (would lose context) |
+| Long research with existing context | Yes | No |
+| Independent specialized task | No | Yes |
+| Avoiding context pollution | No | Yes |
 
 ---
 
@@ -1137,12 +1216,12 @@ graph TD
 - [Hooks Guide](../06-hooks/) - For event-driven automation
 
 ---
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
-- https://docs.anthropic.com/en/docs/claude-code/sub-agents
+- https://code.claude.com/docs/en/sub-agents
 - https://code.claude.com/docs/en/agent-teams
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.117
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -164,6 +164,8 @@ MCP servers configured in your Claude.ai account are automatically available in 
 
 Claude.ai MCP connectors are also available in `--print` mode (v2.1.83+), enabling non-interactive and scripted usage.
 
+> **Startup note (v2.1.117+):** Concurrent connect is the default when both local and claude.ai MCP servers are configured (previously serial), reducing startup latency when multiple servers are in use.
+
 To disable Claude.ai MCP servers in Claude Code, set the `ENABLE_CLAUDEAI_MCP_SERVERS` environment variable to `false`:
 
 ```bash
@@ -1109,10 +1111,10 @@ export GITHUB_TOKEN="your_token"
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code/mcp
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/mcp
+- https://code.claude.com/docs/en/changelog
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/06-hooks/README.md
+++ b/06-hooks/README.md
@@ -9,12 +9,12 @@ Hooks are automated scripts that execute in response to specific events during C
 
 ## Overview
 
-Hooks are automated actions (shell commands, HTTP webhooks, LLM prompts, or subagent evaluations) that execute automatically when specific events occur in Claude Code. They receive JSON input and communicate results via exit codes and JSON output.
+Hooks are automated actions (shell commands, HTTP webhooks, LLM prompts, MCP tool calls, or subagent evaluations) that execute automatically when specific events occur in Claude Code. They receive JSON input and communicate results via exit codes and JSON output.
 
 **Key features:**
 - Event-driven automation
 - JSON-based input/output
-- Support for command, prompt, HTTP, and agent hook types
+- Support for `command`, `http`, `mcp_tool`, `prompt`, and `agent` hook types
 - Pattern matching for tool-specific hooks
 
 ## Configuration
@@ -55,7 +55,7 @@ Hooks are configured in settings files with a specific structure:
 |-------|-------------|---------|
 | `matcher` | Pattern to match tool names (case-sensitive) | `"Write"`, `"Edit\|Write"`, `"*"` |
 | `hooks` | Array of hook definitions | `[{ "type": "command", ... }]` |
-| `type` | Hook type: `"command"` (bash), `"prompt"` (LLM), `"http"` (webhook), or `"agent"` (subagent) | `"command"` |
+| `type` | Hook type: `"command"` (bash), `"prompt"` (LLM), `"http"` (webhook), `"mcp_tool"` (MCP tool invocation, v2.1.118+), or `"agent"` (subagent) | `"command"` |
 | `command` | Shell command to execute | `"$CLAUDE_PROJECT_DIR/.claude/hooks/format.sh"` |
 | `timeout` | Optional timeout in seconds (default 60) | `30` |
 | `once` | If `true`, run the hook only once per session | `true` |
@@ -79,7 +79,7 @@ Hooks are configured in settings files with a specific structure:
 
 ## Hook Types
 
-Claude Code supports four hook types:
+Claude Code supports five hook types:
 
 ### Command Hooks
 
@@ -131,6 +131,30 @@ LLM-evaluated prompts where the hook content is a prompt that Claude evaluates. 
 
 The LLM evaluates the prompt and returns a structured decision (see [Prompt-Based Hooks](#prompt-based-hooks) for details).
 
+### MCP Tool Hooks
+
+> Added in v2.1.118.
+
+The `mcp_tool` type invokes a configured MCP tool directly; configuration references the MCP server and tool name rather than a shell command or URL. This is useful when the validation or reaction logic already lives in an MCP server you have configured.
+
+```json
+{
+  "matcher": "Edit",
+  "hooks": [{
+    "type": "mcp_tool",
+    "server": "my-mcp-server",
+    "tool": "validate_edit"
+  }]
+}
+```
+
+**Key properties:**
+- `"type": "mcp_tool"` -- identifies this as an MCP tool hook
+- `"server"` -- name of the configured MCP server
+- `"tool"` -- the tool name on that server to invoke
+
+The hook input (tool name, tool input, session context) is passed as the MCP tool's arguments. See [MCP server setup](../05-mcp/README.md) for configuring MCP servers.
+
 ### Agent Hooks
 
 Subagent-based verification hooks that spawn a dedicated agent to evaluate conditions or perform complex checks. Unlike prompt hooks (single-turn LLM evaluation), agent hooks can use tools and perform multi-step reasoning.
@@ -151,18 +175,20 @@ Subagent-based verification hooks that spawn a dedicated agent to evaluate condi
 
 ## Hook Events
 
-Claude Code supports **26 hook events**:
+Claude Code supports **28 hook events**:
 
 | Event | When Triggered | Matcher Input | Can Block | Common Use |
 |-------|---------------|---------------|-----------|------------|
 | **SessionStart** | Session begins/resumes/clear/compact | startup/resume/clear/compact | No | Environment setup |
 | **InstructionsLoaded** | After CLAUDE.md or rules file loaded | (none) | No | Modify/filter instructions |
 | **UserPromptSubmit** | User submits prompt | (none) | Yes | Validate prompts |
+| **UserPromptExpansion** | User prompt is expanded (e.g., `@` mentions, slash commands resolved) | (none) | Yes | Transform or inspect expanded prompt |
 | **PreToolUse** | Before tool execution | Tool name | Yes (allow/deny/ask) | Validate, modify inputs |
 | **PermissionRequest** | Permission dialog shown | Tool name | Yes | Auto-approve/deny |
 | **PermissionDenied** | User denies a permission prompt | Tool name | No | Logging, analytics, policy enforcement |
 | **PostToolUse** | After tool succeeds | Tool name | No | Add context, feedback |
 | **PostToolUseFailure** | Tool execution fails | Tool name | No | Error handling, logging |
+| **PostToolBatch** | After a batch of tool uses completes | (none) | No | Aggregate reporting, batched validation |
 | **Notification** | Notification sent | Notification type | No | Custom notifications |
 | **SubagentStart** | Subagent spawned | Agent type name | No | Subagent setup |
 | **SubagentStop** | Subagent finishes | Agent type name | Yes | Subagent validation |
@@ -181,6 +207,8 @@ Claude Code supports **26 hook events**:
 | **Elicitation** | MCP server requests user input | (none) | Yes | Input validation |
 | **ElicitationResult** | User responds to elicitation | (none) | Yes | Response processing |
 | **SessionEnd** | Session terminates | (none) | No | Cleanup, final logging |
+
+> **PostToolUse duration (v2.1.119):** `PostToolUse` and `PostToolUseFailure` hook inputs now include `duration_ms` — see the [PostToolUse](#posttooluse) section for details.
 
 ### PreToolUse
 
@@ -238,6 +266,12 @@ Runs immediately after tool completion. Use for verification, logging, or provid
 **Output control:**
 - `"block"` decision prompts Claude with feedback
 - `additionalContext`: Context added for Claude
+
+**Additional input fields (v2.1.119):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `duration_ms` | number | Tool execution time in milliseconds. Excludes time spent in permission prompts and PreToolUse hook execution. Available on both `PostToolUse` and `PostToolUseFailure` hooks. |
 
 ### UserPromptSubmit
 
@@ -998,6 +1032,7 @@ MCP tools follow the pattern `mcp__<server>__<tool>`:
 - **Workspace trust required:** The `statusLine` and `fileSuggestion` hook output commands now require workspace trust acceptance before they take effect.
 - **HTTP hooks and environment variables:** HTTP hooks require an explicit `allowedEnvVars` list to use environment variable interpolation in URLs. This prevents accidental leakage of sensitive environment variables to remote endpoints.
 - **Managed settings hierarchy:** The `disableAllHooks` setting now respects the managed settings hierarchy, meaning organization-level settings can enforce hook disablement that individual users cannot override.
+- **PowerShell auto-approve (v2.1.119):** PowerShell tool commands can be auto-approved in permission mode, matching Bash. This brings parity for Windows users running Claude Code with PowerShell-backed shell tools.
 
 ### Best Practices
 
@@ -1166,10 +1201,11 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code/hooks
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/hooks
+- https://code.claude.com/docs/en/changelog
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.118
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/07-plugins/README.md
+++ b/07-plugins/README.md
@@ -108,6 +108,7 @@ my-plugin/
 ├── .lsp.json             # LSP server configurations for code intelligence
 ├── bin/                  # Executables added to Bash tool's PATH while plugin is enabled
 ├── settings.json         # Default settings applied when plugin is enabled (currently only `agent` key supported)
+├── themes/               # Optional: ship custom Claude Code themes (v2.1.118+)
 ├── templates/
 │   └── issue-template.md
 ├── scripts/
@@ -478,8 +479,24 @@ Enterprise and advanced users can control marketplace behavior through settings:
 | Setting | Description |
 |---------|-------------|
 | `extraKnownMarketplaces` | Add additional marketplace sources beyond the defaults |
-| `strictKnownMarketplaces` | Control which marketplaces users are allowed to add |
+| `strictKnownMarketplaces` | Control which marketplaces users are allowed to add (managed-only) |
+| `blockedMarketplaces` | Admin-managed blocklist of marketplaces (supports `hostPattern` / `pathPattern` regex fields since v2.1.119) |
 | `deniedPlugins` | Admin-managed blocklist to prevent specific plugins from being installed |
+
+> **Enforcement** (v2.1.117+): `blockedMarketplaces` and `strictKnownMarketplaces` are enforced on every plugin lifecycle event — install, update, refresh, and autoupdate — not just at first add. `strictKnownMarketplaces` is managed-only.
+
+Example `blockedMarketplaces` with host/path regex (v2.1.119):
+
+```json
+{
+  "blockedMarketplaces": [
+    {
+      "hostPattern": "^evil\\.example\\.com$",
+      "pathPattern": "^/marketplaces/.*"
+    }
+  ]
+}
+```
 
 ### Additional Marketplace Features
 
@@ -629,7 +646,10 @@ claude plugin list                           # List installed plugins
 claude plugin enable <name>                  # Enable a disabled plugin
 claude plugin disable <name>                 # Disable a plugin
 claude plugin validate                       # Validate plugin structure
+claude plugin tag <version>                  # Create a release git tag with version validation (v2.1.118+)
 ```
+
+Example: `claude plugin tag v0.3.0` validates the version format, creates the matching git tag, and is the recommended way to cut plugin releases for distribution.
 
 ## Installation Methods
 
@@ -722,7 +742,8 @@ Administrators can control plugin behavior across an organization using managed 
 | `enabledPlugins` | Allowlist of plugins that are enabled by default |
 | `deniedPlugins` | Blocklist of plugins that cannot be installed |
 | `extraKnownMarketplaces` | Add additional marketplace sources beyond the defaults |
-| `strictKnownMarketplaces` | Restrict which marketplaces users are allowed to add |
+| `strictKnownMarketplaces` | Restrict which marketplaces users are allowed to add (managed-only; enforced on every plugin lifecycle event since v2.1.117) |
+| `blockedMarketplaces` | Blocklist of marketplaces; enforced on every plugin lifecycle event since v2.1.117; supports `hostPattern` / `pathPattern` regex fields since v2.1.119 |
 | `allowedChannelPlugins` | Control which plugins are permitted per release channel |
 
 These settings can be applied at the organization level via managed configuration files and take precedence over user-level settings.
@@ -745,10 +766,11 @@ This ensures that plugins cannot escalate privileges or modify the host environm
 2. Write `.claude-plugin/plugin.json` manifest
 3. Create `README.md` with documentation
 4. Test locally with `claude --plugin-dir ./my-plugin`
-5. Submit to plugin marketplace
-6. Get reviewed and approved
-7. Published on marketplace
-8. Users can install with one command
+5. Tag the release with `claude plugin tag v0.3.0` (v2.1.118+) — validates the version string and creates the matching git tag
+6. Submit to plugin marketplace
+7. Get reviewed and approved
+8. Published on marketplace
+9. Users can install with one command
 
 **Example submission:**
 
@@ -968,10 +990,12 @@ The following Claude Code features work together with plugins:
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code/plugins
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/plugins
+- https://code.claude.com/docs/en/plugin-marketplaces
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.117
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.118
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/07-plugins/devops-automation/README.md
+++ b/07-plugins/devops-automation/README.md
@@ -105,3 +105,12 @@ Result:
 🚀 Pods: 3/3 ready
 ⏱️  Time: 2m 34s
 ```
+
+---
+
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
+**Sources**:
+- https://code.claude.com/docs/en/plugins
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/07-plugins/documentation/README.md
+++ b/07-plugins/documentation/README.md
@@ -117,3 +117,12 @@ export GITHUB_TOKEN="your_github_token"
 - Include practical examples
 - Validate regularly
 - Use templates for consistency
+
+---
+
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
+**Sources**:
+- https://code.claude.com/docs/en/plugins
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/07-plugins/pr-review/README.md
+++ b/07-plugins/pr-review/README.md
@@ -89,3 +89,12 @@ Result:
 ✅ Performance: No significant impact
 📝 Recommendations: Add tests for edge cases
 ```
+
+---
+
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
+**Sources**:
+- https://code.claude.com/docs/en/plugins
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/08-checkpoints/README.md
+++ b/08-checkpoints/README.md
@@ -221,6 +221,15 @@ The only checkpoint-related setting is `cleanupPeriodDays`, which controls how l
 
 - `cleanupPeriodDays`: Number of days to retain session history and checkpoints (default: `30`)
 
+> **v2.1.117 update**: `cleanupPeriodDays` now governs retention for four on-disk caches, not just checkpoints:
+>
+> - Session checkpoints
+> - `~/.claude/tasks/` — persistent task lists
+> - `~/.claude/shell-snapshots/` — captured shell-environment snapshots
+> - `~/.claude/backups/` — rolling setting / CLAUDE.md backups
+>
+> A single setting now prunes all four directories uniformly after the same number of days.
+
 ## Limitations
 
 Checkpoints have the following limitations:
@@ -316,10 +325,10 @@ Remember: checkpoints are not a replacement for git. Use checkpoints for rapid e
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code/checkpointing
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/checkpointing
+- https://code.claude.com/docs/en/settings
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -277,7 +277,8 @@ Extended thinking is a deliberate, step-by-step reasoning process where Claude:
 
 **Automatic activation**:
 - Enabled by default for all models (Opus 4.7, Sonnet 4.6, Haiku 4.5)
-- Opus 4.7: Adaptive reasoning with effort levels: `low` (○), `medium` (◐), `high` (●), `xhigh` (new, default on Opus 4.7), `max` (Opus 4.7 only)
+- Opus 4.7: Adaptive reasoning with effort levels: `low` (○), `medium` (◐), `high` (●), `xhigh` (default on Claude Code since Opus 4.7 launch, 2026-04-16), `max` (Opus 4.7 only). Opus 4.7 has a 1M-token native context window (1M context fix landed in v2.1.117 — before that, `/context` miscounted Opus 4.7 against a 200K window and triggered premature autocompact).
+- Pro/Max subscribers on Opus 4.6 / Sonnet 4.6: default effort was raised from `medium` to `high` in v2.1.117.
 - Other models: Fixed budget up to 31,999 tokens
 
 **Configuration methods**:
@@ -477,6 +478,34 @@ claude auto-mode defaults
 ```
 
 **Configure trusted infrastructure** via the `autoMode.environment` managed setting for enterprise deployments. This allows administrators to define trusted CI/CD environments, deployment targets, and infrastructure patterns.
+
+#### Extending defaults with `"$defaults"` (v2.1.118)
+
+Since v2.1.118, `autoMode.allow`, `autoMode.soft_deny`, and `autoMode.environment` accept a `"$defaults"` token that **appends** your rules to the built-in list instead of replacing it. Before v2.1.118, any user-defined array silently clobbered the built-ins.
+
+**Before (replaces built-ins — pre-v2.1.118 behavior):**
+
+```json
+{
+  "autoMode": {
+    "allow": ["Bash(gh pr list:*)"]
+  }
+}
+```
+
+**After (extends built-ins — v2.1.118+):**
+
+```json
+{
+  "autoMode": {
+    "allow": ["$defaults", "Bash(gh pr list:*)"],
+    "soft_deny": ["$defaults", "Bash(kubectl delete:*)"],
+    "environment": ["$defaults", "trusted-ci.internal"]
+  }
+}
+```
+
+Use `"$defaults"` to keep the shipped baseline rules while layering organization- or project-specific additions on top.
 
 ### Fallback Behavior
 
@@ -1231,8 +1260,8 @@ User: Deploy to prodcution<Backspace><Backspace>uction
 Enable Vi/Vim keybindings for text editing:
 
 **Activation**:
-- Use `/vim` command or `/config` to enable
-- Mode switching with `Esc` for NORMAL, `i/a/o` for INSERT
+- Enable via `/config` (toggle "Editor / Vim mode") or in `~/.claude/settings.json` under `editorMode: "vim"`. The standalone `/vim` slash command was removed (see [issue #43370](https://github.com/anthropics/claude-code/issues/43370)); vim mode is now configuration-driven.
+- Mode switching with `Esc` for NORMAL, `i/a/o` for INSERT, `v` for VISUAL, `V` for VISUAL-LINE (v2.1.118+)
 
 **Navigation keys**:
 - `h` / `l` - Move left/right
@@ -1245,6 +1274,19 @@ Enable Vi/Vim keybindings for text editing:
 - `iw` / `aw` - Inner/around word
 - `i"` / `a"` - Inner/around quoted string
 - `i(` / `a(` - Inner/around parentheses
+
+**Visual modes (v2.1.118+)**:
+
+| Key | Mode | Behavior |
+|-----|------|----------|
+| `v` | Visual | Character-wise selection with visual feedback; extend with motion keys |
+| `V` | Visual-line | Line-wise selection; always selects whole lines |
+| `y` | Yank | Copy the current visual selection |
+| `d` / `x` | Delete | Delete the current visual selection |
+| `c` | Change | Delete selection and enter INSERT mode |
+| `Esc` | Exit | Return to NORMAL mode |
+
+Visual selections are highlighted in the input field so you can see exactly what will be yanked, deleted, or changed before you commit the operator.
 
 ### Bash Mode
 
@@ -1736,7 +1778,24 @@ claude --no-sandbox    # Disable sandboxing
 | `sandbox.filesystem.allowWrite` | Paths allowed for write access |
 | `sandbox.filesystem.allowRead` | Paths allowed for read access |
 | `sandbox.filesystem.denyRead` | Paths denied for read access |
+| `sandbox.network.allowedDomains` | Domains Bash-launched processes are allowed to reach (supports `*.` wildcard) |
+| `sandbox.network.deniedDomains` | Domains to block even when `allowedDomains` wildcard would otherwise permit them (v2.1.113+) |
 | `sandbox.enableWeakerNetworkIsolation` | Enable weaker network isolation on macOS |
+
+Example of `deniedDomains` overriding a broad wildcard (v2.1.113+):
+
+```json
+{
+  "sandbox": {
+    "network": {
+      "allowedDomains": ["*.example.com"],
+      "deniedDomains": ["evil.example.com"]
+    }
+  }
+}
+```
+
+The wildcard lets everything on `example.com` through, but `deniedDomains` still blocks the specifically-named host.
 
 ### Example Configuration
 
@@ -1802,6 +1861,7 @@ Since v2.1.83, administrators can deploy multiple managed settings files into a 
 | `availableModels` | Restrict which models users can select |
 | `allowedChannelPlugins` | Control which channel plugins are permitted |
 | `autoMode.environment` | Configure trusted infrastructure for auto mode |
+| `wslInheritsWindowsSettings` | Windows/WSL only (v2.1.118+): when `true`, Claude Code running inside WSL inherits managed settings from the Windows host, so enterprise policies deployed via Registry/MDM apply uniformly across the Windows and WSL shells |
 | Custom policies | Organization-specific permission and tool policies |
 
 ### Example: macOS Plist
@@ -2102,10 +2162,13 @@ For more information about Claude Code and related features:
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
+- https://code.claude.com/docs/en/permission-modes
+- https://code.claude.com/docs/en/interactive-mode
+- https://code.claude.com/docs/en/settings
 - https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.117
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.118
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -24,6 +24,18 @@ graph TD
     G -->|text/json/stream-json| H["Terminal/Pipe"]
 ```
 
+## Runtime & Packaging
+
+Since **v2.1.113**, the Claude Code CLI launches a **native per-platform binary** (macOS, Linux, Windows) via optional npm dependencies. The binary is matched to your OS and architecture at install time — the older bundled-JavaScript runtime is no longer the default on macOS or Linux.
+
+The **user-facing install is unchanged**: `npm install -g @anthropic-ai/claude-code` still works and remains the recommended path. Behind the scenes npm fetches the correct native binary for your platform.
+
+**Download host** (v2.1.116+): native-binary artifacts are served from `https://downloads.claude.ai/claude-code-releases`.
+
+> **Corporate / proxy users**: If your network requires an explicit allowlist, add `downloads.claude.ai` (and `https://downloads.claude.ai/claude-code-releases`) to your proxy egress rules. Environments that previously allowlisted only `storage.googleapis.com` or the npm registry will need to be updated or `claude update` and the initial install will fail.
+
+The older JavaScript bundle is still produced for Windows and for environments that pin to it; those installs continue to ship Glob and Grep as first-class tools (see the Glob/Grep footnote under [Tools](#tool--permission-management)).
+
 ## CLI Commands
 
 | Command | Description | Example |
@@ -36,12 +48,15 @@ graph TD
 | `claude -c -p "query"` | Continue in print mode | `claude -c -p "check for type errors"` |
 | `claude -r "<session>" "query"` | Resume session by ID or name | `claude -r "auth-refactor" "finish this PR"` |
 | `claude update` | Update to latest version | `claude update` |
+| `/doctor` (slash command) | Diagnose installation, config, and plugin health. Since v2.1.116 it can be opened **while Claude is responding**, shows status icons inline, and accepts the `f` keypress to auto-fix detected issues | run `/doctor` inside the REPL |
 | `claude mcp` | Configure MCP servers | See [MCP documentation](../05-mcp/) |
 | `claude mcp serve` | Run Claude Code as an MCP server | `claude mcp serve` |
 | `claude agents` | List all configured subagents | `claude agents` |
 | `claude auto-mode defaults` | Print auto mode default rules as JSON | `claude auto-mode defaults` |
 | `claude remote-control` | Start Remote Control server | `claude remote-control` |
 | `claude plugin` | Manage plugins (install, enable, disable) | `claude plugin install my-plugin` |
+| `claude plugin tag <version>` | Create a release git tag for a plugin with version validation (v2.1.118+) | `claude plugin tag v0.3.0` |
+| `claude install [version]` | Install a specific native-binary version. Accepts `stable`, `latest`, or an explicit version string | `claude install 2.1.119` |
 | `claude auth login` | Log in (supports `--email`, `--sso`) | `claude auth login --email user@example.com` |
 | `claude auth logout` | Log out of current account | `claude auth logout` |
 | `claude auth status` | Check auth status (exit 0 if logged in, 1 if not) | `claude auth status` |
@@ -56,7 +71,7 @@ graph TD
 | `-v, --version` | Output version number | `claude -v` |
 | `-w, --worktree` | Start in isolated git worktree | `claude -w` |
 | `-n, --name` | Session display name | `claude -n "auth-refactor"` |
-| `--from-pr <number>` | Resume sessions linked to GitHub PR | `claude --from-pr 42` |
+| `--from-pr <url-or-number>` | Resume sessions linked to a pull/merge request. Accepts GitHub (cloud + Enterprise), GitLab MR, and Bitbucket PR URLs since v2.1.119; previously GitHub.com only | `claude --from-pr 42` or `claude --from-pr https://gitlab.example.com/org/repo/-/merge_requests/17` |
 | `--remote "task"` | Create web session on claude.ai | `claude --remote "implement API"` |
 | `--remote-control, --rc` | Interactive session with Remote Control | `claude --rc` |
 | `--teleport` | Resume web session locally | `claude --teleport` |
@@ -175,6 +190,10 @@ claude -p --system-prompt-file ./prompts/code-reviewer.txt "review main.py"
 | `--permission-prompt-tool` | MCP tool for permission handling | `claude -p --permission-prompt-tool mcp_auth "query"` |
 | `--enable-auto-mode` | Unlock auto permission mode | `claude --enable-auto-mode` |
 
+> **Glob / Grep footnote (v2.1.113+)**: On native macOS/Linux builds, `Glob` and `Grep` are provided as the embedded `bfs` and `ugrep` binaries invoked through the Bash tool rather than as separate first-class tools. Windows and npm-bundled (JS) installs still expose them as standalone tools. For subagent `allowedTools` / `disallowedTools` lists the backend substitution is transparent — you can keep referring to `Glob` / `Grep` in your configuration on every platform.
+
+> **PowerShell auto-approve (v2.1.119)**: PowerShell tool commands can be auto-approved in permission mode exactly the same way Bash commands are. Use the same matcher syntax you already use for `Bash(...)` rules to scope PowerShell permissions — for example, `PowerShell(Get-ChildItem:*)`.
+
 ### Permission Examples
 
 ```bash
@@ -225,6 +244,8 @@ claude -p --json-schema '{"type":"object","properties":{"bugs":{"type":"array"}}
 |------|-------------|---------|
 | `--add-dir` | Add additional working directories | `claude --add-dir ../apps ../lib` |
 | `--setting-sources` | Comma-separated setting sources | `claude --setting-sources user,project` |
+
+> **`/config` persistence (v2.1.119)**: Changes made interactively via the `/config` command are now written to `~/.claude/settings.json` and participate in the normal precedence chain (project → local → policy → user). Before v2.1.119, some `/config` changes were session-only. See [Memory & Settings](../02-memory/README.md) for the full precedence order.
 | `--settings` | Load settings from file or JSON | `claude --settings ./settings.json` |
 | `--plugin-dir` | Load plugins from directory (repeatable) | `claude --plugin-dir ./my-plugin` |
 
@@ -664,8 +685,8 @@ Claude Code supports multiple models with different capabilities:
 
 | Model | ID | Context Window | Notes |
 |-------|-----|----------------|-------|
-| Opus 4.7 | `claude-opus-4-7` | 1M tokens | Most capable, adaptive effort levels |
-| Sonnet 4.6 | `claude-sonnet-4-6` | 1M tokens | Balanced speed and capability |
+| Opus 4.7 | `claude-opus-4-7` | 1M tokens (1M context fix landed in v2.1.117) | Most capable, adaptive effort levels; `xhigh` is the default effort on Claude Code since Opus 4.7 launch (2026-04-16) |
+| Sonnet 4.6 | `claude-sonnet-4-6` | 1M tokens | Balanced speed and capability; default effort for Pro/Max subscribers raised from `medium` to `high` in v2.1.117 |
 | Haiku 4.5 | `claude-haiku-4-5` | 1M tokens | Fastest, best for quick tasks |
 
 ### Model Selection
@@ -685,7 +706,7 @@ claude --model opusplan "design and implement the API"
 
 ### Effort Levels (Opus 4.7)
 
-Opus 4.7 supports adaptive reasoning with effort levels, ordered from lightest to heaviest: `low` (○), `medium` (◐), `high` (●), `xhigh` (new in v2.1.111), and `max` (Opus 4.7 only). The default on Opus 4.7 is `xhigh`.
+Opus 4.7 supports adaptive reasoning with effort levels, ordered from lightest to heaviest: `low` (○), `medium` (◐), `high` (●), `xhigh` (default on Claude Code since Opus 4.7 launch, 2026-04-16), and `max` (Opus 4.7 only). On Opus 4.6 / Sonnet 4.6, the default effort for Pro/Max subscribers was raised from `medium` to `high` in v2.1.117.
 
 ```bash
 # Set effort level via CLI flag
@@ -736,6 +757,12 @@ The "ultrathink" keyword in prompts activates deep reasoning. The `max` effort l
 | `ENABLE_TOOL_SEARCH` | Enable tool search capability |
 | `MAX_MCP_OUTPUT_TOKENS` | Maximum tokens for MCP tool output |
 | `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce mode — treats files as read-only by default (for Perforce/P4 version control workflows) (added v2.1.98) |
+| `DISABLE_UPDATES` | Blocks all update paths including manual `claude update`. Stricter than `DISABLE_AUTOUPDATER`, which only blocks the background autoupdater (v2.1.118+) |
+| `CLAUDE_CODE_HIDE_CWD` | When set to `1`, hides the current working directory in the startup logo (privacy / screen-share use) (v2.1.119+) |
+| `CLAUDE_CODE_FORK_SUBAGENT` | Set to `1` to enable forked subagents on external builds (Bedrock, Vertex, Foundry). No effect on Anthropic API where forked subagents are GA (v2.1.117+) |
+| `OTEL_LOG_TOOL_DETAILS` | Set to `1` to unredact custom and MCP command names in OpenTelemetry events (v2.1.117+). Redaction remains the default. |
+
+> **`ENABLE_TOOL_SEARCH` on Vertex AI (v2.1.119+)**: Tool search is **disabled by default on Google Cloud Vertex AI** deployments. Users who want the tool-search capability on Vertex must explicitly opt in with `export ENABLE_TOOL_SEARCH=true`. On direct Anthropic API it remains enabled by default.
 
 ---
 
@@ -841,10 +868,16 @@ claude -p --output-format json "query"
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
+- https://code.claude.com/docs/en/cli-reference
+- https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/changelog
 - https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.113
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.116
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.117
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.118
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -20,7 +20,7 @@
 | **Skills** | 5 bundled | 4 | 9 | [03-skills/](03-skills/) |
 | **Plugins** | - | 3 | 3 | [07-plugins/](07-plugins/) |
 | **MCP Servers** | 1 | 8 | 9 | [05-mcp/](05-mcp/) |
-| **Hooks** | 25 events | 8 | 8 | [06-hooks/](06-hooks/) |
+| **Hooks** | 28 events | 8 | 8 | [06-hooks/](06-hooks/) |
 | **Memory** | 7 types | 3 | 3 | [02-memory/](02-memory/) |
 | **Total** | **99** | **45** | **119** | |
 
@@ -35,7 +35,7 @@ Commands are user-invoked shortcuts that execute specific actions.
 | Command | Description | When to Use |
 |---------|-------------|-------------|
 | `/help` | Show help information | Get started, learn commands |
-| `/btw` | Side question without adding to context | Quick tangent questions |
+| `/btw` | Ephemeral side question — doesn't pollute main context | Quick tangent questions |
 | `/chrome` | Configure Chrome integration | Browser automation |
 | `/clear` | Clear conversation history | Start fresh, reduce context |
 | `/diff` | Interactive diff viewer | Review changes |
@@ -53,11 +53,11 @@ Commands are user-invoked shortcuts that execute specific actions.
 | `/passes` | View usage passes | Subscription info |
 | `/plugin` | Manage plugins | Install/remove extensions |
 | `/plan` | Enter planning mode | Complex implementations |
-| `/proactive` | Alias for `/loop` | Same as `/loop` |
+| `/proactive` | Alias for `/loop` (v2.1.105) | Same as `/loop` |
 | `/recap` | Show session recap when returning to a session | After being away, get context on what was done |
 | `/rewind` | Rewind to checkpoint | Undo changes, explore alternatives |
 | `/checkpoint` | Manage checkpoints | Save/restore states |
-| `/cost` | Show token usage costs | Monitor spending |
+| `/cost` | Shortcut alias that opens the cost tab of `/usage` (v2.1.118+) | Monitor spending |
 | `/context` | Show context window usage | Manage conversation length |
 | `/export` | Export conversation | Save for reference |
 | `/extra-usage` | Configure extra usage limits | Rate limit management |
@@ -79,16 +79,16 @@ Commands are user-invoked shortcuts that execute specific actions.
 | `/copy` | Copy last response to clipboard | Share output quickly |
 | `/teleport` | Transfer session to another machine | Continue work remotely |
 | `/desktop` | Open Claude Desktop app | Switch to desktop interface |
-| `/theme` | Change color theme | Customize appearance |
-| `/usage` | Show API usage statistics | Monitor quota and costs |
+| `/theme` | Change color theme; v2.1.118 added custom named themes via `~/.claude/themes/<name>.json` (plugins can ship a `themes/` dir) | Customize appearance |
+| `/usage` | Canonical command for usage/cost/stats — merged `/cost` and `/stats` into a single tabbed view (v2.1.118) | Monitor quota and costs |
 | `/focus` | Toggle focus view (distraction-free output display) | Reduce visual noise during long tasks |
 | `/fork` | Fork current conversation | Explore alternatives |
-| `/stats` | Show session statistics | Review session metrics |
+| `/stats` | Shortcut alias that opens the stats tab of `/usage` (v2.1.118+) | Review session metrics |
 | `/statusline` | Configure status line | Customize status display |
 | `/stickers` | View session stickers | Fun rewards |
 | `/fast` | Toggle fast output mode | Speed up responses |
 | `/terminal-setup` | Configure terminal integration | Setup terminal features |
-| `/undo` | Alias for `/rewind` | Same as `/rewind` |
+| `/undo` | Alias for `/rewind` (v2.1.108) | Same as `/rewind` |
 | `/upgrade` | Check for updates | Version management |
 | `/team-onboarding` | Generate a teammate ramp-up guide from this project's Claude Code usage | Onboarding new teammates (v2.1.101) |
 | `/ultraplan` | Hand a planning task to a Claude Code web session in plan mode | Heavy planning offload (Research Preview, v2.1.91+) |
@@ -530,10 +530,11 @@ chmod +x ~/.claude/hooks/*.sh
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/commands
+- https://code.claude.com/docs/en/hooks
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.118
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/INDEX.md
+++ b/INDEX.md
@@ -218,7 +218,7 @@ Event-driven automation scripts that execute automatically.
 
 **Usage**: Configured in settings, executed automatically
 
-**Hook Types** (4 types, 25 events):
+**Hook Types** (5 types, 28 events):
 - Tool Hooks: PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest
 - Session Hooks: SessionStart, SessionEnd, Stop, StopFailure, SubagentStart, SubagentStop
 - Task Hooks: UserPromptSubmit, TaskCompleted, TaskCreated, TeammateIdle
@@ -874,12 +874,13 @@ Want to add more examples? Follow the structure:
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/hooks
+- https://code.claude.com/docs/en/commands
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 **Total Examples**: 100+ files
 **Categories**: 10 features

--- a/LEARNING-ROADMAP.md
+++ b/LEARNING-ROADMAP.md
@@ -102,7 +102,7 @@ graph TD
 | **3** | [Checkpoints](08-checkpoints/) | ⭐⭐ Intermediate | 45 min | Level 1 | Session management | Safe exploration | Experimentation, recovery |
 | **4** | [CLI Basics](10-cli/) | ⭐⭐ Beginner+ | 30 min | Level 1 | None | Core CLI usage | Interactive & print mode |
 | **5** | [Skills](03-skills/) | ⭐⭐ Intermediate | 1 hour | Level 2 | Slash Commands | Automatic expertise | Reusable capabilities, consistency |
-| **6** | [Hooks](06-hooks/) | ⭐⭐ Intermediate | 1 hour | Level 2 | Tools, Commands | Workflow automation (25 events, 4 types) | Validation, quality gates |
+| **6** | [Hooks](06-hooks/) | ⭐⭐ Intermediate | 1 hour | Level 2 | Tools, Commands | Workflow automation (28 events, 5 types) | Validation, quality gates |
 | **7** | [MCP](05-mcp/) | ⭐⭐⭐ Intermediate+ | 1 hour | Level 2 | Configuration | Live data access | Real-time integration, APIs |
 | **8** | [Subagents](04-subagents/) | ⭐⭐⭐ Intermediate+ | 1.5 hours | Level 2 | Memory, Commands | Complex task handling (6 built-in including Bash) | Delegation, specialized expertise |
 | **9** | [Advanced Features](09-advanced-features/) | ⭐⭐⭐⭐⭐ Advanced | 2-3 hours | Level 3 | All previous | Power user tools | Planning, Auto Mode, Channels, Voice Dictation, permissions |
@@ -235,8 +235,8 @@ Before starting Level 2, make sure you're comfortable with these Level 1 concept
 
 #### What You'll Achieve
 ✅ Auto-invoke specialized capabilities with YAML frontmatter (including `effort` and `shell` fields)
-✅ Set up event-driven automation across 25 hook events
-✅ Use all 4 hook types (command, http, prompt, agent)
+✅ Set up event-driven automation across 28 hook events
+✅ Use all 5 hook types (command, http, mcp_tool, prompt, agent)
 ✅ Enforce code quality standards
 ✅ Create custom hooks for your workflow
 
@@ -738,12 +738,12 @@ Once you've completed all milestones:
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/hooks
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 **Maintained by**: Claude How-To Contributors
 **License**: Educational purposes, free to use and adapt

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -118,7 +118,7 @@ claude -r "session"    # Resume session by name/ID
 | **Skills** | `.claude/skills/*/SKILL.md` | Auto-invoked |
 | **Subagents** | `.claude/agents/*.md` | Auto-delegated |
 | **MCP** | `.mcp.json` (project) or `~/.claude.json` (user) | `/mcp__server__action` |
-| **Hooks (25 events)** | `~/.claude/hooks/*.sh` | Event-triggered (4 types) |
+| **Hooks (28 events)** | `~/.claude/hooks/*.sh` | Event-triggered (5 types) |
 | **Plugins** | Via `/plugin install` | Bundles all |
 | **Checkpoints** | Built-in | `Esc+Esc` or `/rewind` |
 | **Planning Mode** | Built-in | `/plan <task>` |
@@ -189,7 +189,7 @@ vim CLAUDE.md
 
 ### Automation & Hooks
 ```bash
-# Install hooks (25 events, 4 types: command, http, prompt, agent)
+# Install hooks (28 events, 5 types: command, http, mcp_tool, prompt, agent)
 mkdir -p ~/.claude/hooks
 cp 06-hooks/*.sh ~/.claude/hooks/
 chmod +x ~/.claude/hooks/*.sh
@@ -389,7 +389,7 @@ cp -r 03-skills/code-review ~/.claude/skills/
 | **Auto Mode** | Fully autonomous operation with background classifier | `--enable-auto-mode` flag, `Shift+Tab` to cycle modes |
 | **Channels** | Discord and Telegram integration | `--channels` flag, Discord/Telegram bots |
 | **Voice Dictation** | Speak commands and context to Claude | `/voice` command |
-| **Hooks (26 events)** | Expanded hook system with 4 types | command, http, prompt, agent hook types |
+| **Hooks (28 events)** | Expanded hook system with 5 types | command, http, mcp_tool, prompt, agent hook types |
 | **MCP Elicitation** | MCP servers can request user input at runtime | Auto-prompted when server needs clarification |
 | **Plugin LSP** | Language Server Protocol support for plugins | `userConfig`, `${CLAUDE_PLUGIN_DATA}` variable |
 | **Remote Control** | Control Claude Code via WebSocket API | `claude --remote` for external integrations |
@@ -444,7 +444,7 @@ echo $GITHUB_TOKEN
 | Auto workflow | Skill | `03-skills/code-review/` |
 | Specialized task | Subagent | `04-subagents/code-reviewer.md` |
 | External data | MCP (+ Elicitation) | `05-mcp/github-mcp.json` |
-| Event automation | Hook (26 events, 4 types) | `06-hooks/pre-commit.sh` |
+| Event automation | Hook (28 events, 5 types) | `06-hooks/pre-commit.sh` |
 | Complete solution | Plugin (+ LSP support) | `07-plugins/pr-review/` |
 | Safe experiment | Checkpoint | `08-checkpoints/checkpoint-examples.md` |
 | Fully autonomous | Auto Mode | `--enable-auto-mode` or `Shift+Tab` |
@@ -505,10 +505,11 @@ Getting started checklist:
 **This Card**: Keep it handy for quick reference!
 
 ---
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/hooks
+- https://code.claude.com/docs/en/commands
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/luongnv89/claude-howto?style=flat&color=gold)](https://github.com/luongnv89/claude-howto/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/luongnv89/claude-howto?style=flat)](https://github.com/luongnv89/claude-howto/network/members)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.1.112-brightgreen)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.1.119-brightgreen)](CHANGELOG.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-2.1+-purple)](https://code.claude.com)
 
 🌐 **Language / Ngôn ngữ / 语言 / Мова:** [English](README.md) | [Tiếng Việt](vi/README.md) | [中文](zh/README.md) | [Українська](uk/README.md)
@@ -102,7 +102,7 @@ Run `/lesson-quiz [topic]` after each module. The quiz pinpoints what you missed
 
 - **21,800+ GitHub stars** from developers who use Claude Code daily
 - **2,585+ forks** — teams adapting this guide for their own workflows
-- **Actively maintained** — synced with every Claude Code release (latest: v2.1.112, April 2026)
+- **Actively maintained** — synced with every Claude Code release (latest: v2.1.119, April 2026)
 - **Community-driven** — contributions from developers who share their real-world configurations
 
 [![Star History Chart](https://api.star-history.com/svg?repos=luongnv89/claude-howto&type=Date)](https://star-history.com/#luongnv89/claude-howto&Date)
@@ -139,6 +139,8 @@ Take the self-assessment or pick your level:
 ---
 
 ## Get Started in 15 Minutes
+
+> **Installation note**: Starting in v2.1.113, Claude Code ships as a native per-platform binary (macOS/Linux/Windows). `npm install -g @anthropic-ai/claude-code` still works — the native binary is downloaded as an optional dep on first use. As of v2.1.116, downloads come from `https://downloads.claude.ai/claude-code-releases` — corporate proxies must allowlist this host.
 
 ```bash
 # 1. Clone the guide
@@ -199,7 +201,7 @@ cp -r 03-skills/code-review ~/.claude/skills/
 Yes. MIT licensed, free forever. Use it in personal projects, at work, in your team — no restrictions beyond including the license notice.
 
 **Is this maintained?**
-Actively. The guide is synced with every Claude Code release. Current version: v2.1.112 (April 2026), compatible with Claude Code 2.1+.
+Actively. The guide is synced with every Claude Code release. Current version: v2.1.119 (April 2026), compatible with Claude Code 2.1+.
 
 **How is this different from the official docs?**
 The official docs are a feature reference. This guide is a tutorial with diagrams, production-ready templates, and a progressive learning path. They complement each other — start here to learn, reference the docs when you need specifics.
@@ -480,7 +482,7 @@ Configure hooks in `~/.claude/settings.json`:
 
 **Usage**: Hooks execute automatically on events
 
-**Hook Types** (4 types, 25 events):
+**Hook Types** (5 types, 28 events):
 - **Tool Hooks**: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`
 - **Session Hooks**: `SessionStart`, `SessionEnd`, `Stop`, `StopFailure`, `SubagentStart`, `SubagentStop`
 - **Task Hooks**: `UserPromptSubmit`, `TaskCompleted`, `TaskCreated`, `TeammateIdle`
@@ -869,10 +871,11 @@ MIT License - see [LICENSE](LICENSE). Free to use, modify, and distribute. The o
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/changelog
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.113
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -631,10 +631,10 @@ Before submitting content, verify:
 
 ---
 
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/changelog
 - https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/claude_concepts_guide.md
+++ b/claude_concepts_guide.md
@@ -2808,7 +2808,7 @@ Hooks are event-driven shell commands that execute automatically in response to 
 
 ### Hook Events
 
-Claude Code supports **25 hook events** across four hook types (command, http, prompt, agent):
+Claude Code supports **28 hook events** across five hook types (command, http, mcp_tool, prompt, agent):
 
 | Hook Event | Trigger | Use Cases |
 |------------|---------|-----------|
@@ -3117,24 +3117,39 @@ Complete configuration example:
 
 ---
 
+## Models and Reasoning Effort
+
+Claude Code supports three models with adaptive reasoning effort:
+
+| Model | Context Window | Effort Levels | Default Effort (Claude Code) |
+|-------|----------------|---------------|------------------------------|
+| Claude Opus 4.7 | 1M tokens (native) | `low`, `medium`, `high`, `xhigh`, `max` | `xhigh` (since Opus 4.7 launch, 2026-04-16) |
+| Claude Sonnet 4.6 | 1M tokens | `low`, `medium`, `high`, `max` | `high` for Pro/Max subscribers (raised from `medium` in v2.1.117) |
+| Claude Haiku 4.5 | 200K tokens | `low`, `medium`, `high` | `medium` |
+
+> **Note**: v2.1.117 fixed a bug where Opus 4.7 sessions computed `/context` against 200K instead of the native 1M window — upgrade to v2.1.117 or later to actually get the 1M context on Opus 4.7.
+
+> **Note**: `/cost` and `/stats` merged into `/usage` in v2.1.118. `/usage` is now the canonical command with tabs for cost/stats/etc.; `/cost` and `/stats` remain as shortcut aliases that open the corresponding tab.
+
 ## Resources
 
 - [Claude Code Documentation](https://code.claude.com/docs/en/overview)
-- [Anthropic Documentation](https://docs.anthropic.com)
+- [Claude Code Changelog](https://code.claude.com/docs/en/changelog)
 - [MCP GitHub Servers](https://github.com/modelcontextprotocol/servers)
 - [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook)
 
 ---
 
-*Last updated: April 16, 2026*
+*Last updated: April 24, 2026*
 *For Claude Haiku 4.5, Sonnet 4.6, and Opus 4.7*
 *Now includes: Hooks, Checkpoints, Planning Mode, Extended Thinking, Background Tasks, Permission Modes (6 modes), Headless Mode, Session Management, Auto Memory, Agent Teams, Scheduled Tasks, Chrome Integration, Channels, Voice Dictation, and Bundled Skills*
 
 ---
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/hooks
 - https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/resources.md
+++ b/resources.md
@@ -241,7 +241,7 @@ These steps capture the core recommendations for smooth workflows with Claude Co
 | **Extended Thinking** | Deep reasoning toggle via `Alt+T`/`Option+T` or `MAX_THINKING_TOKENS` env var | [Advanced Features](09-advanced-features/) |
 | **Permission Modes** | Fine-grained control: default, acceptEdits, plan, auto, dontAsk, bypassPermissions | [Advanced Features](09-advanced-features/) |
 | **7-Tier Memory** | Managed Policy, Project, Project Rules, User, User Rules, Local, Auto Memory | [Memory Guide](02-memory/) |
-| **Hook Events** | 25 events: PreToolUse, PostToolUse, PostToolUseFailure, Stop, StopFailure, SubagentStart, SubagentStop, Notification, Elicitation, and more | [Hooks Guide](06-hooks/) |
+| **Hook Events** | 28 events: PreToolUse, PostToolUse, PostToolUseFailure, Stop, StopFailure, SubagentStart, SubagentStop, Notification, Elicitation, and more | [Hooks Guide](06-hooks/) |
 | **Agent Teams** | Coordinate multiple agents working together on complex tasks | [Subagents Guide](04-subagents/) |
 | **Scheduled Tasks** | Set up recurring tasks with `/loop` and cron tools | [Advanced Features](09-advanced-features/) |
 | **Chrome Integration** | Browser automation with headless Chromium | [Advanced Features](09-advanced-features/) |
@@ -249,10 +249,10 @@ These steps capture the core recommendations for smooth workflows with Claude Co
 | **Monitor Tool** | Watch a background command's stdout stream and react to events instead of polling (v2.1.98+) | [Advanced Features](09-advanced-features/) |
 
 ---
-**Last Updated**: April 16, 2026
-**Claude Code Version**: 2.1.112
+**Last Updated**: April 24, 2026
+**Claude Code Version**: 2.1.119
 **Sources**:
-- https://docs.anthropic.com/en/docs/claude-code
-- https://www.anthropic.com/news/claude-opus-4-7
-- https://support.claude.com/en/articles/12138966-release-notes
+- https://code.claude.com/docs/en/overview
+- https://code.claude.com/docs/en/changelog
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -35,6 +35,9 @@ SKIP_DOMAINS = {
     "wikipedia.org",
     # GitHub API requires auth — unauthenticated requests return 404 for protected endpoints
     "api.github.com",
+    # Claude Code native-binary download host — directory listing returns 404, artifacts are
+    # fetched programmatically by the installer via the full filename path
+    "downloads.claude.ai",
 }
 SKIP_DOMAIN_SUFFIXES = (".example.com", ".example.org", ".internal")
 # Placeholder/template URLs that are intentionally non-resolvable


### PR DESCRIPTION
## Summary

Documentation sync to Claude Code v2.1.119. Executes the plan in `update-plan-2026-04-24.md` across 21 in-scope README/reference files. Highlights:

- **Host migration**: All `docs.anthropic.com/en/docs/claude-code/*` → `code.claude.com/docs/en/*`.
- **/cost & /stats**: Documented as shortcut aliases of canonical `/usage` (v2.1.118).
- **Opus 4.7**: 1M native context (v2.1.117 `/context` fix noted); `xhigh` as Claude Code default effort.
- **Native binary packaging** (v2.1.113) and `downloads.claude.ai/claude-code-releases` host (v2.1.116) called out for corporate proxies.
- **Hooks**: event count normalized to 28 across all refs; `UserPromptExpansion` and `PostToolBatch` added; new `mcp_tool` type (v2.1.118); `duration_ms` on `PostToolUse` / `PostToolUseFailure` (v2.1.119).
- **Agent frontmatter**: `mcpServers` (v2.1.117+), `permissionMode` (v2.1.119+), `tools`/`disallowedTools` in `--print` (v2.1.119+).
- **Glob/Grep → bfs/ugrep** footnote for native macOS/Linux builds.
- **Plugin marketplace enforcement** extended to install/update/refresh/autoupdate (v2.1.117) + `hostPattern`/`pathPattern` regex support (v2.1.119).
- **`--from-pr`** accepts GitLab MR, Bitbucket PR, GitHub Enterprise URLs (v2.1.119).
- **5 new env vars**: `DISABLE_UPDATES`, `CLAUDE_CODE_HIDE_CWD`, `CLAUDE_CODE_FORK_SUBAGENT`, `ENABLE_TOOL_SEARCH`, `OTEL_LOG_TOOL_DETAILS`.
- **Deprecated settings**: `includeCoAuthoredBy` → `attribution.commit`/`attribution.pr`; `voiceEnabled` → `voice.enabled`. New: `prUrlTemplate`.
- **New feature docs**: `/theme`, `/btw`, `claude plugin tag`, `claude install [version]`, `sandbox.network.deniedDomains`, auto mode `"$defaults"`, `wslInheritsWindowsSettings`, Vim visual modes, `/doctor` improvements, forked subagents, `disableSkillShellExecution`, MCP concurrent-connect default, PowerShell auto-approve parity.
- **Footer refresh**: all 21 in-scope files now stamped `Last Updated: April 24, 2026` / `Claude Code Version: 2.1.119`.
- **Link-check**: `downloads.claude.ai` added to skip-domains (directory listing returns 404; installer fetches full filename path).

## Test plan

- [ ] `pre-commit run --all-files` passes locally (markdown-lint, cross-references, mermaid-syntax, link-check, build-epub)
- [ ] `grep -rn "docs.anthropic.com/en/docs/claude-code" .` returns no matches
- [ ] No stale `Claude Code Version: 2.1.112` or `Last Updated: April 16, 2026` in footers
- [ ] `/usage`, `/cost`, `/stats` relationship documented consistently across refs
- [ ] Hook event count shows **28** everywhere it's mentioned
- [ ] Spot-check rendering in the GitHub preview for each modified README
- [ ] `uv run scripts/build_epub.py` completes without errors

## Scope note

Per plan: mandatory metadata footer applies to READMEs and root reference docs only. Leaf templates (`01-slash-commands/*.md` except README, `04-subagents/*.md` except README, `03-skills/<skill>/SKILL.md`, `06-hooks/*.sh`, example files) are intentionally not modified in this PR.

Phase 3 (P2 conflicts) task 3.1 was a no-op — no hard-coded Pro-plan tier claims exist in the repo.