### PR TITLE
docs: sync to Claude Code v2.1.126

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -601,8 +601,8 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/interactive-mode

--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -1198,11 +1198,11 @@ For the most up-to-date information, refer to the official Claude Code documenta
 - [Official Memory Docs](https://code.claude.com/docs/en/memory) - Anthropic documentation
 
 ---
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/memory
 - https://code.claude.com/docs/en/settings
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -150,7 +150,7 @@ disable-model-invocation: true              # Only user can invoke
 user-invocable: false                       # Hide from slash menu
 allowed-tools: Read, Grep, Glob             # Restrict tool access
 model: opus                                 # Specific model to use
-effort: high                                # Effort level override (low, medium, high, max)
+effort: high                                # Effort level override (low, medium, high, xhigh, max)
 context: fork                               # Run in isolated subagent
 agent: Explore                              # Which agent type (with context: fork)
 shell: bash                                 # Shell for commands: bash (default) or powershell
@@ -173,7 +173,7 @@ paths: "src/api/**/*.ts"               # Glob patterns limiting when skill activ
 | `user-invocable` | `false` = hidden from the `/` menu. Only Claude can invoke it automatically. |
 | `allowed-tools` | Comma-separated list of tools the skill may use without permission prompts. |
 | `model` | Model override while the skill is active (e.g., `opus`, `sonnet`). |
-| `effort` | Effort level override while the skill is active: `low`, `medium`, `high`, or `max`. |
+| `effort` | Effort level override while the skill is active: `low`, `medium`, `high`, `xhigh`, or `max`. Available levels depend on the model — `xhigh` is the Claude Code default for Opus 4.7. |
 | `context` | `fork` to run the skill in a forked subagent context with its own context window. |
 | `agent` | Subagent type when `context: fork` (e.g., `Explore`, `Plan`, `general-purpose`). |
 | `shell` | Shell used for `!`command`` substitutions and scripts: `bash` (default) or `powershell`. |
@@ -242,6 +242,7 @@ Skills support dynamic values that are resolved before the skill content reaches
 | `$ARGUMENTS[N]` or `$N` | Access specific argument by index (0-based) |
 | `${CLAUDE_SESSION_ID}` | Current session ID |
 | `${CLAUDE_SKILL_DIR}` | Directory containing the skill's SKILL.md file |
+| `${CLAUDE_EFFORT}` | Current effort level (`low`, `medium`, `high`, `xhigh`, or `max`). Useful for branching skill behavior: e.g., `[ "${CLAUDE_EFFORT}" = "max" ] && deep_analysis` (v2.1.120+) |
 | `` !`command` `` | Dynamic context injection — runs a shell command and inlines the output |
 
 **Example:**
@@ -598,6 +599,8 @@ ls ~/.claude/skills/
 ls .claude/skills/
 ```
 
+> **Tip (v2.1.121+):** Type to filter the `/skills` interactive menu — useful when many skills are installed.
+
 ### Testing a Skill
 
 Two ways to test:
@@ -820,8 +823,8 @@ Once you start building skills seriously, two things become essential: a library
 - [Hooks Guide](../06-hooks/) - Event-driven automation
 
 ---
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/settings

--- a/04-subagents/README.md
+++ b/04-subagents/README.md
@@ -1217,11 +1217,11 @@ graph TD
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/sub-agents
 - https://code.claude.com/docs/en/agent-teams
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -207,6 +207,27 @@ When MCP tool descriptions exceed 10% of the context window, Claude Code automat
 
 > **Note:** Tool search requires Sonnet 4 or later, or Opus 4 or later. Haiku models are not supported for tool search.
 
+### Bypassing Tool Search per Server (v2.1.121+)
+
+If a particular MCP server's tools are needed on every turn, mark its
+configuration with `"alwaysLoad": true` to skip tool-search deferral and
+keep its tools always available:
+
+```json
+{
+  "mcpServers": {
+    "always-on-tool": {
+      "command": "node",
+      "args": ["./tools/always.js"],
+      "alwaysLoad": true
+    }
+  }
+}
+```
+
+Use sparingly — every always-loaded tool consumes context that could
+otherwise be used for tool search to surface a more relevant tool.
+
 ## Dynamic Tool Updates
 
 Claude Code supports MCP `list_changed` notifications. When an MCP server dynamically adds, removes, or modifies its available tools, Claude Code receives the update and adjusts its tool list automatically -- no reconnection or restart required.
@@ -1111,8 +1132,8 @@ export GITHUB_TOKEN="your_token"
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/mcp
 - https://code.claude.com/docs/en/changelog

--- a/06-hooks/README.md
+++ b/06-hooks/README.md
@@ -523,6 +523,17 @@ All hooks receive JSON input via stdin:
 }
 ```
 
+> **Scope (v2.1.121+):** `hookSpecificOutput.updatedToolOutput` is now honored for **all** tools, not just MCP tools. A `PostToolUse` hook on `Bash`, `Edit`, `Read`, etc. can rewrite the tool's output before Claude sees it — useful for redacting secrets, normalizing diffs, or filtering noisy command output. Example (strip ANSI color codes from a `Bash` output):
+>
+> ```json
+> {
+>   "hookSpecificOutput": {
+>     "hookEventName": "PostToolUse",
+>     "updatedToolOutput": "<plain-text output with ANSI escapes removed>"
+>   }
+> }
+> ```
+
 ## Environment Variables
 
 | Variable | Availability | Description |
@@ -1355,11 +1366,11 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/changelog
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.118
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/07-plugins/README.md
+++ b/07-plugins/README.md
@@ -660,9 +660,13 @@ claude plugin enable <name>                  # Enable a disabled plugin
 claude plugin disable <name>                 # Disable a plugin
 claude plugin validate                       # Validate plugin structure
 claude plugin tag <version>                  # Create a release git tag with version validation (v2.1.118+)
+claude plugin prune                          # Remove orphaned auto-installed plugin dependencies (v2.1.121+)
+claude plugin uninstall <name> --prune       # Uninstall and cascade-clean orphaned dependencies (v2.1.121+)
 ```
 
 Example: `claude plugin tag v0.3.0` validates the version format, creates the matching git tag, and is the recommended way to cut plugin releases for distribution.
+
+`claude plugin prune` is useful after installing or uninstalling marketplace plugins that pulled in their own dependencies — it removes any auto-installed plugins whose parent plugin has since been removed. `plugin uninstall --prune` does the same cascade in a single step.
 
 ## Installation Methods
 
@@ -1033,12 +1037,12 @@ The following Claude Code features work together with plugins:
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/plugins
 - https://code.claude.com/docs/en/plugin-marketplaces
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.118
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/07-plugins/devops-automation/README.md
+++ b/07-plugins/devops-automation/README.md
@@ -108,9 +108,9 @@ Result:
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/plugins
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/07-plugins/documentation/README.md
+++ b/07-plugins/documentation/README.md
@@ -120,9 +120,9 @@ export GITHUB_TOKEN="your_github_token"
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/plugins
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/07-plugins/pr-review/README.md
+++ b/07-plugins/pr-review/README.md
@@ -92,9 +92,9 @@ Result:
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/plugins
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/08-checkpoints/README.md
+++ b/08-checkpoints/README.md
@@ -325,8 +325,8 @@ Remember: checkpoints are not a replacement for git. Use checkpoints for rapid e
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/checkpointing
 - https://code.claude.com/docs/en/settings

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -807,6 +807,10 @@ Permission modes control what actions Claude can take without explicit approval.
 
 Cycle through modes with `Shift+Tab` in the CLI. Set a default with the `--permission-mode` flag or the `permissions.defaultMode` setting.
 
+> **`--dangerously-skip-permissions` extended path coverage (v2.1.121, v2.1.126)**: The `--dangerously-skip-permissions` CLI flag (and equivalent `bypassPermissions` mode) now bypasses prompts for writes to a much broader allowlist — `.claude/skills/`, `.claude/agents/`, `.claude/commands/`, `.claude/`, `.git/`, `.vscode/`, and shell config files. Catastrophic removal commands (`rm -rf /`, etc.) still prompt regardless of mode. Treat the flag as a sharper tool than before; use it only in throwaway sandboxes.
+
+> **Windows shell detection (v2.1.120, v2.1.126)**: Git for Windows / Git Bash is no longer required. When Git Bash is absent, Claude Code uses PowerShell as the shell tool. From v2.1.126 PowerShell is the *primary* shell when the PowerShell tool is enabled, and detection covers PowerShell 7 installed via the Microsoft Store, MSI without PATH, or as a `.NET global tool`.
+
 ### Activation Methods
 
 **Keyboard shortcut**:
@@ -2162,8 +2166,8 @@ For more information about Claude Code and related features:
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/permission-modes
 - https://code.claude.com/docs/en/interactive-mode

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -56,8 +56,11 @@ The older JavaScript bundle is still produced for Windows and for environments t
 | `claude remote-control` | Start Remote Control server | `claude remote-control` |
 | `claude plugin` | Manage plugins (install, enable, disable) | `claude plugin install my-plugin` |
 | `claude plugin tag <version>` | Create a release git tag for a plugin with version validation (v2.1.118+) | `claude plugin tag v0.3.0` |
-| `claude install [version]` | Install a specific native-binary version. Accepts `stable`, `latest`, or an explicit version string | `claude install 2.1.119` |
-| `claude auth login` | Log in (supports `--email`, `--sso`) | `claude auth login --email user@example.com` |
+| `claude install [version]` | Install a specific native-binary version. Accepts `stable`, `latest`, or an explicit version string | `claude install 2.1.126` |
+| `claude project purge [path]` | Delete all local Claude Code state for a project (transcripts, tasks, debug logs, file-edit history, prompt history, and `~/.claude.json` entry). Omit `[path]` for an interactive picker. Flags: `--dry-run` to preview, `-y/--yes` to skip confirmation, `-i/--interactive` to confirm each item, `--all` for every project (v2.1.126+) | `claude project purge ~/work/repo --dry-run` |
+| `claude plugin prune` | Remove orphaned auto-installed plugin dependencies (parent plugin gone). `plugin uninstall --prune` does the same cascade after uninstalling a target (v2.1.121+) | `claude plugin prune` |
+| `claude ultrareview [target]` | Run `/ultrareview` non-interactively. Prints findings to stdout, exits 0 on success / 1 on failure. Use `--json` for raw payload, `--timeout <minutes>` to override the 30-minute default (v2.1.120+) | `claude ultrareview 1234 --json` |
+| `claude auth login` | Log in (supports `--email`, `--sso`). Since v2.1.126, accepts the OAuth code pasted into the terminal as a fallback when the browser callback can't reach localhost (WSL2, SSH, containers) | `claude auth login --email user@example.com` |
 | `claude auth logout` | Log out of current account | `claude auth logout` |
 | `claude auth status` | Check auth status (exit 0 if logged in, 1 if not) | `claude auth status` |
 
@@ -146,6 +149,8 @@ claude -p --model opus --fallback-model sonnet "analyze architecture"
 # Use opusplan (Opus plans, Sonnet executes)
 claude --model opusplan "design and implement the caching layer"
 ```
+
+> **Gateway model discovery (v2.1.126+)**: When `ANTHROPIC_BASE_URL` points at an Anthropic-compatible gateway, `/model` populates its picker from the gateway's `/v1/models` endpoint instead of the hard-coded list — useful for self-hosted proxies that expose a different model lineup.
 
 ## System Prompt Customization
 
@@ -319,6 +324,21 @@ claude -r "feature-auth" --fork-session "test with different architecture"
 - Test breaking changes without affecting the main session
 
 The original session remains unchanged, and the fork becomes a new independent session.
+
+### Project State Cleanup (v2.1.126+)
+
+`claude project purge` deletes all local Claude Code state for a project — transcripts, task lists, debug logs, file-edit history, prompt history lines, and the project's `~/.claude.json` entry. Use `--dry-run` first to preview the deletion; `--all` walks every project on the machine.
+
+```bash
+# Preview what would be deleted (safe)
+claude project purge ~/work/repo --dry-run
+
+# Delete state for a specific project, no prompts
+claude project purge ~/work/repo --yes
+
+# Walk every project interactively
+claude project purge --all --interactive
+```
 
 ## Advanced Features
 
@@ -504,6 +524,16 @@ pipeline {
     }
 }
 ```
+
+**Headless `ultrareview` (v2.1.120+):**
+
+```yaml
+# .github/workflows/ultrareview.yml
+- name: Claude ultrareview
+  run: claude ultrareview ${{ github.event.pull_request.number }} --json > review.json
+```
+
+`claude ultrareview` exits 0 on a clean review and 1 when findings are reported, so it's a drop-in PR gate. Use `--timeout <minutes>` to override the 30-minute default.
 
 ### 2. Script Piping
 
@@ -761,6 +791,8 @@ The "ultrathink" keyword in prompts activates deep reasoning. The `max` effort l
 | `CLAUDE_CODE_HIDE_CWD` | When set to `1`, hides the current working directory in the startup logo (privacy / screen-share use) (v2.1.119+) |
 | `CLAUDE_CODE_FORK_SUBAGENT` | Set to `1` to enable forked subagents on external builds (Bedrock, Vertex, Foundry). No effect on Anthropic API where forked subagents are GA (v2.1.117+) |
 | `OTEL_LOG_TOOL_DETAILS` | Set to `1` to unredact custom and MCP command names in OpenTelemetry events (v2.1.117+). Redaction remains the default. |
+| `ANTHROPIC_BEDROCK_SERVICE_TIER` | Selects the Bedrock service tier: `default`, `flex`, or `priority` (v2.1.122+) |
+| `AI_AGENT` | Set automatically on subprocesses so external CLIs (e.g., `gh`) can attribute traffic to Claude Code (v2.1.120+) |
 
 > **`ENABLE_TOOL_SEARCH` on Vertex AI (v2.1.119+)**: Tool search is **disabled by default on Google Cloud Vertex AI** deployments. Users who want the tool-search capability on Vertex must explicitly opt in with `export ENABLE_TOOL_SEARCH=true`. On direct Anthropic API it remains enabled by default.
 
@@ -868,8 +900,8 @@ claude -p --output-format json "query"
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/cli-reference
 - https://code.claude.com/docs/en/settings
@@ -879,5 +911,5 @@ claude -p --output-format json "query"
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.116
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.118
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -530,8 +530,8 @@ chmod +x ~/.claude/hooks/*.sh
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,89 @@
 # Changelog
 
+## [v2.5.0] — 2026-05-02
+
+### Synced to Claude Code v2.1.126
+
+Bumps tutorial coverage from Claude Code v2.1.119 → v2.1.126 (May 1, 2026 release).
+v2.1.120 was rolled back on its first release day (2026-04-24) but re-released
+successfully on 2026-04-28 with the originally-reported regressions fixed.
+v2.1.124 and v2.1.125 were skipped by Anthropic and never released.
+
+### Added (English docs)
+
+- `claude project purge [path]` subcommand (v2.1.126) — deletes all Claude Code
+  state for a project (transcripts, tasks, debug logs, file-edit history,
+  prompt history, `~/.claude.json` entry). Supports `--dry-run`, `-y/--yes`,
+  `-i/--interactive`, `--all`. Documented in `10-cli/README.md`.
+- `claude plugin prune` subcommand (v2.1.121) — removes orphaned auto-installed
+  plugin dependencies; `plugin uninstall --prune` cascades. Documented in
+  `07-plugins/README.md`.
+- `claude ultrareview [target]` subcommand (v2.1.120) — runs `/ultrareview`
+  non-interactively from CI/scripts, prints findings to stdout, exits 0/1 on
+  success/failure; supports `--json` and `--timeout <minutes>`. Documented in
+  `10-cli/README.md`.
+- `${CLAUDE_EFFORT}` placeholder available inside skill content (v2.1.120) —
+  resolves to the current effort level. Documented in `03-skills/README.md`.
+- `alwaysLoad` MCP server config option (v2.1.121) — when `true`, all tools
+  from that server skip tool-search deferral. Documented in `05-mcp/README.md`.
+- `PostToolUse.hookSpecificOutput.updatedToolOutput` now works for all tools
+  (v2.1.121), previously MCP-only. Documented in `06-hooks/README.md`.
+- `ANTHROPIC_BEDROCK_SERVICE_TIER` environment variable (v2.1.122) — selects
+  Bedrock service tier (`default`, `flex`, `priority`). Documented in
+  `10-cli/README.md` env-var table.
+- `--dangerously-skip-permissions` extended-path coverage (v2.1.121, v2.1.126)
+  — now bypasses prompts for writes to `.claude/skills/`, `.claude/agents/`,
+  `.claude/commands/`, `.claude/`, `.git/`, `.vscode/`, shell config files.
+  Catastrophic removal commands (`rm -rf /` etc.) still prompt. Documented in
+  `09-advanced-features/README.md` permission-modes section.
+- OAuth code paste fallback (v2.1.126) — `claude auth login` accepts the OAuth
+  code pasted into the terminal when the browser callback can't reach
+  localhost (WSL2, SSH, containers). Documented in `10-cli/README.md`.
+- Type-to-filter `/skills` menu (v2.1.121). Documented in `03-skills/README.md`.
+- `AI_AGENT` environment variable (v2.1.120) — set on subprocesses so `gh` can
+  attribute traffic to Claude Code. Documented in `10-cli/README.md` env-var
+  table.
+
+### Changed
+
+- `--from-pr` (v2.1.119) and `/resume` PR-URL search (v2.1.122) now both
+  support GitHub, GitHub Enterprise, GitLab, and Bitbucket URLs.
+- Windows: Git for Windows / Git Bash no longer required (v2.1.120) — Claude
+  Code uses PowerShell as the shell tool when Git Bash is absent. From v2.1.126,
+  PowerShell is the primary shell when the PowerShell tool is enabled. Detection
+  extended to PowerShell 7 installed via Microsoft Store, MSI without PATH, or
+  `.NET global tool`. Documented in `09-advanced-features/README.md` platform
+  notes.
+- `/model` picker now lists models from your gateway's `/v1/models` endpoint
+  when `ANTHROPIC_BASE_URL` points at an Anthropic-compatible gateway
+  (v2.1.126). Documented in `10-cli/README.md`.
+- `--dangerously-skip-permissions` no longer prompts for writes to a much
+  broader allowlist (see Added). Catastrophic removals still prompt.
+- Image paste auto-downscale (v2.1.126) — images larger than 2000px are
+  downscaled on paste; oversized images in history are auto-removed and the
+  request retried. (Tutorial-relevant only as a safety/UX note.)
+
+### Security
+
+- Fixed `allowManagedDomainsOnly` / `allowManagedReadPathsOnly` being ignored
+  when a higher-priority managed-settings source lacked a `sandbox` block
+  (v2.1.126).
+
+### Notes for translation maintainers
+
+The `vi/`, `zh/`, `uk/`, and `ja/` localized trees are community-maintained
+and may lag the English source. Contributors syncing translations should diff
+against the English files updated in this release.
+
 ## [v2.4.0] — 2026-04-27
 
 ### Synced to Claude Code v2.1.119
 
 Bumps tutorial coverage from Claude Code v2.1.112 → v2.1.119 (April 23, 2026 release).
-v2.1.120 was published April 24 and rolled back due to regressions; clients are
-auto-rolled back to v2.1.119, which remains the stable target.
+v2.1.120 was published April 24, briefly rolled back the same day due to regressions,
+and re-released on April 28 with fixes — it is now part of the normal release line.
+A subsequent v2.1.126 (May 1, 2026) is the next stable target and is covered in the
+v2.5.0 entry above.
 
 ### Added (English docs)
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -874,13 +874,13 @@ Want to add more examples? Follow the structure:
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/commands
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 **Total Examples**: 100+ files
 **Categories**: 10 features

--- a/LEARNING-ROADMAP.md
+++ b/LEARNING-ROADMAP.md
@@ -738,12 +738,12 @@ Once you've completed all milestones:
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 **Maintained by**: Claude How-To Contributors
 **License**: Educational purposes, free to use and adapt

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -505,11 +505,11 @@ Getting started checklist:
 **This Card**: Keep it handy for quick reference!
 
 ---
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/commands
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/luongnv89/claude-howto?style=flat&color=gold)](https://github.com/luongnv89/claude-howto/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/luongnv89/claude-howto?style=flat)](https://github.com/luongnv89/claude-howto/network/members)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.1.119-brightgreen)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.1.126-brightgreen)](CHANGELOG.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-2.1+-purple)](https://code.claude.com)
 
 🌐 **Language / Ngôn ngữ / 语言 / Мова:** [English](README.md) | [Tiếng Việt](vi/README.md) | [中文](zh/README.md) | [Українська](uk/README.md) | [日本語](ja/README.md)
@@ -102,7 +102,7 @@ Run `/lesson-quiz [topic]` after each module. The quiz pinpoints what you missed
 
 - **GitHub stars** from developers who use Claude Code daily
 - **Forks** from teams adapting this guide for their own workflows
-- **Actively maintained** — synced with every Claude Code release (latest: v2.1.119, April 2026)
+- **Actively maintained** — synced with every Claude Code release (latest: v2.1.126, May 2026)
 - **Community-driven** — contributions from developers who share their real-world configurations
 
 [![Star History Chart](https://api.star-history.com/svg?repos=luongnv89/claude-howto&type=Date)](https://star-history.com/#luongnv89/claude-howto&Date)
@@ -201,7 +201,7 @@ cp -r 03-skills/code-review ~/.claude/skills/
 Yes. MIT licensed, free forever. Use it in personal projects, at work, in your team — no restrictions beyond including the license notice.
 
 **Is this maintained?**
-Actively. The guide is synced with every Claude Code release. Current version: v2.1.119 (April 2026), compatible with Claude Code 2.1+.
+Actively. The guide is synced with every Claude Code release. Current version: v2.1.126 (May 2026), compatible with Claude Code 2.1+.
 
 **How is this different from the official docs?**
 The official docs are a feature reference. This guide is a tutorial with diagrams, production-ready templates, and a progressive learning path. They complement each other — start here to learn, reference the docs when you need specifics.
@@ -871,11 +871,11 @@ MIT License - see [LICENSE](LICENSE). Free to use, modify, and distribute. The o
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/changelog
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.113
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -631,8 +631,8 @@ Before submitting content, verify:
 
 ---
 
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/changelog

--- a/claude_concepts_guide.md
+++ b/claude_concepts_guide.md
@@ -3145,8 +3145,8 @@ Claude Code supports three models with adaptive reasoning effort:
 *Now includes: Hooks, Checkpoints, Planning Mode, Extended Thinking, Background Tasks, Permission Modes (6 modes), Headless Mode, Session Management, Auto Memory, Agent Teams, Scheduled Tasks, Chrome Integration, Channels, Voice Dictation, and Bundled Skills*
 
 ---
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks

--- a/resources.md
+++ b/resources.md
@@ -249,10 +249,10 @@ These steps capture the core recommendations for smooth workflows with Claude Co
 | **Monitor Tool** | Watch a background command's stdout stream and react to events instead of polling (v2.1.98+) | [Advanced Features](09-advanced-features/) |
 
 ---
-**Last Updated**: April 24, 2026
-**Claude Code Version**: 2.1.119
+**Last Updated**: May 2, 2026
+**Claude Code Version**: 2.1.126
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/changelog
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.119
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.126
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5


### PR DESCRIPTION
## Summary

Bumps tutorial coverage from Claude Code **v2.1.119 → v2.1.126** (May 1, 2026 release), covering six new upstream releases since the April 27 sync.

- v2.1.120 was rolled back on its first release day (2026-04-24) but re-released 2026-04-28 with regressions fixed; v2.1.124/125 skipped by Anthropic.
- 22 in-scope English files updated; localized `vi/`/`zh/`/`uk/`/`ja/` trees out of scope (community-maintained).

### New feature documentation

- `claude project purge [path]` (v2.1.126) — `10-cli/`
- `claude plugin prune` / `plugin uninstall --prune` (v2.1.121) — `07-plugins/`, `10-cli/`
- `claude ultrareview [target]` non-interactive form (v2.1.120) — `10-cli/`
- `${CLAUDE_EFFORT}` placeholder + type-to-filter `/skills` (v2.1.120-121) — `03-skills/`
- `alwaysLoad` MCP server config option (v2.1.121) — `05-mcp/`
- `PostToolUse.updatedToolOutput` for non-MCP tools (v2.1.121) — `06-hooks/`
- `ANTHROPIC_BEDROCK_SERVICE_TIER`, `AI_AGENT` env vars — `10-cli/`
- `--dangerously-skip-permissions` extended path coverage + Windows PowerShell-as-primary-shell (v2.1.121, v2.1.126) — `09-advanced-features/`
- `/model` gateway `/v1/models` discovery + OAuth code paste fallback (v2.1.126) — `10-cli/`

### Fixes

- `xhigh` missing from `03-skills/README.md` effort enum (regression from April 24)
- `README.md` "latest version" claims (lines 105, 204) and shields.io version badge
- `CHANGELOG.md` v2.4.0 entry's stale "v2.1.120 was rolled back" paragraph

### CHANGELOG

New `[v2.5.0] — 2026-05-02` entry summarizes the v2.1.120 → v2.1.126 sync.

## Test plan

- [x] `pre-commit run --all-files` passes (markdown-lint, cross-references, mermaid-syntax, link-check, build-epub)
- [x] All 22 in-scope English footers carry `Last Updated: May 2, 2026` / `Claude Code Version: 2.1.126` (verified by `grep -L`)
- [x] No `vi/`/`zh/`/`uk/`/`ja/` files modified
- [x] `xhigh` present in `03-skills/README.md` lines 153 and 176