### PR TITLE
docs: sync to Claude Code v2.1.170

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -26,6 +26,7 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/agents` | Manage agent configurations |
 | `/branch [name]` | Branch conversation into a new session (alias: `/fork`). Note: `/fork` renamed to `/branch` in v2.1.77 |
 | `/btw <question>` | Ask an ephemeral side question while Claude is working on the main task; doesn't pollute the main conversation context |
+| `/cd <path>` | Move the session to a new working directory without breaking the prompt cache (added v2.1.169) |
 | `/chrome` | Configure Chrome browser integration |
 | `/clear` | Clear conversation (aliases: `/reset`, `/new`) |
 | `/color [color\|default]` | Set prompt bar color. Bare `/color` (no args) picks a random session color (v2.1.128+); pass a color name or hex to set explicitly. |
@@ -98,6 +99,8 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/usage` | Canonical usage dashboard (v2.1.118) — combines plan usage limits, rate limits, cost, and daily session stats. `/cost` and `/stats` are typing-shortcut aliases that open specific tabs |
 | `/voice` | Toggle push-to-talk voice dictation |
 | `/workflows` | View running and completed dynamic workflow runs (added v2.1.154). See [Dynamic Workflows](../09-advanced-features/README.md#dynamic-workflows) |
+
+> **Why `/cd` matters:** changing directories used to lose cache warmth (making the next turn slower and costlier); `/cd` preserves the prompt cache across the switch.
 
 ### Bundled Skills
 
@@ -627,8 +630,8 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: June 10, 2026
+**Claude Code Version**: 2.1.170
 **Sources**:
 - https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/interactive-mode

--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -1198,11 +1198,12 @@ For the most up-to-date information, refer to the official Claude Code documenta
 - [Official Memory Docs](https://code.claude.com/docs/en/memory) - Anthropic documentation
 
 ---
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: June 10, 2026
+**Claude Code Version**: 2.1.170
 **Sources**:
 - https://code.claude.com/docs/en/memory
 - https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/cli-reference
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.144
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.145

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -787,6 +787,23 @@ Skills support the `` !`command` `` syntax to inject the output of shell command
 
 When `disableSkillShellExecution` is `true`, any `` !`command` `` markers in a skill are left as literal text instead of being executed — removing the skill-level shell-injection attack surface without disabling skills themselves. Consider combining this with an `allowedTools` allowlist for defense in depth.
 
+### Hiding bundled skills (`disableBundledSkills`)
+
+The `disableBundledSkills` setting (added in **v2.1.169**) hides the bundled skills, workflows, and commands that ship with Claude Code from the model. Use it when the built-in skills are noise for a given project, or to reduce the model's skill surface:
+
+```jsonc
+// ~/.claude/settings.json or project .claude/settings.json
+{
+  "disableBundledSkills": true
+}
+```
+
+The equivalent environment-variable form is:
+
+```bash
+export CLAUDE_CODE_DISABLE_BUNDLED_SKILLS=1
+```
+
 ## Skills vs Other Features
 
 | Feature | Invocation | Best For |
@@ -858,8 +875,8 @@ Once you start building skills seriously, two things become essential: a library
 - [Hooks Guide](../06-hooks/) - Event-driven automation
 
 ---
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: June 10, 2026
+**Claude Code Version**: 2.1.170
 **Sources**:
 - https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/settings

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -118,7 +118,7 @@ Every MCP stdio server is spawned with `CLAUDE_PROJECT_DIR=<absolute path to rep
 
 Use this when your stdio server needs to read files relative to the project root regardless of where Claude Code was launched.
 
-stdio MCP servers also receive `CLAUDE_CODE_SESSION_ID` (matching the value passed to hooks and Bash), including when the session is resumed with `--resume` (v2.1.161+).
+stdio MCP servers also receive `CLAUDE_CODE_SESSION_ID` (matching the value passed to hooks and Bash), including when the session is resumed with `--resume` (v2.1.163+).
 
 ### SSE Transport (Deprecated)
 

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -118,6 +118,8 @@ Every MCP stdio server is spawned with `CLAUDE_PROJECT_DIR=<absolute path to rep
 
 Use this when your stdio server needs to read files relative to the project root regardless of where Claude Code was launched.
 
+stdio MCP servers also receive `CLAUDE_CODE_SESSION_ID` (matching the value passed to hooks and Bash), including when the session is resumed with `--resume` (v2.1.161+).
+
 ### SSE Transport (Deprecated)
 
 Server-Sent Events transport is deprecated in favor of `http` but still supported:
@@ -1168,8 +1170,8 @@ export GITHUB_TOKEN="your_token"
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: June 10, 2026
+**Claude Code Version**: 2.1.170
 **Sources**:
 - https://code.claude.com/docs/en/mcp
 - https://code.claude.com/docs/en/changelog

--- a/06-hooks/README.md
+++ b/06-hooks/README.md
@@ -370,6 +370,17 @@ Run when Claude finishes responding (Stop) or a subagent completes (SubagentStop
 
 > **Safety cap on consecutive blocks (v2.1.143)**: If a `Stop` hook returns `"decision": "block"` (or sets `continue: false`) **8 times in a row** for the same turn, Claude Code short-circuits the loop and ends the session with a warning. Override the threshold with the env var `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP=<integer>` (set to `0` to disable the cap entirely). This prevents a buggy Stop hook from looping the session forever.
 
+**Return field (v2.1.163):** A `Stop` or `SubagentStop` hook can return `hookSpecificOutput.additionalContext` to give Claude feedback and **continue the turn without surfacing an error label**. Previously, influencing the model from a Stop hook was awkward; now the hook can inject context cleanly, avoiding the error-label behavior of older feedback paths (such as `"decision": "block"`).
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "additionalContext": "Reminder: run the test suite before declaring done."
+  }
+}
+```
+
 ### SubagentStart
 
 Runs when a subagent begins execution. The matcher input is the agent type name, allowing hooks to target specific subagent types.
@@ -1449,8 +1460,8 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: June 10, 2026
+**Claude Code Version**: 2.1.170
 **Sources**:
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/changelog

--- a/07-plugins/README.md
+++ b/07-plugins/README.md
@@ -736,6 +736,14 @@ claude plugin install plugin-name@marketplace-name
 /plugin disable plugin-name
 ```
 
+### Listing installed plugins (v2.1.163)
+Confirm which plugins are active in the current session:
+```bash
+/plugin list             # all installed plugins
+/plugin list --enabled   # only enabled plugins
+/plugin list --disabled  # only disabled plugins
+```
+
 ### Local Plugin (for development)
 ```bash
 # CLI flag for local testing (repeatable for multiple plugins)
@@ -1107,10 +1115,11 @@ The following Claude Code features work together with plugins:
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: June 10, 2026
+**Claude Code Version**: 2.1.170
 **Sources**:
 - https://code.claude.com/docs/en/plugins
+- https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/plugin-marketplaces
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.118

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -1058,6 +1058,20 @@ claude -p --json-schema '{"type":"object","properties":{"issues":{"type":"array"
 claude -p --no-session-persistence "one-off analysis"
 ```
 
+### Safe Mode (troubleshooting)
+
+`--safe-mode` (and the `CLAUDE_CODE_SAFE_MODE` environment variable, e.g. `CLAUDE_CODE_SAFE_MODE=1`) starts Claude Code with **all customizations disabled** — CLAUDE.md, plugins, skills, hooks, and MCP servers are all turned off.
+
+```bash
+# Launch with every customization disabled
+claude --safe-mode
+
+# Equivalent via environment variable
+CLAUDE_CODE_SAFE_MODE=1 claude
+```
+
+It is a troubleshooting tool: when a custom config is causing problems, launch in safe mode to isolate whether the issue is in your setup or in Claude Code itself.
+
 ---
 
 ## Session Management
@@ -2071,6 +2085,18 @@ Since v2.1.83, administrators can deploy multiple managed settings files into a 
 }
 ```
 
+### Fallback Models (`fallbackModel`)
+
+The `fallbackModel` setting lets you configure **up to three** fallback models, tried in order, when the primary model is overloaded or unavailable.
+
+```json
+{
+  "fallbackModel": ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"]
+}
+```
+
+As of **v2.1.166** the `--fallback-model` flag also applies to interactive sessions (not just headless). On a fallback, Claude Code retries an unexpected non-retryable error once; auth, rate-limit, request-size, and transport errors still fail immediately.
+
 ### Environment Variables
 
 Override config with environment variables:
@@ -2301,9 +2327,10 @@ For more information about Claude Code and related features:
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: June 10, 2026
+**Claude Code Version**: 2.1.170
 **Sources**:
+- https://code.claude.com/docs/en/troubleshooting
 - https://code.claude.com/docs/en/permission-modes
 - https://code.claude.com/docs/en/interactive-mode
 - https://code.claude.com/docs/en/settings

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -81,6 +81,7 @@ The older JavaScript bundle is still produced for Windows and for environments t
 | `--teleport` | Resume web session locally | `claude --teleport` |
 | `--teammate-mode` | Agent team display mode | `claude --teammate-mode tmux` |
 | `--bare` | Minimal mode (skip hooks, skills, plugins, MCP, auto memory, CLAUDE.md) | `claude --bare` |
+| `--safe-mode` | Start with all customizations disabled (CLAUDE.md, plugins, skills, hooks, MCP) to isolate config problems; also `CLAUDE_CODE_SAFE_MODE=1` (v2.1.169) | `claude --safe-mode` |
 | `--enable-auto-mode` | Unlock auto permission mode (no longer required for Max subscribers on Opus 4.7) | `claude --enable-auto-mode` |
 | `--channels` | Subscribe to MCP channel plugins | `claude --channels discord,telegram` |
 | `--chrome` / `--no-chrome` | Enable/disable Chrome browser integration | `claude --chrome` |
@@ -127,7 +128,7 @@ claude -p "list todos" | grep "URGENT"
 | Flag | Description | Example |
 |------|-------------|---------|
 | `--model` | Set model (sonnet, opus, haiku, or full name) | `claude --model opus` |
-| `--fallback-model` | Automatic model fallback when overloaded | `claude -p --fallback-model sonnet "query"` |
+| `--fallback-model` | Automatic model fallback when the primary is overloaded/unavailable; configure up to three via the `fallbackModel` setting. Applies to interactive sessions too since v2.1.166 (previously print mode only) | `claude -p --fallback-model sonnet "query"` |
 | `--agent` | Specify agent for session | `claude --agent my-custom-agent` |
 | `--agents` | Define custom subagents via JSON | See [Agents Configuration](#agents-configuration) |
 | `--effort` | Set effort level (low, medium, high, xhigh, max) | `claude --effort xhigh` |
@@ -751,6 +752,7 @@ Claude Code supports multiple models with different capabilities:
 | Opus 4.8 | `claude-opus-4-8` | 1M tokens | Most capable; adaptive effort levels `low → max`; default effort `high` (v2.1.154) |
 | Sonnet 4.6 | `claude-sonnet-4-6` | 1M tokens | Balanced speed and capability; default effort for Pro/Max subscribers raised from `medium` to `high` in v2.1.117 |
 | Haiku 4.5 | `claude-haiku-4-5` | 200K tokens | Fastest, best for quick tasks; no effort levels |
+| Fable 5 | `claude-fable-5` | — | Mythos-class model, made safe for general use (v2.1.170) |
 
 ### Model Selection
 
@@ -801,6 +803,8 @@ The "ultrathink" keyword in prompts activates deep reasoning. The `/effort` menu
 | `MAX_THINKING_TOKENS` | Set extended thinking token budget |
 | `CLAUDE_CODE_EFFORT_LEVEL` | Set effort level (`low`/`medium`/`high`/`xhigh`/`max`) — default is `high` on Opus 4.8 (`xhigh` on Opus 4.7); `xhigh` needs Opus 4.8/4.7; `max` works on Opus 4.8/4.7/4.6 and Sonnet 4.6 |
 | `CLAUDE_CODE_SIMPLE` | Minimal mode, set by `--bare` flag |
+| `CLAUDE_CODE_SAFE_MODE` | Set to `1` to start with all customizations disabled (CLAUDE.md, plugins, skills, hooks, MCP) — env-var form of `--safe-mode`, for isolating config problems (v2.1.169) |
+| `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to hide the bundled skills, workflows, and commands from the model (v2.1.169) |
 | `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | Disable automatic CLAUDE.md updates |
 | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` | Disable background task execution |
 | `CLAUDE_CODE_DISABLE_CRON` | Disable scheduled/cron tasks |
@@ -943,12 +947,14 @@ claude -p --output-format json "query"
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: June 10, 2026
+**Claude Code Version**: 2.1.170
 **Sources**:
 - https://code.claude.com/docs/en/cli-reference
 - https://code.claude.com/docs/en/settings
 - https://code.claude.com/docs/en/changelog
+- https://code.claude.com/docs/en/troubleshooting
+- https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/model-config
 - https://platform.claude.com/docs/en/about-claude/models/overview
 - https://www.anthropic.com/news/claude-opus-4-8


### PR DESCRIPTION
## Summary

Additive documentation sync from **v2.1.160 → v2.1.170**. No breaking changes in the window — every change is a new row or short subsection. Generated from `update-plan-2026-06-10.md`.

## Changes

| Feature | Location | Version |
|---|---|---|
| **Claude Fable 5** model row (`claude-fable-5`) | `10-cli` model table | v2.1.170 |
| `--safe-mode` flag + `CLAUDE_CODE_SAFE_MODE` env var | `10-cli`, `09-advanced-features` | v2.1.169 |
| `/cd` (preserves prompt cache) | `01-slash-commands` | v2.1.169 |
| `disableBundledSkills` setting + env var | `03-skills`, `10-cli` | v2.1.169 |
| `fallbackModel` (up to 3; `--fallback-model` now interactive) | `09-advanced-features`, `10-cli` | v2.1.166 |
| `/plugin list --enabled/--disabled` | `07-plugins` | v2.1.163 |
| Stop/SubagentStop `hookSpecificOutput.additionalContext` | `06-hooks` | v2.1.163 |
| stdio MCP servers get `CLAUDE_CODE_SESSION_ID` on `--resume` | `05-mcp` (+ new footer) | v2.1.163 |

All 8 edited files' metadata footers refreshed to **2.1.170 / June 10, 2026**.

## Notes / judgment calls

- **Fable 5** documented conservatively as "Mythos-class model, made safe for general use" — **no** claim it supersedes Opus 4.8 as default (the changelog makes none). No repo-wide `Compatible Models` footer sweep.
- **`02-memory`** intentionally has no new rows: it has no general settings/env registry table, only topical ones; those items live in their owning modules (`03-skills`, `09-advanced`, `10-cli`). Footer still bumped.
- **Cross-ref docs** (`INDEX`/`CATALOG`/`QUICK_REFERENCE`) untouched — none enumerate the tables that got new rows, so editing them would be footer-only churn.

## Validation

`pre-commit run --all-files` passes (markdown-lint, cross-references, mermaid — 286 diagrams, build-epub). The `link-check` hook reports some **pre-existing external URLs** hitting transient timeouts/500s (Anthropic engineering blog, a GitHub release tag) — non-blocking and unrelated to this diff; no dead links were introduced by the new content.
