### PR TITLE
fix(memory): correct quiz Q2 answer from discontinued # prefix to /memory

### DIFF
--- a/.claude/skills/lesson-quiz/references/question-bank.md
+++ b/.claude/skills/lesson-quiz/references/question-bank.md
@@ -101,10 +101,10 @@
 ### Q2
 - **Category**: practical
 - **Question**: How do you quickly add a new rule to memory during a conversation?
-- **Options**: A) Type `/memory add "rule text"` | B) Prefix your message with `#` (e.g., `# always use TypeScript`) | C) Type `/rule "rule text"` | D) Use `@add-memory "rule text"`
-- **Correct**: B
-- **Explanation**: The `#` prefix pattern allows quick single-rule additions during conversation. Claude will ask which memory level to save it to.
-- **Review**: Quick memory updates section
+- **Options**: A) Use the `/memory` slash command or ask conversationally | B) Prefix your message with `#` (e.g., `# always use TypeScript`) | C) Type `/rule "rule text"` | D) Use `@add-memory "rule text"`
+- **Correct**: A
+- **Explanation**: The recommended ways to add memory are the `/memory` command (opens memory files in your editor) or asking Claude conversationally (e.g., "remember that we always use TypeScript strict mode"). The `#` prefix was discontinued and no longer works.
+- **Review**: Quick memory updates section in README
 
 ### Q3
 - **Category**: conceptual

--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -992,7 +992,7 @@ graph LR
 
 **Quick update workflow:**
 
-1. For single rules: Use `#` prefix in conversation
+1. For single rules: Use `/memory` to open editor, or ask conversationally
 2. For multiple changes: Use `/memory` to open editor
 3. For initial setup: Use `/init` to create template
 


### PR DESCRIPTION
## Summary

Fixes #106 — The lesson quiz Q2 for Memory had `#` prefix as the correct answer, but the lesson README explicitly states it was discontinued. This PR:

- **question-bank.md**: Changes Q2 correct answer from `#` prefix (B) → `/memory` / conversational request (A), updates explanation to note `#` was discontinued
- **README.md**: Fixes residual `#` prefix reference in "Quick update workflow" section (line 995) to match the deprecation notice earlier in the same file (line 85)

## Test plan

- [ ] Quiz Q2 now marks `/memory` as correct, not `#` prefix
- [ ] README no longer recommends discontinued `#` prefix anywhere
- [ ] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)