### PR TITLE
docs: sync to Claude Code v2.1.145 (2 patches since v2.1.143)

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -40,7 +40,7 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/effort [low\|medium\|high\|xhigh\|max\|auto]` | Set effort level via interactive arrow-key slider. Levels: `low` → `medium` → `high` → `xhigh` (new in v2.1.111) → `max`. Default is `xhigh` on Opus 4.7; `max` requires Opus 4.7 |
 | `/exit` | Exit the REPL (alias: `/quit`) |
 | `/export [filename]` | Export the current conversation to a file or clipboard |
-| `/extra-usage` | Configure extra usage for rate limits |
+| `/usage-credits` | Configure extra usage for rate limits (renamed from `/extra-usage` in v2.1.144; `/extra-usage` still works as an alias) |
 | `/fast [on\|off]` | Toggle fast mode |
 | `/feedback` | Submit feedback (alias: `/bug`). Since v2.1.141, can attach recent sessions (last 24h or 7d) so reports spanning more than one session include context. |
 | `/focus` | Toggle focus view (added v2.1.110; replaces `Ctrl+O` for focus toggle) |
@@ -59,7 +59,7 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/mcp` | Manage MCP servers and OAuth |
 | `/memory` | Edit `CLAUDE.md`, toggle auto-memory |
 | `/mobile` | QR code for mobile app (aliases: `/ios`, `/android`) |
-| `/model [model]` | Select model with left/right arrows for effort |
+| `/model [model]` | Select model with left/right arrows for effort. Since v2.1.144, the choice applies only to the current session by default; press `d` after selecting a model to set it as the default for new sessions. |
 | `/passes` | Share free week of Claude Code |
 | `/permissions` | View/update permissions (alias: `/allowed-tools`) |
 | `/plan [description]` | Enter plan mode |
@@ -620,16 +620,19 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 
 ---
 
-**Last Updated**: May 19, 2026
-**Claude Code Version**: 2.1.143
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/interactive-mode
 - https://code.claude.com/docs/en/changelog
+- https://code.claude.com/docs/en/commands
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.118
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.116
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.139
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.141
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 
 *Part of the [Claude How To](../) guide series*

--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -1198,12 +1198,12 @@ For the most up-to-date information, refer to the official Claude Code documenta
 - [Official Memory Docs](https://code.claude.com/docs/en/memory) - Anthropic documentation
 
 ---
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/memory
 - https://code.claude.com/docs/en/settings
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.131
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.138
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -291,6 +291,8 @@ Commands execute immediately; Claude only sees the final output. By default, com
 
 Add `context: fork` to run a skill in an isolated subagent context. The skill content becomes the task for a dedicated subagent with its own context window, keeping the main conversation uncluttered.
 
+> **v2.1.145 fix**: A skill using `context: fork` could previously trigger an infinite re-invocation loop in rare cases. Upgrade to v2.1.145+ if you author or rely on forking skills.
+
 The `agent` field specifies which agent type to use:
 
 | Agent Type | Best For |
@@ -792,15 +794,19 @@ When `disableSkillShellExecution` is `true`, any `` !`command` `` markers in a s
 
 ## Bundled Skills
 
-Claude Code ships with several built-in skills that are always available without installation:
+Claude Code ships with nine built-in skills that are always available without installation:
 
 | Skill | Description |
 |-------|-------------|
-| `/simplify` | Review changed files for reuse, quality, and efficiency; spawns 3 parallel review agents |
 | `/batch <instruction>` | Orchestrate large-scale parallel changes across codebase using git worktrees |
-| `/debug [description]` | Troubleshoot current session by reading debug log |
-| `/loop [interval] <prompt>` | Run prompt repeatedly on interval (e.g., `/loop 5m check the deploy`) |
 | `/claude-api` | Load Claude API/SDK reference; auto-activates on `anthropic`/`@anthropic-ai/sdk` imports |
+| `/debug [description]` | Troubleshoot current session by reading debug log |
+| `/fewer-permission-prompts` | Scan transcripts and propose a prioritized allowlist for common read-only tools |
+| `/loop [interval] <prompt>` | Run prompt repeatedly on interval (e.g., `/loop 5m check the deploy`) |
+| `/run` *(v2.1.145+)* | Launch this project's app to see a change running — looks for a project skill, otherwise falls back to built-in patterns per project type |
+| `/run-skill-generator` *(v2.1.145+)* | Teach `/run`/`/verify` how to handle a specific project by generating a per-project skill |
+| `/simplify` | Review changed files for reuse, quality, and efficiency; spawns 3 parallel review agents |
+| `/verify` *(v2.1.145+)* | Build, run, and observe the app to confirm a fix works (not just that tests pass) |
 
 These skills are available out-of-the-box and do not need to be installed or configured. They follow the same SKILL.md format as custom skills.
 
@@ -846,10 +852,12 @@ Once you start building skills seriously, two things become essential: a library
 - [Hooks Guide](../06-hooks/) - Event-driven automation
 
 ---
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/settings
 - https://code.claude.com/docs/en/changelog
+- https://code.claude.com/docs/en/commands
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/06-hooks/README.md
+++ b/06-hooks/README.md
@@ -348,6 +348,12 @@ Run when Claude finishes responding (Stop) or a subagent completes (SubagentStop
 
 **Additional input field:** Both `Stop` and `SubagentStop` hooks receive a `last_assistant_message` field in their JSON input, containing the final message from Claude or the subagent before stopping. This is useful for evaluating task completion.
 
+**v2.1.145 additions:** The `Stop` and `SubagentStop` hook inputs now also include two arrays:
+- `background_tasks` — any background tasks the session has spawned (handy for blocking stop until work finishes).
+- `session_crons` — any cron jobs (`/schedule`) created during the session.
+
+Hook authors can read these to decide whether to block stop — for example, "don't stop while a background test run or scheduled task is still pending."
+
 **Configuration:**
 ```json
 {
@@ -1265,6 +1271,7 @@ MCP tools follow the pattern `mcp__<server>__<tool>`:
 - **HTTP hooks and environment variables:** HTTP hooks require an explicit `allowedEnvVars` list to use environment variable interpolation in URLs. This prevents accidental leakage of sensitive environment variables to remote endpoints.
 - **Managed settings hierarchy:** The `disableAllHooks` setting now respects the managed settings hierarchy, meaning organization-level settings can enforce hook disablement that individual users cannot override.
 - **PowerShell auto-approve (v2.1.119):** PowerShell tool commands can be auto-approved in permission mode, matching Bash. This brings parity for Windows users running Claude Code with PowerShell-backed shell tools.
+- **Bash bare env-var auto-approve closed (v2.1.145):** Before v2.1.145, a Bash command of the form `FOO=bar somecommand` (a bare variable assignment inline with a non-allowlisted command) could be auto-approved when only `FOO=bar` by itself was on the allowlist. v2.1.145 closes this — such commands now hit the permission prompt. Scripts relying on the implicit allow will start prompting; re-allow them explicitly via a `Bash(...)` permission rule that covers the full command, not just the variable assignment.
 
 ### Best Practices
 
@@ -1433,8 +1440,8 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 
 ---
 
-**Last Updated**: May 19, 2026
-**Claude Code Version**: 2.1.143
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/changelog
@@ -1444,4 +1451,5 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.139
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.141
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.143
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/08-checkpoints/README.md
+++ b/08-checkpoints/README.md
@@ -325,8 +325,8 @@ Remember: checkpoints are not a replacement for git. Use checkpoints for rapid e
 
 ---
 
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/checkpointing
 - https://code.claude.com/docs/en/settings

--- a/08-checkpoints/checkpoint-examples.md
+++ b/08-checkpoints/checkpoint-examples.md
@@ -339,8 +339,9 @@ User: Now let's continue with the approach that worked.
 6. **Summarize long sessions**: Use "Summarize from here" to keep conversations manageable
 
 ---
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/checkpointing
 - https://code.claude.com/docs/en/changelog
+**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/09-advanced-features/planning-mode-examples.md
+++ b/09-advanced-features/planning-mode-examples.md
@@ -533,7 +533,9 @@ Proceed with this plan? (yes/no/modify)
 7. **Plan for testing** at each phase
 
 ---
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/changelog
+- https://code.claude.com/docs/en/best-practices
+**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -486,6 +486,7 @@ When you dispatch a session from the view (or via `claude --bg <prompt>`), you c
 | `--model <model>` | v2.1.142 | Pin a model for the dispatched session |
 | `--effort <level>` | v2.1.142 | Pin an effort level (`low`/`medium`/`high`/`xhigh`/`max`) |
 | `--dangerously-skip-permissions` | v2.1.142 | Run the dispatched session without permission prompts (use only in sandboxes) |
+| `--json` | v2.1.145 | Print the agent list as machine-readable JSON for scripting (status bars, session pickers, tmux-resurrect integrations) |
 
 Sessions that finish their work but leave a background shell open move from "Working" to "Completed" (v2.1.141 fix). Within an attached agent session, `Shift+Tab` cycles through permission modes including auto mode (v2.1.143).
 
@@ -938,12 +939,13 @@ claude -p --output-format json "query"
 
 ---
 
-**Last Updated**: May 19, 2026
-**Claude Code Version**: 2.1.143
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/cli-reference
 - https://code.claude.com/docs/en/settings
 - https://code.claude.com/docs/en/changelog
+- https://code.claude.com/docs/en/agent-view
 - https://www.anthropic.com/news/claude-opus-4-7
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.113
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.116
@@ -955,4 +957,5 @@ claude -p --output-format json "query"
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.141
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.142
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.143
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -17,12 +17,12 @@
 |---------|----------|----------|-------|-----------|
 | **Slash Commands** | 60+ | 8 | 68+ | [01-slash-commands/](01-slash-commands/) |
 | **Subagents** | 6 | 11 | 17 | [04-subagents/](04-subagents/) |
-| **Skills** | 5 bundled | 6 | 11 | [03-skills/](03-skills/) |
+| **Skills** | 9 bundled | 6 | 15 | [03-skills/](03-skills/) |
 | **Plugins** | - | 3 | 3 | [07-plugins/](07-plugins/) |
 | **MCP Servers** | 1 | 8 | 9 | [05-mcp/](05-mcp/) |
 | **Hooks** | 29 events | 8 | 8 | [06-hooks/](06-hooks/) |
 | **Memory** | 7 types | 3 | 3 | [02-memory/](02-memory/) |
-| **Total** | **99** | **47** | **121** | |
+| **Total** | **103** | **47** | **125** | |
 
 ---
 
@@ -60,7 +60,7 @@ Commands are user-invoked shortcuts that execute specific actions.
 | `/cost` | Shortcut alias that opens the cost tab of `/usage` (v2.1.118+) | Monitor spending |
 | `/context` | Show context window usage | Manage conversation length |
 | `/export` | Export conversation | Save for reference |
-| `/extra-usage` | Configure extra usage limits | Rate limit management |
+| `/usage-credits` | Configure extra usage limits (renamed from `/extra-usage` in v2.1.144; old name still works as alias) | Rate limit management |
 | `/feedback` | Submit feedback or bug report | Report issues |
 | `/login` | Authenticate with Anthropic | Access features |
 | `/logout` | Sign out | Switch accounts |
@@ -239,11 +239,15 @@ cp -r 03-skills/* ~/.claude/skills/
 
 | Skill | Description | When Auto-Invoked |
 |-------|-------------|-------------------|
-| `/simplify` | Review code for quality | After writing code |
 | `/batch` | Run prompts on multiple files | Batch operations |
-| `/debug` | Debug failing tests/errors | Debugging sessions |
-| `/loop` | Run prompts on interval | Recurring tasks |
 | `/claude-api` | Build apps with Claude API | API development |
+| `/debug` | Debug failing tests/errors | Debugging sessions |
+| `/fewer-permission-prompts` | Scan transcripts and propose a prioritized allowlist | Reduce repeat permission prompts |
+| `/loop` | Run prompts on interval | Recurring tasks |
+| `/run` *(v2.1.145+)* | Launch this project's app to see a change running | Verifying a change in the real app |
+| `/run-skill-generator` *(v2.1.145+)* | Teach `/run`/`/verify` how to handle a specific project | First-time project setup for `/run` |
+| `/simplify` | Review code for quality | After writing code |
+| `/verify` *(v2.1.145+)* | Build, run, and observe the app to confirm a fix works | Validating a fix end-to-end |
 
 ---
 
@@ -340,12 +344,16 @@ Event-driven automation that executes shell commands on Claude Code events.
 | Event | Description | When Triggered | Use Cases |
 |-------|-------------|----------------|-----------|
 | `SessionStart` | Session begins/resumes | Session initialization | Setup tasks |
+| `Setup` | Initial environment setup (one-time per session) | First-time session bootstrap | Provision tooling, install deps |
 | `InstructionsLoaded` | Instructions loaded | CLAUDE.md or rules file loaded | Custom instruction handling |
 | `UserPromptSubmit` | Before prompt processing | User sends message | Input validation |
+| `UserPromptExpansion` | User prompt expanded (@-mentions, slash commands resolved) | After expansion, before submit | Transform or inspect expanded prompt |
 | `PreToolUse` | Before tool execution | Before any tool runs | Validation, logging |
 | `PermissionRequest` | Permission dialog shown | Before sensitive actions | Custom approval flows |
+| `PermissionDenied` | User denies a permission prompt | After permission decline | Logging, analytics, policy enforcement |
 | `PostToolUse` | After tool succeeds | After any tool completes | Formatting, notifications |
 | `PostToolUseFailure` | Tool execution fails | After tool error | Error handling, logging |
+| `PostToolBatch` | After a batch of tool uses completes | End of a tool batch | Aggregate reporting, batched validation |
 | `Notification` | Notification sent | Claude sends notification | External alerts |
 | `SubagentStart` | Subagent spawned | Subagent task starts | Initialize subagent context |
 | `SubagentStop` | Subagent finishes | Subagent task complete | Chain actions |
@@ -530,12 +538,13 @@ chmod +x ~/.claude/hooks/*.sh
 
 ---
 
-**Last Updated**: May 19, 2026
-**Claude Code Version**: 2.1.143
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/commands
 - https://code.claude.com/docs/en/hooks
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.138
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.143
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## [v2.1.145] — 2026-05-20
+
+### Synced to Claude Code v2.1.145
+
+Bumps tutorial coverage from Claude Code v2.1.143 → v2.1.145 (May 19, 2026
+release). Anthropic shipped two patches (v2.1.144 and v2.1.145) since the last
+sync. Highlights: the `/extra-usage` rename to `/usage-credits`, `/model`
+becoming session-only by default, three new bundled skills (`/run`, `/verify`,
+`/run-skill-generator`), Stop/SubagentStop hook input fields
+`background_tasks` and `session_crons`, `claude agents --json` for scripting,
+and a security fix that closes the bare-env-var Bash auto-approve loophole.
+This sync also catches up six root-level reference docs
+(`LEARNING-ROADMAP.md`, `QUICK_REFERENCE.md`, `INDEX.md`, `resources.md`,
+`claude_concepts_guide.md`, `STYLE_GUIDE.md`) that were missed in the
+v2.1.143 sync and were still pinned to v2.1.138.
+
+### Added
+
+- `/usage-credits` slash command (v2.1.144) — replaces `/extra-usage` as the
+  primary name; `/extra-usage` still works as an alias. Documented in
+  `01-slash-commands/README.md` and `CATALOG.md`.
+- Three new bundled skills (v2.1.145) — `/run` (launches the project's app to
+  see a change running), `/verify` (builds, runs, and observes the app to
+  confirm a fix works), `/run-skill-generator` (teaches `/run`/`/verify` how
+  to handle a specific project by generating a per-project skill). Documented
+  in `03-skills/README.md`, `CATALOG.md`, and `QUICK_REFERENCE.md`. Brings
+  the canonical bundled-skill count to **9**.
+- Stop/SubagentStop hook input fields `background_tasks` and `session_crons`
+  (v2.1.145) — hook authors can read these to decide whether to block stop
+  while background work or scheduled tasks are still pending. Documented in
+  `06-hooks/README.md`.
+- `claude agents --json` (v2.1.145) — print the agent list as machine-readable
+  JSON for scripting (status bars, session pickers, tmux-resurrect).
+  Documented in `10-cli/README.md`.
+- Five hook-event rows that were missing from summary tables — `Setup`,
+  `UserPromptExpansion`, `PermissionDenied`, `PostToolBatch` (the narrative
+  already claimed "29 events"; the summary tables in `CATALOG.md`,
+  `claude_concepts_guide.md`, and `INDEX.md` only listed 25).
+
+### Behavior changes
+
+- **`/model` is session-only by default (v2.1.144)**: selecting a model now
+  applies only to the current session; press `d` after selecting to set the
+  choice as the new default for future sessions. Documented in
+  `01-slash-commands/README.md`.
+- **Bash bare env-var auto-approve closed (v2.1.145 security fix)**: a
+  command of the form `FOO=bar somecommand` is no longer auto-approved when
+  only `FOO=bar` was on the allowlist. Re-allow such commands explicitly via
+  `Bash(...)` permission rules that cover the full command. Documented in
+  `06-hooks/README.md`.
+- **`context: fork` infinite-loop fix (v2.1.145)**: a skill using
+  `context: fork` could previously trigger an infinite re-invocation loop in
+  rare cases. Documented as a note in `03-skills/README.md`.
+
+### Documentation
+
+- Caught up six root-level reference docs from v2.1.138 to v2.1.145:
+  `LEARNING-ROADMAP.md`, `QUICK_REFERENCE.md`, `INDEX.md`, `resources.md`,
+  `claude_concepts_guide.md`, `STYLE_GUIDE.md`.
+- Fixed the bundled-skills mismatch — `CATALOG.md`, `QUICK_REFERENCE.md`, and
+  `03-skills/README.md` previously listed three different 5-item lists;
+  reconciled to the canonical 9 (`/batch`, `/claude-api`, `/debug`,
+  `/fewer-permission-prompts`, `/loop`, `/run`, `/run-skill-generator`,
+  `/simplify`, `/verify`). The `QUICK_REFERENCE.md` cell had also incorrectly
+  listed `/voice` and `/browse` as bundled skills — neither is bundled.
+- Renamed "New Features (March 2026)" → "New Features (May 2026)" in
+  `QUICK_REFERENCE.md` and `resources.md` to match the rest of the repo.
+- Bumped the version badge in `README.md` from `2.1.138` to `2.1.145` and
+  updated the two "latest: v2.1.138" claims in the body.
+- Updated the STYLE_GUIDE sample metadata footer from `2.1.97` to `2.1.145`
+  so contributors copy the current version.
+
 ## [v2.1.143] — 2026-05-19
 
 ### Synced to Claude Code v2.1.143

--- a/INDEX.md
+++ b/INDEX.md
@@ -219,9 +219,9 @@ Event-driven automation scripts that execute automatically.
 **Usage**: Configured in settings, executed automatically
 
 **Hook Types** (5 types, 29 events):
-- Tool Hooks: PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest
-- Session Hooks: SessionStart, SessionEnd, Stop, StopFailure, SubagentStart, SubagentStop
-- Task Hooks: UserPromptSubmit, TaskCompleted, TaskCreated, TeammateIdle
+- Tool Hooks: PreToolUse, PostToolUse, PostToolUseFailure, PostToolBatch, PermissionRequest, PermissionDenied
+- Session Hooks: SessionStart, Setup, SessionEnd, Stop, StopFailure, SubagentStart, SubagentStop
+- Task Hooks: UserPromptSubmit, UserPromptExpansion, TaskCompleted, TaskCreated, TeammateIdle
 - Lifecycle Hooks: ConfigChange, CwdChanged, FileChanged, PreCompact, PostCompact, WorktreeCreate, WorktreeRemove, Notification, InstructionsLoaded, Elicitation, ElicitationResult
 
 ---
@@ -874,14 +874,14 @@ Want to add more examples? Follow the structure:
 
 ---
 
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/commands
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.131
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.138
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 **Total Examples**: 100+ files
 **Categories**: 10 features

--- a/LEARNING-ROADMAP.md
+++ b/LEARNING-ROADMAP.md
@@ -738,13 +738,13 @@ Once you've completed all milestones:
 
 ---
 
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.131
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.138
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 **Maintained by**: Claude How-To Contributors
 **License**: Educational purposes, free to use and adapt

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -130,7 +130,7 @@ claude -r "session"    # Resume session by name/ID
 | **Git Worktrees** | Built-in | `/worktree` |
 | **Auto Memory** | Built-in | Auto-saves to CLAUDE.md |
 | **Task List** | Built-in | `/task list` |
-| **Bundled Skills (5)** | Built-in | `/simplify`, `/loop`, `/claude-api`, `/voice`, `/browse` |
+| **Bundled Skills (9)** | Built-in | `/batch`, `/claude-api`, `/debug`, `/fewer-permission-prompts`, `/loop`, `/run` *(v2.1.145+)*, `/run-skill-generator` *(v2.1.145+)*, `/simplify`, `/verify` *(v2.1.145+)* |
 
 ---
 
@@ -382,7 +382,7 @@ cp -r 03-skills/code-review ~/.claude/skills/
 
 ---
 
-## New Features (March 2026)
+## New Features (May 2026)
 
 | Feature | Description | Usage |
 |---------|-------------|-------|
@@ -398,11 +398,15 @@ cp -r 03-skills/code-review ~/.claude/skills/
 | **Task List** | Manage background tasks | `/task list`, `/task status <id>` |
 | **Auto Memory** | Automatic memory saving from conversations | Claude auto-saves key context to CLAUDE.md |
 | **Git Worktrees** | Isolated workspaces for parallel development | `/worktree` to create isolated workspace |
-| **Model Selection** | Switch between Sonnet 4.6, Opus 4.7, and Haiku 4.5 | `/model` or `--model` flag |
+| **Model Selection** | Switch between Sonnet 4.6, Opus 4.7, and Haiku 4.5 | `/model` — session-only by default since v2.1.144; press `d` to set a new default |
 | **Agent Teams** | Coordinate multiple agents on tasks | Enable with `CLAUDE_AGENT_TEAMS=1` env var |
 | **Scheduled Tasks** | Recurring tasks with `/loop` | `/loop 5m /command` or CronCreate tool |
 | **Chrome Integration** | Browser automation | `--chrome` flag or `/chrome` command |
 | **Keyboard Customization** | Custom keybindings | `/keybindings` command |
+| **/usage-credits** | Configure extra usage limits (renamed from `/extra-usage` in v2.1.144; old name still works as alias) | `/usage-credits` |
+| **/run** *(v2.1.145+)* | Launch this project's app to see a change running | `/run` |
+| **/verify** *(v2.1.145+)* | Build, run, and observe the app to confirm a fix works | `/verify` |
+| **/run-skill-generator** *(v2.1.145+)* | Teach `/run`/`/verify` how to handle a specific project | `/run-skill-generator` |
 
 ---
 
@@ -504,12 +508,12 @@ Getting started checklist:
 **This Card**: Keep it handy for quick reference!
 
 ---
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/commands
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.131
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.138
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/luongnv89/claude-howto?style=flat&color=gold)](https://github.com/luongnv89/claude-howto/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/luongnv89/claude-howto?style=flat)](https://github.com/luongnv89/claude-howto/network/members)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.1.138-brightgreen)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.1.145-brightgreen)](CHANGELOG.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-2.1+-purple)](https://code.claude.com)
 
 🌐 **Language / Ngôn ngữ / 语言 / Мова:** [English](README.md) | [Tiếng Việt](vi/README.md) | [中文](zh/README.md) | [Українська](uk/README.md) | [日本語](ja/README.md)
@@ -102,7 +102,7 @@ Run `/lesson-quiz [topic]` after each module. The quiz pinpoints what you missed
 
 - **GitHub stars** from developers who use Claude Code daily
 - **Forks** from teams adapting this guide for their own workflows
-- **Actively maintained** — synced with every Claude Code release (latest: v2.1.138, May 2026)
+- **Actively maintained** — synced with every Claude Code release (latest: v2.1.145, May 2026)
 - **Community-driven** — contributions from developers who share their real-world configurations
 
 [![Star History Chart](https://api.star-history.com/svg?repos=luongnv89/claude-howto&type=Date)](https://star-history.com/#luongnv89/claude-howto&Date)
@@ -201,7 +201,7 @@ cp -r 03-skills/code-review ~/.claude/skills/
 Yes. MIT licensed, free forever. Use it in personal projects, at work, in your team — no restrictions beyond including the license notice.
 
 **Is this maintained?**
-Actively. The guide is synced with every Claude Code release. Current version: v2.1.138 (May 2026), compatible with Claude Code 2.1+.
+Actively. The guide is synced with every Claude Code release. Current version: v2.1.145 (May 2026), compatible with Claude Code 2.1+.
 
 **How is this different from the official docs?**
 The official docs are a feature reference. This guide is a tutorial with diagrams, production-ready templates, and a progressive learning path. They complement each other — start here to learn, reference the docs when you need specifics.
@@ -871,13 +871,15 @@ MIT License - see [LICENSE](LICENSE). Free to use, modify, and distribute. The o
 
 ---
 
-**Last Updated**: May 19, 2026
-**Claude Code Version**: 2.1.143
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/changelog
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.131
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.138
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.143
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.113
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -597,12 +597,12 @@ Lesson READMEs end with a metadata block:
 
 ```markdown
 ---
-**Last Updated**: March 2026
-**Claude Code Version**: 2.1.97
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5
 ```
 
-- Use month + year format (e.g., "March 2026")
+- Use month + day + year format (e.g., "May 20, 2026")
 - Update the version when features change
 - List all compatible models
 
@@ -631,10 +631,11 @@ Before submitting content, verify:
 
 ---
 
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/changelog
 - https://www.anthropic.com/news/claude-opus-4-7
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/claude_concepts_guide.md
+++ b/claude_concepts_guide.md
@@ -2813,12 +2813,16 @@ Claude Code supports **29 hook events** across five hook types (command, http, m
 | Hook Event | Trigger | Use Cases |
 |------------|---------|-----------|
 | **SessionStart** | Session begins/resumes/clear/compact | Environment setup, initialization |
+| **Setup** | Initial environment setup (one-time per session) | Provision tooling, install deps |
 | **InstructionsLoaded** | CLAUDE.md or rules file loaded | Validation, transformation, augmentation |
 | **UserPromptSubmit** | User submits prompt | Input validation, prompt filtering |
+| **UserPromptExpansion** | User prompt expanded (@-mentions, slash commands resolved) | Transform or inspect expanded prompt |
 | **PreToolUse** | Before any tool runs | Validation, approval gates, logging |
 | **PermissionRequest** | Permission dialog shown | Auto-approve/deny flows |
+| **PermissionDenied** | User denies a permission prompt | Logging, analytics, policy enforcement |
 | **PostToolUse** | After tool succeeds | Auto-formatting, notifications, cleanup |
 | **PostToolUseFailure** | Tool execution fails | Error handling, logging |
+| **PostToolBatch** | After a batch of tool uses completes | Aggregate reporting, batched validation |
 | **Notification** | Notification sent | Alerting, external integrations |
 | **SubagentStart** | Subagent spawned | Context injection, initialization |
 | **SubagentStop** | Subagent finishes | Result validation, logging |
@@ -3139,11 +3143,12 @@ Claude Code supports three models with adaptive reasoning effort:
 - [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook)
 
 ---
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
 - https://www.anthropic.com/news/claude-opus-4-7
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.138
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5

--- a/resources.md
+++ b/resources.md
@@ -228,7 +228,7 @@ These steps capture the core recommendations for smooth workflows with Claude Co
 
 ---
 
-## New Features & Capabilities (March 2026)
+## New Features & Capabilities (May 2026)
 
 ### Key Feature Resources
 
@@ -247,13 +247,18 @@ These steps capture the core recommendations for smooth workflows with Claude Co
 | **Chrome Integration** | Browser automation with headless Chromium | [Advanced Features](09-advanced-features/) |
 | **Keyboard Customization** | Customize keybindings including chord sequences | [Advanced Features](09-advanced-features/) |
 | **Monitor Tool** | Watch a background command's stdout stream and react to events instead of polling (v2.1.98+) | [Advanced Features](09-advanced-features/) |
+| **/goal mode** | Register a session-level completion condition; Claude keeps working until met (v2.1.139+) | [Slash Commands](01-slash-commands/) |
+| **claude agents (Agent View)** | List, inspect, and resume background agents from the terminal; `--json` for machine-readable output (v2.1.139+, `--json` added v2.1.145) | [code.claude.com/docs/en/agent-view](https://code.claude.com/docs/en/agent-view) |
+| **/run, /verify, /run-skill-generator** | Bundled skills to launch your project, confirm a fix works, and generate per-project run/verify skills (v2.1.145+) | [Skills Guide](03-skills/) |
+| **Stop/SubagentStop hook fields** | Stop and SubagentStop hook inputs now include `background_tasks` and `session_crons` (v2.1.145+) | [Hooks Guide](06-hooks/) |
 
 ---
-**Last Updated**: May 9, 2026
-**Claude Code Version**: 2.1.138
+**Last Updated**: May 20, 2026
+**Claude Code Version**: 2.1.145
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/changelog
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.131
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.138
+- https://code.claude.com/docs/en/agent-view
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.144
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.7, Claude Haiku 4.5


### PR DESCRIPTION
## Summary

- Syncs tutorial coverage from Claude Code v2.1.143 → v2.1.145 and catches up six root-level reference docs (`LEARNING-ROADMAP.md`, `QUICK_REFERENCE.md`, `INDEX.md`, `resources.md`, `claude_concepts_guide.md`, `STYLE_GUIDE.md`) that were missed in the v2.1.143 sync and still pinned to v2.1.138.
- Reconciles the bundled-skills list across `CATALOG.md`, `QUICK_REFERENCE.md`, and `03-skills/README.md` to the canonical **9** (`/batch`, `/claude-api`, `/debug`, `/fewer-permission-prompts`, `/loop`, `/run`, `/run-skill-generator`, `/simplify`, `/verify`). Removes the wrong `/voice` and `/browse` claims.
- Adds the 4 missing hook-event rows (`Setup`, `UserPromptExpansion`, `PermissionDenied`, `PostToolBatch`) to the summary tables so the "29 events" narrative matches the tables.

### New v2.1.144 / v2.1.145 content

- `/extra-usage` → `/usage-credits` rename (v2.1.144); old name kept as alias.
- `/model` is now session-only by default (v2.1.144); press `d` to set a new default.
- Three new bundled skills (v2.1.145): `/run`, `/verify`, `/run-skill-generator`.
- Stop / SubagentStop hook input gains `background_tasks` and `session_crons` arrays (v2.1.145).
- `claude agents --json` flag for scripting (v2.1.145).
- Bash bare-env-var auto-approve security fix documented (v2.1.145).
- `context: fork` infinite-loop fix noted (v2.1.145).

### Cosmetic

- `README.md` version badge `2.1.138` → `2.1.145`; two "latest: v2.1.138" body claims updated.
- STYLE_GUIDE sample footer `2.1.97` → `2.1.145` so contributors copy the current version.
- Renamed "New Features (March 2026)" → "(May 2026)" in `QUICK_REFERENCE.md` and `resources.md`.
- Top entry added to `CHANGELOG.md`.

### Phase 3 decisions (taken per the update plan's recommendations)

- **URL migration**: only files touched in this sync use the canonical `code.claude.com` host; legacy `docs.anthropic.com` links elsewhere left untouched (the 301 still works).
- **Plugin sub-files**: the 22 `07-plugins/*/{agents,commands,templates}/*.md` template files remain un-footered — they are copy-paste templates, not version-anchored docs.

### Out of scope (Task 4.6 coverage gap)

The update plan lists 21 official-docs areas the repo doesn't yet cover (Agent SDK, `/output-style`, `/statusline`, Goal mode, Sandboxing, `/ultraplan`, etc.). None were built in this PR — they're a follow-up decision for the maintainer.

## Test plan

- [x] `pre-commit run` on all 17 modified files — 5 gates green (markdown-lint, cross-references, mermaid-syntax, link-check, build-epub).
- [x] `pytest scripts/tests/ -v` — 92 passed.
- [x] Every modified `.md` file ends with `**Last Updated**: May 20, 2026` / `**Claude Code Version**: 2.1.145` (verified with `grep`). `CHANGELOG.md` exempt by repo convention.
- [ ] Reviewer to confirm Phase 3 decisions (URL migration option C, plugin footer option A).
- [ ] Reviewer to decide if any Task 4.6 coverage-gap items should become follow-up issues.

---

Closes #126