### PR TITLE
docs(hooks): fix README divergence in Example 8 SessionEnd hook

### DIFF
--- a/06-hooks/README.md
+++ b/06-hooks/README.md
@@ -1030,19 +1030,38 @@ done | paste -sd ',' -)
 printf " Notes? (optional, press Enter to skip): "
 read -r NOTES </dev/tty
 
-SESSION="{\"date\":\"$DATE\",\"time\":\"$TIME\",\"modules\":[${MODULES_JSON}],\"notes\":\"${NOTES}\"}"
-
-python3 - "$PROGRESS_FILE" "$SESSION" <<'PYEOF'
+# Pass NOTES as a separate argument so Python handles JSON escaping —
+# avoids broken JSON when notes contain quotes or backslashes.
+python3 - "$PROGRESS_FILE" "$DATE" "$TIME" "$MODULES_JSON" "$NOTES" <<'PYEOF'
 import sys, json
-path, new_session = sys.argv[1], json.loads(sys.argv[2])
+
+path, date, time_str, modules_raw, notes = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
+
+new_session = {
+    "date": date,
+    "time": time_str,
+    "modules": json.loads(f"[{modules_raw}]") if modules_raw else [],
+    "notes": notes,
+}
+
 with open(path, 'r') as f:
     data = json.load(f)
+
 data.setdefault('sessions', []).append(new_session)
+
 with open(path, 'w') as f:
     json.dump(data, f, indent=2)
 PYEOF
 
 echo " Saved to $PROGRESS_FILE"
+```
+
+**Install** — copy the script into the project's hook directory so the path in `settings.json` resolves:
+
+```bash
+mkdir -p .claude/hooks
+cp 06-hooks/session-end.sh .claude/hooks/
+chmod +x .claude/hooks/session-end.sh
 ```
 
 **Configuration** (in `.claude/settings.json`):


### PR DESCRIPTION
## Summary

Closes #99 — two scoped README polish items surfaced when reviewing #87.

- **Fix 1.** README Example 8 was teaching a JSON-escape bug the author had already fixed in `06-hooks/session-end.sh`. The inline `SESSION="{...}"` shell interpolation breaks on notes containing `"` or `\`. Replaced with the canonical argv-based Python pattern from `session-end.sh` (lines 68–89), including the explanatory comment so the lesson carries the rationale.
- **Fix 2.** The Configuration snippet pointed at `\$CLAUDE_PROJECT_DIR/.claude/hooks/session-end.sh`, but no copy/install step preceded it — pasting the config verbatim produced a silent no-op. Added an Install block (`mkdir -p .claude/hooks` + `cp` + `chmod +x`) immediately before Configuration.

Scope is strictly the two edits called out in the issue. The MODULES_JSON pipeline-while block also diverges from `session-end.sh`, but acceptance criterion #4 forbids touching anything else, so left alone.

## Test plan

- [x] README Example 8 code block uses the same `argv`-based Python invocation as `06-hooks/session-end.sh`
- [x] README includes the install steps (`mkdir -p .claude/hooks` + `cp` + `chmod +x`) before the Configuration JSON
- [x] `pre-commit run --all-files` passes (markdown-lint, cross-references, mermaid-syntax, link-check, build-epub all Passed)
- [x] No other content changes — diff is limited to the two README edits