### PR TITLE
fix(cli): correct agent priority order to match official docs

### DIFF
--- a/.claude/skills/lesson-quiz/references/question-bank.md
+++ b/.claude/skills/lesson-quiz/references/question-bank.md
@@ -813,9 +813,9 @@
 ### Q7
 - **Category**: conceptual
 - **Question**: What is the agent definition priority order?
-- **Options**: A) Project > User > CLI | B) CLI > User > Project | C) User > CLI > Project | D) All are equal priority
+- **Options**: A) Project > User > CLI | B) CLI > Project > User | C) User > CLI > Project | D) All are equal priority
 - **Correct**: B
-- **Explanation**: CLI-defined agents (--agents flag) have highest priority, then User-level (~/.claude/agents/), then Project-level (.claude/agents/).
+- **Explanation**: CLI-defined agents (--agents flag) have highest priority, then Project-level (.claude/agents/), then User-level (~/.claude/agents/).
 - **Review**: Agents configuration section
 
 ### Q8

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -435,10 +435,10 @@ claude -p --agents "$(cat agents.json)" --model sonnet "analyze performance"
 
 When multiple agent definitions exist, they are loaded in this priority order:
 1. **CLI-defined** (`--agents` flag) - Session-specific
-2. **User-level** (`~/.claude/agents/`) - All projects
-3. **Project-level** (`.claude/agents/`) - Current project
+2. **Project-level** (`.claude/agents/`) - Current project
+3. **User-level** (`~/.claude/agents/`) - All projects
 
-CLI-defined agents override both user and project agents for the session.
+CLI-defined agents override both project and user agents for the session. Project-level agents override user-level agents when their names collide. See [Lesson 04 — Subagents](../04-subagents/README.md#file-locations) for the full priority table including plugin-level agents.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix Lesson 10's incorrect agent priority order to match Lesson 04 and the official Claude Code docs (CLI > Project > User, not CLI > User > Project)
- Update the matching quiz question Q7 in `lesson-quiz/references/question-bank.md` so the answer reflects the corrected ordering
- Add a cross-link from Lesson 10 to Lesson 04's full priority table

## Why

Two lessons disagreed on whether **project-level** or **user-level** agents win when names collide:
- `04-subagents/README.md` said CLI > **Project** > User > Plugin (correct)
- `10-cli/README.md` said CLI > **User** > Project (incorrect)

The official Claude Code docs (https://docs.claude.com/en/docs/claude-code/sub-agents) confirm Lesson 04 is correct: project-level agents take precedence over user-level when both define an agent with the same name.

## Closes

Closes #98

## Test plan

- [x] `pre-commit run --files <changed>` passes (markdown-lint, cross-references, mermaid-syntax, link-check, build-epub)
- [x] No other lessons reference the wrong order (grepped repo for `User > Project > CLI` and `CLI > User > Project` — only the two intentionally-fixed locations remain)
- [x] Cross-link anchor `#file-locations` verified to exist in `04-subagents/README.md`

## Out of scope

The official docs also list a top-tier "Managed settings" (org-wide) and a bottom-tier "Plugin" agent source. Both lessons currently omit one or both. Adding those is left for a separate PR — this PR is scoped to reconciling the existing contradiction flagged in #98.