### PR TITLE
fix(quiz): correct Q4 extended thinking toggle wording

### DIFF
--- a/.claude/skills/lesson-quiz/references/question-bank.md
+++ b/.claude/skills/lesson-quiz/references/question-bank.md
@@ -704,10 +704,10 @@
 
 ### Q4
 - **Category**: practical
-- **Question**: How do you toggle extended thinking visibility during a session?
-- **Options**: A) Type `/effort max` | B) Press `Option+T` (macOS) or `Alt+T` | C) Include "ultrathink" in prompt | D) It's always visible and cannot be toggled
+- **Question**: How do you toggle extended thinking on or off during a session?
+- **Options**: A) Type `/effort max` | B) Press `Option+T` (macOS) or `Alt+T` | C) Include "ultrathink" in prompt | D) It's always enabled and cannot be toggled
 - **Correct**: B
-- **Explanation**: Option+T (macOS) or Alt+T toggles extended thinking visibility. For one-off deep reasoning, include "ultrathink" in your prompt; for session-level control, use `/effort` command.
+- **Explanation**: Option+T (macOS) or Alt+T toggles extended thinking on/off for the session. (`Ctrl+O` toggles verbose mode to show/hide the reasoning text.) For one-off deep reasoning, include "ultrathink" in your prompt; for session-level control, use `/effort` command.
 - **Review**: Extended Thinking section
 
 ### Q5


### PR DESCRIPTION
## Summary

- Fix Q4 wording: "visibility" → "on or off"
- Fix Option D: "always visible" → "always enabled"
- Add Ctrl+O verbose mode explanation to explanation

## Changes

Single file modified: `.claude/skills/lesson-quiz/references/question-bank.md`

## Verification

Cross-checked against official Claude Code docs:
- `Alt+T` / `Option+T` = toggle extended thinking **on/off** (the feature itself)
- `Ctrl+O` = toggle verbose transcript (show/hide reasoning text)

This is a follow-up to PR #83, fixing the issue raised in the review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)