### PR TITLE
fix(i18n): correct logo paths in translated root-level files

### DIFF
--- a/uk/CONTRIBUTING.md
+++ b/uk/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 <!-- i18n-date: 2026-04-09 -->
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Внесок у Claude How To

--- a/uk/STYLE_GUIDE.md
+++ b/uk/STYLE_GUIDE.md
@@ -3,8 +3,8 @@
 <!-- i18n-date: 2026-04-09 -->
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Гайд зі стилю

--- a/uk/claude_concepts_guide.md
+++ b/uk/claude_concepts_guide.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Повний довідник концепцій Claude

--- a/uk/resources.md
+++ b/uk/resources.md
@@ -3,8 +3,8 @@
 <!-- i18n-date: 2026-04-10 -->
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Список корисних ресурсів

--- a/vi/CONTRIBUTING.md
+++ b/vi/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Đóng Góp Cho Claude How To / Contributing to Claude How To

--- a/vi/resources.md
+++ b/vi/resources.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Danh Sách Tài Nguyên Hữu Ích

--- a/zh/CATALOG.md
+++ b/zh/CATALOG.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Claude Code 功能目录

--- a/zh/CONTRIBUTING.md
+++ b/zh/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # 为 Claude How To 贡献内容

--- a/zh/INDEX.md
+++ b/zh/INDEX.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Claude Code 示例 - 完整索引

--- a/zh/LEARNING-ROADMAP.md
+++ b/zh/LEARNING-ROADMAP.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # 📚 Claude Code 学习路线图

--- a/zh/QUICK_REFERENCE.md
+++ b/zh/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Claude Code 示例 - 速查卡

--- a/zh/README.md
+++ b/zh/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 <p align="center">

--- a/zh/STYLE_GUIDE.md
+++ b/zh/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # 风格指南

--- a/zh/claude_concepts_guide.md
+++ b/zh/claude_concepts_guide.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # Claude Concepts 完整指南

--- a/zh/resources.md
+++ b/zh/resources.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="resources/logos/claude-howto-logo-dark.svg">
-  <img alt="Claude How To" src="resources/logos/claude-howto-logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="../resources/logos/claude-howto-logo-dark.svg">
+  <img alt="Claude How To" src="../resources/logos/claude-howto-logo.svg">
 </picture>
 
 # 优质资源清单


### PR DESCRIPTION
Type: chore

## Summary

Follow-up to #123 — that PR fixed module README logo paths in `01-` … `10-` subdirectories but missed root-level translated files (README, INDEX, CATALOG, CONTRIBUTING, STYLE_GUIDE, etc.) which had the same broken-path bug.

They used `resources/logos/...` (root-relative) but live one directory deep, so they resolved to `{lang}/resources/logos/...` and returned 404.

## Changes

Path fix: `resources/logos/...` → `../resources/logos/...` in the top `<picture>` block.

- **zh/** (9 files): README, INDEX, CATALOG, CONTRIBUTING, STYLE_GUIDE, LEARNING-ROADMAP, QUICK_REFERENCE, claude_concepts_guide, resources
- **uk/** (4 files): CONTRIBUTING, STYLE_GUIDE, claude_concepts_guide, resources
- **vi/** (2 files): CONTRIBUTING, resources

For STYLE_GUIDE files, the in-code-fence `<picture>` example was intentionally left as `resources/logos/...` to mirror the English source — it documents the canonical pattern, not the path the file itself uses.

`ja/STYLE_GUIDE.md` was already correct at HEAD.

## Test plan

- [x] `pre-commit run --all-files` passes (markdown-lint, cross-references, mermaid-syntax, link-check, build-epub, vietnamese variants)
- [x] Verified no remaining broken `src="resources/logos/"` paths outside intentional code-fence examples
