### PR TITLE
fix(advanced-features): correct effort level model support

### DIFF
--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -277,7 +277,7 @@ Extended thinking is a deliberate, step-by-step reasoning process where Claude:
 
 **Automatic activation**:
 - Enabled by default for all models (Opus 4.7, Sonnet 4.6, Haiku 4.5)
-- Opus 4.7: Adaptive reasoning with effort levels: `low` (○), `medium` (◐), `high` (●), `xhigh` (default on Claude Code since Opus 4.7 launch, 2026-04-16), `max` (Opus 4.7 only). Opus 4.7 has a 1M-token native context window (1M context fix landed in v2.1.117 — before that, `/context` miscounted Opus 4.7 against a 200K window and triggered premature autocompact).
+- Opus 4.7: Adaptive reasoning with effort levels: `low` (○), `medium` (◐), `high` (●), `xhigh` (Opus 4.7 only, default on Claude Code since Opus 4.7 launch, 2026-04-16), `max`. Opus 4.6 and Sonnet 4.6 also support `low`, `medium`, `high`, `max` (no `xhigh`). Opus 4.7 has a 1M-token native context window (1M context fix landed in v2.1.117 — before that, `/context` miscounted Opus 4.7 against a 200K window and triggered premature autocompact).
 - Pro/Max subscribers on Opus 4.6 / Sonnet 4.6: default effort was raised from `medium` to `high` in v2.1.117.
 - Other models: Fixed budget up to 31,999 tokens
 
@@ -291,9 +291,9 @@ Extended thinking is a deliberate, step-by-step reasoning process where Claude:
 export MAX_THINKING_TOKENS=1024
 ```
 
-**Effort level** (Opus 4.7 only):
+**Effort level** (supported on Opus 4.7, Opus 4.6, and Sonnet 4.6):
 ```bash
-export CLAUDE_CODE_EFFORT_LEVEL=xhigh   # low (○), medium (◐), high (●), xhigh (default on Opus 4.7), or max (Opus 4.7 only)
+export CLAUDE_CODE_EFFORT_LEVEL=xhigh   # low (○), medium (◐), high (●), xhigh (Opus 4.7 only, default), or max
 ```
 
 **CLI flag**:
@@ -306,7 +306,7 @@ claude --effort high "complex architectural review"
 /effort high
 ```
 
-> **Note:** The keyword "ultrathink" in prompts activates deep reasoning mode. Effort levels `low`, `medium`, `high`, `xhigh` (new, default on Opus 4.7), and `max` (Opus 4.7 only) control how much reasoning Claude performs.
+> **Note:** The keyword "ultrathink" in prompts activates deep reasoning mode. Effort levels `low`, `medium`, `high`, and `max` are supported on Opus 4.7, Opus 4.6, and Sonnet 4.6. `xhigh` (default on Opus 4.7) is Opus 4.7 only.
 
 ### Benefits of Extended Thinking
 
@@ -394,7 +394,7 @@ Extended thinking is controlled via environment variables, keyboard shortcuts, a
 # Set thinking token budget
 export MAX_THINKING_TOKENS=16000
 
-# Set effort level (Opus 4.7 only): low (○), medium (◐), high (●), xhigh (default on Opus 4.7), or max (Opus 4.7 only)
+# Set effort level (Opus 4.7, Opus 4.6, Sonnet 4.6): low (○), medium (◐), high (●), xhigh (Opus 4.7 only, default), or max
 export CLAUDE_CODE_EFFORT_LEVEL=xhigh
 ```
 
@@ -1965,7 +1965,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 
 # Thinking configuration
 export MAX_THINKING_TOKENS=16000
-export CLAUDE_CODE_EFFORT_LEVEL=xhigh   # low, medium, high, xhigh (default on Opus 4.7), or max (Opus 4.7 only)
+export CLAUDE_CODE_EFFORT_LEVEL=xhigh   # low, medium, high, xhigh (Opus 4.7 only, default), or max (supported on Opus 4.7, Opus 4.6, Sonnet 4.6)
 
 # Feature toggles
 export CLAUDE_CODE_DISABLE_AUTO_MEMORY=true


### PR DESCRIPTION
## Summary

- The README claimed `max` effort level was Opus 4.7 only — per [official docs](https://code.claude.com/docs/en/model-config#adjust-effort-level), `max` is supported on **Opus 4.7, Opus 4.6, and Sonnet 4.6**. Only `xhigh` is Opus 4.7 exclusive.
- Updates 5 occurrences in `09-advanced-features/README.md` to reflect the actual support matrix.
- Discovered while reviewing #83 — separate fix since it's a pre-existing inaccuracy unrelated to that PR's scope.

## Verification (official docs)

> Effort is supported on Opus 4.7, Opus 4.6, and Sonnet 4.6.
>
> | Model | Levels |
> |---|---|
> | Opus 4.7 | `low`, `medium`, `high`, `xhigh`, `max` |
> | Opus 4.6 and Sonnet 4.6 | `low`, `medium`, `high`, `max` |

Source: https://code.claude.com/docs/en/model-config#adjust-effort-level

## Out of scope

- `uk/09-advanced-features/README.md` and `vi/09-advanced-features/README.md` still describe an Opus-4.6-era support matrix and don't mention `xhigh` at all. Those need a broader translation sync — leaving them for a separate localization PR rather than expanding scope here.

## Test plan

- [x] Local pre-commit hooks pass (markdown-lint, cross-references, mermaid-syntax, link-check)
- [ ] CI checks pass on PR
- [ ] Visual review of the 5 updated lines for clarity