### PR TITLE
docs: sync to Claude Code v2.1.179

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -37,13 +37,13 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/cost` | Typing-shortcut alias for `/usage` — opens the cost tab (v2.1.118+) |
 | `/desktop` | Continue in Desktop app (alias: `/app`) |
 | `/diff` | Interactive diff viewer for uncommitted changes |
-| `/doctor` | Diagnose installation health — openable while Claude is responding; shows status icons; press `f` to auto-fix issues (enhanced in v2.1.116) |
+| `/doctor` | Diagnose installation health — openable while Claude is responding; shows status icons; press `f` to auto-fix issues (enhanced in v2.1.116; layout refreshed to a flat tree with clearer icons in v2.1.178) |
 | `/effort [low\|medium\|high\|xhigh\|max\|auto]` | Set effort level via interactive arrow-key slider. Levels: `low` → `medium` → `high` → `xhigh` (new in v2.1.111) → `max`. Default is `high` on Opus 4.8 (`xhigh` on Opus 4.7); `xhigh` needs Opus 4.8 or 4.7; `max` works on Opus 4.8/4.7/4.6 and Sonnet 4.6. The menu also offers `ultracode` (not a model effort level — it sends `xhigh` and has Claude orchestrate dynamic workflows; session-only) |
 | `/exit` | Exit the REPL (alias: `/quit`) |
 | `/export [filename]` | Export the current conversation to a file or clipboard |
 | `/usage-credits` | Configure extra usage for rate limits (renamed from `/extra-usage` in v2.1.144; `/extra-usage` still works as an alias) |
 | `/fast [on\|off]` | Toggle fast mode |
-| `/feedback` | Submit feedback (alias: `/bug`). Since v2.1.141, can attach recent sessions (last 24h or 7d) so reports spanning more than one session include context. |
+| `/feedback` | Submit feedback (alias: `/bug`). Since v2.1.141, can attach recent sessions (last 24h or 7d) so reports spanning more than one session include context. As of v2.1.178, `/bug` requires a description before it can be submitted. |
 | `/focus` | Toggle focus view (added v2.1.110; replaces `Ctrl+O` for focus toggle) |
 | `/goal <statement>` | Register a session-level completion condition; Claude keeps working until the goal is met. `/goal clear` removes it. Active goal appears in the status line, with a live overlay panel showing elapsed time, turn count, and token usage (added v2.1.139). |
 | `/help` | Show help |
@@ -630,8 +630,8 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 
 ---
 
-**Last Updated**: June 10, 2026
-**Claude Code Version**: 2.1.170
+**Last Updated**: June 17, 2026
+**Claude Code Version**: 2.1.179
 **Sources**:
 - https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/interactive-mode

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -99,7 +99,7 @@ When skills share the same name across levels, higher-priority locations win: **
 
 ### Automatic Discovery
 
-**Nested directories**: When you work with files in subdirectories, Claude Code automatically discovers skills from nested `.claude/skills/` directories. For example, if you're editing a file in `packages/frontend/`, Claude Code also looks for skills in `packages/frontend/.claude/skills/`. This supports monorepo setups where packages have their own skills.
+**Nested directories**: When you work with files in subdirectories, Claude Code automatically discovers skills from nested `.claude/skills/` directories. For example, if you're editing a file in `packages/frontend/`, Claude Code also looks for skills in `packages/frontend/.claude/skills/`. This supports monorepo setups where packages have their own skills. As of v2.1.178, when a skill name collides across nested `.claude/skills/` directories, the directory **closest to your current working directory wins** — a package-level skill overrides a repo-root skill of the same name.
 
 **`--add-dir` directories**: Skills from directories added via `--add-dir` are loaded automatically with live change detection. Any edits to skill files in those directories take effect immediately without restarting Claude Code.
 
@@ -875,8 +875,8 @@ Once you start building skills seriously, two things become essential: a library
 - [Hooks Guide](../06-hooks/) - Event-driven automation
 
 ---
-**Last Updated**: June 10, 2026
-**Claude Code Version**: 2.1.170
+**Last Updated**: June 17, 2026
+**Claude Code Version**: 2.1.179
 **Sources**:
 - https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/settings

--- a/04-subagents/README.md
+++ b/04-subagents/README.md
@@ -76,6 +76,8 @@ Subagent files can be stored in multiple locations with different scopes:
 
 When duplicate names exist, higher-priority sources take precedence.
 
+> **Nested `.claude/` precedence (v2.1.178)**: When the same agent name is defined in multiple nested `.claude/agents/` directories (for example, a monorepo with package-level `.claude/` folders), the definition **closest to your current working directory wins**. The same closest-wins rule applies to nested workflow and output-style definitions.
+
 ---
 
 ## Configuration
@@ -1238,12 +1240,13 @@ See the OpenTelemetry section in [Advanced Features → Telemetry](../09-advance
 
 ---
 
-**Last Updated**: June 15, 2026
-**Claude Code Version**: 2.1.176
+**Last Updated**: June 17, 2026
+**Claude Code Version**: 2.1.179
 **Sources**:
 - https://code.claude.com/docs/en/sub-agents
 - https://code.claude.com/docs/en/agent-teams
 - https://code.claude.com/docs/en/changelog#2-1-172
+- https://code.claude.com/docs/en/changelog
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.131
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.138

--- a/07-plugins/README.md
+++ b/07-plugins/README.md
@@ -798,6 +798,8 @@ export CLAUDE_CODE_PLUGIN_PREFER_HTTPS=1
 claude plugin install code-reviewer@anthropic
 ```
 
+> **Remote session plugin loading (v2.1.179)**: Plugin loading performance in remote sessions was improved in v2.1.179, so plugins become available faster when you connect to a remote session.
+
 ## When to Create a Plugin
 
 ```mermaid
@@ -1116,11 +1118,12 @@ The following Claude Code features work together with plugins:
 
 ---
 
-**Last Updated**: June 15, 2026
-**Claude Code Version**: 2.1.176
+**Last Updated**: June 17, 2026
+**Claude Code Version**: 2.1.179
 **Sources**:
 - https://code.claude.com/docs/en/plugins
 - https://code.claude.com/docs/en/changelog#2-1-172
+- https://code.claude.com/docs/en/changelog
 - https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/plugin-marketplaces
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -48,7 +48,7 @@ The older JavaScript bundle is still produced for Windows and for environments t
 | `claude -c -p "query"` | Continue in print mode | `claude -c -p "check for type errors"` |
 | `claude -r "<session>" "query"` | Resume session by ID or name | `claude -r "auth-refactor" "finish this PR"` |
 | `claude update` | Update to latest version | `claude update` |
-| `/doctor` (slash command) | Diagnose installation, config, and plugin health. Since v2.1.116 it can be opened **while Claude is responding**, shows status icons inline, and accepts the `f` keypress to auto-fix detected issues | run `/doctor` inside the REPL |
+| `/doctor` (slash command) | Diagnose installation, config, and plugin health. Since v2.1.116 it can be opened **while Claude is responding**, shows status icons inline, and accepts the `f` keypress to auto-fix detected issues. v2.1.178 refreshed the layout to a flat tree with clearer status icons and highlighted commands | run `/doctor` inside the REPL |
 | `claude mcp` | Configure MCP servers | See [MCP documentation](../05-mcp/) |
 | `claude mcp serve` | Run Claude Code as an MCP server | `claude mcp serve` |
 | `claude agents` | Open the **Agent View** (Research Preview, v2.1.139+) — multi-session manager listing every Claude Code session with its status. See [Agent View](#agent-view-claude-agents-v21139) below. | `claude agents` |
@@ -218,6 +218,8 @@ claude --allowedTools "Bash(git status:*)" "Bash(git log:*)"
 # Block dangerous operations
 claude --disallowedTools "Bash(rm -rf:*)" "Bash(git push --force:*)"
 ```
+
+> **Parameter matching `Tool(param:value)` (v2.1.178)**: Permission rules follow the format `Tool` (every use) or `Tool(specifier)`. As of v2.1.178, a specifier can match a tool's input **parameters**, not just command or path patterns — using the `Tool(param:value)` form with wildcard support. This generalizes the matching you already use for `Bash(...)` command prefixes (e.g. `Bash(npm run test *)`) and `Read(...)` path globs (e.g. `Read(./.env.*)`) so other tools can be scoped by their arguments. Check the [permissions reference](https://code.claude.com/docs/en/settings) for the current per-tool example strings before writing a rule, since the exact parameter names differ by tool.
 
 ## Output & Format
 
@@ -967,12 +969,14 @@ claude -p --output-format json "query"
 
 ---
 
-**Last Updated**: June 15, 2026
-**Claude Code Version**: 2.1.176
+**Last Updated**: June 17, 2026
+**Claude Code Version**: 2.1.179
 **Sources**:
 - https://code.claude.com/docs/en/cli-reference
 - https://code.claude.com/docs/en/changelog#2-1-174
 - https://code.claude.com/docs/en/changelog#2-1-176
+- https://code.claude.com/docs/en/changelog
+- https://code.claude.com/docs/en/settings
 - https://code.claude.com/docs/en/settings
 - https://code.claude.com/docs/en/changelog
 - https://code.claude.com/docs/en/troubleshooting


### PR DESCRIPTION
## Summary

Additive documentation sync from the v2.1.176 baseline to **v2.1.179** (latest documented version).

**No breaking changes, removals, or deprecations** in the v2.1.177–v2.1.179 window. v2.1.177 is a chore-only release (empty body); v2.1.179 is bugfix-only plus a plugin perf note. All new surface area is from v2.1.178.

## Changes

**New in v2.1.178:**
- **`10-cli`** — documented the generalized `Tool(param:value)` parameter-matching permission syntax (with wildcard support). Cites the permissions reference for current per-tool example strings rather than inventing them.
- **`03-skills`** — nested `.claude/skills/` collision rule: closest directory to cwd wins.
- **`04-subagents`** — nested `.claude/` precedence (closest-to-cwd wins) for agents/workflows/output-styles. Existing "up to 5 levels" nesting content left untouched.
- **`/doctor`** — flat-tree layout refresh note (`10-cli`, `01-slash-commands`).
- **`/bug`** — now requires a description before submit (`01-slash-commands`).

**New in v2.1.179:**
- **`07-plugins`** — improved plugin loading performance in remote sessions.

## Metadata

Footers on all five edited files bumped to **v2.1.179 / June 17, 2026** with relevant source URLs. No blanket footer sweep — untouched files keep their existing versions.

## Verification

- `pre-commit run --all-files` → **passed** (markdown-lint, cross-references, mermaid 286 diagrams, link-check, build-epub, plus vi/ja translation suites)
- Pre-commit hooks on commit → passed

## Sources

- https://code.claude.com/docs/en/changelog
- https://code.claude.com/docs/en/settings
- https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md