### PR TITLE
fix(memory): correct settings.json precedence chain order

### DIFF
--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -298,9 +298,9 @@ Claude Code settings (including `autoMemoryDirectory`, `claudeMdExcludes`, and o
 |-------|----------|-------|
 | 1 (Highest) | Managed policy (system-level) | Organization-wide enforcement |
 | 2 | `managed-settings.d/` (v2.1.83+) | Modular policy drop-ins, merged alphabetically |
-| 3 | `~/.claude/settings.json` | User preferences |
+| 3 | `.claude/settings.local.json` | Local overrides (git-ignored) |
 | 4 | `.claude/settings.json` | Project-level (committed to git) |
-| 5 (Lowest) | `.claude/settings.local.json` | Local overrides (git-ignored) |
+| 5 (Lowest) | `~/.claude/settings.json` | User preferences |
 
 **Platform-specific configuration (v2.1.51+):**
 
@@ -310,7 +310,7 @@ Settings can also be configured via:
 
 These platform-native mechanisms are read alongside JSON settings files and follow the same precedence rules.
 
-> **Note (v2.1.119)**: `/config` changes now persist to `~/.claude/settings.json`. Values written via `/config` participate in the normal project/local/policy precedence chain described above — they are no longer session-only. Use `/config` for interactive edits and edit `settings.json` files directly for scripted or managed configuration.
+> **Note (v2.1.119)**: `/config` changes now persist to `~/.claude/settings.json`. Values written via `/config` participate in the normal policy/local/project precedence chain described above — they are no longer session-only. Use `/config` for interactive edits and edit `settings.json` files directly for scripted or managed configuration.
 
 ### Retention and Cleanup Settings
 

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -252,7 +252,7 @@ claude -p --json-schema '{"type":"object","properties":{"bugs":{"type":"array"}}
 | `--add-dir` | Add additional working directories | `claude --add-dir ../apps ../lib` |
 | `--setting-sources` | Comma-separated setting sources | `claude --setting-sources user,project` |
 
-> **`/config` persistence (v2.1.119)**: Changes made interactively via the `/config` command are now written to `~/.claude/settings.json` and participate in the normal precedence chain (project → local → policy → user). Before v2.1.119, some `/config` changes were session-only. See [Memory & Settings](../02-memory/README.md) for the full precedence order.
+> **`/config` persistence (v2.1.119)**: Changes made interactively via the `/config` command are now written to `~/.claude/settings.json` and participate in the normal precedence chain (policy → local → project → user). Before v2.1.119, some `/config` changes were session-only. See [Memory & Settings](../02-memory/README.md) for the full precedence order.
 | `--settings` | Load settings from file or JSON | `claude --settings ./settings.json` |
 | `--plugin-dir` | Load plugins from directory (repeatable) | `claude --plugin-dir ./my-plugin` |
 


### PR DESCRIPTION
## Summary

Fix incorrect `settings.json` precedence chain order in two files, as reported in #130.

## Changes

| File | Before | After |
|------|--------|-------|
| `10-cli/README.md` L255 | `project → local → policy → user` | `policy → local → project → user` |
| `02-memory/README.md` L301-303 | user(3) → project(4) → local(5) | **local**(3) → **project**(4) → **user**(5) |
| `02-memory/README.md` L313 | `project/local/policy` | `policy/local/project` |

## Correct Precedence (per [official docs](https://code.claude.com/docs/en/settings))

1. **Policy** (managed, highest)
2. CLI args
3. **Local** (`.claude/settings.local.json`)
4. **Project** (`.claude/settings.json`)
5. **User** (`~/.claude/settings.json`, lowest)

Closes #130