### PR TITLE
docs(skills): question-bank fixes

### DIFF
--- a/.claude/skills/lesson-quiz/references/question-bank.md
+++ b/.claude/skills/lesson-quiz/references/question-bank.md
@@ -209,9 +209,9 @@
 ### Q5
 - **Category**: conceptual
 - **Question**: What is the approximate context budget allocated to skill metadata (Level 1)?
-- **Options**: A) 0.5% of context window | B) 2% of context window | C) 5% of context window | D) 10% of context window
+- **Options**: A) 0.5% of context window | B) 1% of context window | C) 5% of context window | D) 10% of context window
 - **Correct**: B
-- **Explanation**: Skill metadata occupies about 2% of the context window (fallback: 16,000 characters). This is configurable with `SLASH_COMMAND_TOOL_CHAR_BUDGET`.
+- **Explanation**: Skill metadata occupies about 1% of the context window (fallback: 8,000 characters). This is configurable with `SLASH_COMMAND_TOOL_CHAR_BUDGET`.
 - **Review**: Context budget section
 
 ### Q6
@@ -269,9 +269,9 @@
 ### Q2
 - **Category**: practical
 - **Question**: What is the priority order for agent definitions?
-- **Options**: A) Project > User > CLI | B) CLI > User > Project | C) User > Project > CLI | D) They all have equal priority
+- **Options**: A) Project > User > CLI | B) CLI > Project > User | C) User > Project > CLI | D) They all have equal priority
 - **Correct**: B
-- **Explanation**: CLI-defined agents (`--agents` flag) override User-level (`~/.claude/agents/`), which override Project-level (`.claude/agents/`).
+- **Explanation**: CLI-defined agents (`--agents` flag) override Project-level (`.claude/agents/`), which override User-level (`~/.claude/agents/`).
 - **Review**: File locations section
 
 ### Q3


### PR DESCRIPTION
## Description
Fixes incorrect question options in a question-bank for lessons `Lesson 03: Skills`,  `Lesson 04: Subagents`

## Type of Change
- [ ] New example or template
- [X] Documentation improvement
- [ ] Bug fix
- [ ] Feature guide
- [ ] Other (please describe)

## Related Issues
None

## Changes Made
- Changed question options to be aligned with lessons README.md

## Files Changed
- `.claude/skills/lesson-quiz/references/question-bank.md`

## Testing
How have you tested this?
- [ ] Tested locally with Claude Code
- [ ] Verified examples work
- [ ] Checked links and references
- [X] Reviewed for typos and clarity

## Checklist
- [X] Follows project structure and conventions
- [X] Includes clear documentation/examples
- [X] Code/examples are copy-paste ready
- [X] All links are verified and working
- [X] No sensitive information included (keys, tokens, credentials)
- [X] Updated relevant README files
- [X] Commit message follows conventional commit format
- [X] No large files (>1MB) added

## Screenshots or Examples
None

## Breaking Changes
Does this change any existing content or behavior?
- [X] No breaking changes
- [ ] Yes, and it's documented below
