### PR TITLE
fix(zh-slash-commands-readme): fixed table formatting errors caused b…

### DIFF
--- a/zh/01-slash-commands/README.md
+++ b/zh/01-slash-commands/README.md
@@ -37,11 +37,11 @@ Claude Code 目前提供 55+ 个内置命令和 5 个内置 Skills。你可以�
 | `/desktop` | 继续在桌面应用中处理（别名：`/app`） |
 | `/diff` | 查看未提交更改的交互式 diff |
 | `/doctor` | 检查安装健康状态 |
-| `/effort [low|medium|high|max|auto]` | 设置推理强度；`max` 需要 Opus 4.6 |
+| `/effort [low\|medium\|high\|max\|auto]` | 设置推理强度；`max` 需要 Opus 4.6 |
 | `/exit` | 退出 REPL（别名：`/quit`） |
 | `/export [filename]` | 将当前对话导出为文件或剪贴板内容 |
 | `/extra-usage` | 配置额外用量以应对速率限制 |
-| `/fast [on|off]` | 切换快速模式 |
+| `/fast [on\|off]` | 切换快速模式 |
 | `/feedback` | 提交反馈（别名：`/bug`） |
 | `/help` | 显示帮助 |
 | `/hooks` | 查看 hook 配置 |

--- a/zh/01-slash-commands/README.md
+++ b/zh/01-slash-commands/README.md
@@ -28,7 +28,7 @@ Claude Code 目前提供 55+ 个内置命令和 5 个内置 Skills。你可以�
 | `/btw <question>` | 额外问题，不写入历史 |
 | `/chrome` | 配置 Chrome 浏览器集成 |
 | `/clear` | 清空对话（别名：`/reset`、`/new`） |
-| `/color [color|default]` | 设置提示栏颜色 |
+| `/color [color\|default]` | 设置提示栏颜色 |
 | `/compact [instructions]` | 压缩对话，可附带聚焦指令 |
 | `/config` | 打开设置（别名：`/settings`） |
 | `/context` | 用彩色网格可视化上下文占用 |


### PR DESCRIPTION
## Description
Fixed table formatting errors caused by missing escaping.

## Type of Change
- [ ] New example or template
- [ ] Documentation improvement
- [x] Bug fix
- [ ] Feature guide
- [ ] Other (please describe)

## Related Issues

## Changes Made

## What to Review

## Files Changed
- `zh/01-slash-commands/README.md`

## Testing
How have you tested this?
- [ ] Tested locally with Claude Code
- [ ] Verified examples work
- [ ] Checked links and references
- [x] Reviewed for typos and clarity

## Checklist
- [x] Follows project structure and conventions
- [x] Includes clear documentation/examples
- [x] Code/examples are copy-paste ready
- [x] All links are verified and working
- [x] No sensitive information included (keys, tokens, credentials)
- [x] Updated relevant README files
- [x] Commit message follows conventional commit format
- [x] No large files (>1MB) added

## Screenshots or Examples


## Breaking Changes
Does this change any existing content or behavior?
- [x] No breaking changes
- [ ] Yes, and it's documented below

If yes, please describe:

## Additional Notes

