### PR TITLE
docs: sync to Claude Code v2.1.187

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -76,7 +76,7 @@ Built-in commands are shortcuts for common actions. There are **60+ built-in com
 | `/remote-env` | Configure default remote environment |
 | `/rename [name]` | Rename session |
 | `/resume [session]` | Resume conversation (alias: `/continue`) |
-| `/review` | **Deprecated** — install the `code-review` plugin instead |
+| `/review <pr>` | Review a GitHub PR. As of v2.1.186 it runs on the same review engine as `/code-review medium`. Use `/code-review` to review the local working diff |
 | `/rewind` | Rewind conversation and/or code (alias: `/checkpoint`) |
 | `/sandbox` | Toggle sandbox mode |
 | `/schedule [description]` | Create/manage Cloud scheduled tasks |
@@ -119,7 +119,6 @@ These skills ship with Claude Code and are invoked like slash commands:
 
 | Command | Status |
 |---------|--------|
-| `/review` | Deprecated — replaced by `code-review` plugin |
 | `/output-style` | Deprecated since v2.1.73 |
 | `/fork` | Renamed to `/branch` (alias still works, v2.1.77) |
 | `/pr-comments` | Removed in v2.1.91 — ask Claude directly to view PR comments |
@@ -129,7 +128,7 @@ These skills ship with Claude Code and are invoked like slash commands:
 
 - `/fork` renamed to `/branch` with `/fork` kept as alias (v2.1.77)
 - `/output-style` deprecated (v2.1.73)
-- `/review` deprecated in favor of the `code-review` plugin
+- `/review <pr>` now uses the same review engine as `/code-review medium` (v2.1.186)
 - `/effort` command added; `max` level available on Opus 4.6+ (originally Opus 4.6-only)
 - `/voice` command added for push-to-talk voice dictation
 - `/schedule` command added for creating/managing scheduled tasks
@@ -630,14 +629,16 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 
 ---
 
-**Last Updated**: June 17, 2026
-**Claude Code Version**: 2.1.179
+**Last Updated**: June 24, 2026
+**Claude Code Version**: 2.1.187
 **Sources**:
 - https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/interactive-mode
 - https://code.claude.com/docs/en/changelog
 - https://code.claude.com/docs/en/commands
 - https://code.claude.com/docs/en/model-config
+- https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- https://docs.anthropic.com/en/docs/claude-code/slash-commands
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.139
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.144
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.152

--- a/02-memory/README.md
+++ b/02-memory/README.md
@@ -331,6 +331,7 @@ These platform-native mechanisms are read alongside JSON settings files and foll
 |---------|------|-------------|
 | `attribution.commit` | boolean | Adds the `Co-Authored-By: Claude` trailer to commits Claude creates. Replaces the deprecated `includeCoAuthoredBy` flag. |
 | `attribution.pr` | boolean | Adds Claude attribution to pull request descriptions. Replaces the deprecated `includeCoAuthoredBy` flag for PRs. |
+| `attribution.sessionUrl` | boolean | Omit the claude.ai session link from commits and PRs created in web and Remote Control sessions (v2.1.183+). |
 | `voice.enabled` | boolean | Enables push-to-talk voice dictation (`/voice`). Replaces the deprecated `voiceEnabled` flag. |
 | `prUrlTemplate` | string | **New in v2.1.119.** Custom URL template for the footer PR badge; useful for GitLab, Bitbucket, or internal code-review platforms. Supports `{{owner}}`, `{{repo}}`, and `{{number}}` placeholders. |
 
@@ -1198,11 +1199,13 @@ For the most up-to-date information, refer to the official Claude Code documenta
 - [Official Memory Docs](https://code.claude.com/docs/en/memory) - Anthropic documentation
 
 ---
-**Last Updated**: June 10, 2026
-**Claude Code Version**: 2.1.170
+**Last Updated**: June 24, 2026
+**Claude Code Version**: 2.1.187
 **Sources**:
 - https://code.claude.com/docs/en/memory
 - https://code.claude.com/docs/en/settings
+- https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- https://docs.anthropic.com/en/docs/claude-code/settings
 - https://code.claude.com/docs/en/cli-reference
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.144

--- a/04-subagents/README.md
+++ b/04-subagents/README.md
@@ -707,6 +707,7 @@ Control how teammate activity is displayed:
 | **Auto** | `--teammate-mode auto` | Automatically chooses the best display mode for your terminal |
 | **In-process** (default) | `--teammate-mode in-process` | Shows teammate output inline in the current terminal |
 | **Split-panes** | `--teammate-mode tmux` | Opens each teammate in a separate tmux or iTerm2 pane |
+| **iTerm2** | `--teammate-mode iterm2` | (v2.1.186+) Spawns teammates in dedicated iTerm2 panes. Requires the `it2` CLI; auto mode warns when it can't be found |
 
 ```bash
 claude --teammate-mode tmux
@@ -1240,10 +1241,11 @@ See the OpenTelemetry section in [Advanced Features → Telemetry](../09-advance
 
 ---
 
-**Last Updated**: June 17, 2026
-**Claude Code Version**: 2.1.179
+**Last Updated**: June 24, 2026
+**Claude Code Version**: 2.1.187
 **Sources**:
 - https://code.claude.com/docs/en/sub-agents
+- https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
 - https://code.claude.com/docs/en/agent-teams
 - https://code.claude.com/docs/en/changelog#2-1-172
 - https://code.claude.com/docs/en/changelog

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -361,9 +361,17 @@ claude mcp remove github
 # Reset project-specific approval choices
 claude mcp reset-project-choices
 
+# Authenticate an MCP server from the CLI (v2.1.186+)
+claude mcp login github
+
+# Sign out of an MCP server (v2.1.186+)
+claude mcp logout github
+
 # Import from Claude Desktop
 claude mcp add-from-claude-desktop
 ```
+
+`claude mcp login <name>` / `claude mcp logout <name>` are the non-interactive equivalent of the OAuth flow in the `/mcp` menu — authenticate or sign out without opening it. Add `--no-browser` to `login` to complete OAuth over SSH or in a headless session (it redirects the flow through stdin).
 
 ## Available MCP Servers Table
 
@@ -1170,11 +1178,13 @@ export GITHUB_TOKEN="your_token"
 
 ---
 
-**Last Updated**: June 10, 2026
-**Claude Code Version**: 2.1.170
+**Last Updated**: June 24, 2026
+**Claude Code Version**: 2.1.187
 **Sources**:
 - https://code.claude.com/docs/en/mcp
 - https://code.claude.com/docs/en/changelog
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.139
+- https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- https://docs.anthropic.com/en/docs/claude-code/mcp
 **Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -526,6 +526,16 @@ Since v2.1.118, `autoMode.allow`, `autoMode.soft_deny`, and `autoMode.environmen
 
 Use `"$defaults"` to keep the shipped baseline rules while layering organization- or project-specific additions on top.
 
+#### Built-in intent-based protection (v2.1.183)
+
+Separate from user-configured `hard_deny`, auto mode blocks the following destructive commands by default unless you explicitly asked for them this session:
+
+- `git reset --hard`, `git checkout -- .`, `git clean -fd`, `git stash drop`
+- `git commit --amend` (when the commit wasn't made by the agent this session)
+- `terraform destroy`, `pulumi destroy`, `cdk destroy` (unless you asked for the specific stack)
+
+This is built-in default protection driven by inferred intent — you don't need to add these to `hard_deny` yourself.
+
 ### Fallback Behavior
 
 When the classifier is uncertain, auto mode falls back to prompting the user:
@@ -1371,6 +1381,8 @@ Execute shell commands directly with `!` prefix:
 
 Use this for quick command execution without switching contexts.
 
+**Since v2.1.187 (changed in v2.1.186):** the output of a `!` command is now automatically sent to Claude, which responds to it. To keep the previous behavior where the output is only added to context without a response, set `"respondToBashCommands": false` in `settings.json`.
+
 ---
 
 ## TUI Mode (Fullscreen)
@@ -1905,6 +1917,8 @@ claude --no-sandbox    # Disable sandboxing
 | `sandbox.enableWeakerNetworkIsolation` | Enable weaker network isolation on macOS |
 | `sandbox.bwrapPath` | (v2.1.133+, Linux/WSL) Path to the `bubblewrap` binary. Default: `$PATH` lookup. |
 | `sandbox.socatPath` | (v2.1.133+, Linux/WSL) Path to the `socat` binary. Default: `$PATH` lookup. |
+| `sandbox.credentials` | (v2.1.187+) Block sandboxed commands from reading credential files and secret environment variables. |
+| `sandbox.allowAppleEvents` | (v2.1.181+, macOS) Opt in to let sandboxed commands send Apple Events. |
 
 **Linux/WSL binary paths** (v2.1.133+) — point Claude Code at non-standard install locations:
 
@@ -2186,6 +2200,17 @@ The `/config` command provides an interactive menu to toggle settings such as:
 - Permission mode
 - Model selection
 
+In the interactive menu, press Enter or Space to change the selected setting, and Esc to save and close (v2.1.183+).
+
+You can also set a setting directly from the prompt without opening the menu:
+
+```bash
+/config thinking=false      # set a single setting inline (v2.1.181+)
+/config --help              # list available shorthand keys (v2.1.183+)
+```
+
+The `key=value` shorthand works in interactive sessions, with `-p`, and in Remote Control.
+
 ### Per-Project Configuration
 
 Create `.claude/config.json` in your project:
@@ -2328,9 +2353,11 @@ For more information about Claude Code and related features:
 
 ---
 
-**Last Updated**: June 15, 2026
-**Claude Code Version**: 2.1.176
+**Last Updated**: June 24, 2026
+**Claude Code Version**: 2.1.187
 **Sources**:
+- https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- https://docs.anthropic.com/en/docs/claude-code/settings
 - https://code.claude.com/docs/en/troubleshooting
 - https://code.claude.com/docs/en/changelog#2-1-175
 - https://code.claude.com/docs/en/permission-modes

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -1381,7 +1381,7 @@ Execute shell commands directly with `!` prefix:
 
 Use this for quick command execution without switching contexts.
 
-**Since v2.1.187 (changed in v2.1.186):** the output of a `!` command is now automatically sent to Claude, which responds to it. To keep the previous behavior where the output is only added to context without a response, set `"respondToBashCommands": false` in `settings.json`.
+**Since v2.1.186:** the output of a `!` command is now automatically sent to Claude, which responds to it. To keep the previous behavior where the output is only added to context without a response, set `"respondToBashCommands": false` in `settings.json`.
 
 ---
 

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -49,7 +49,7 @@ The older JavaScript bundle is still produced for Windows and for environments t
 | `claude -r "<session>" "query"` | Resume session by ID or name | `claude -r "auth-refactor" "finish this PR"` |
 | `claude update` | Update to latest version | `claude update` |
 | `/doctor` (slash command) | Diagnose installation, config, and plugin health. Since v2.1.116 it can be opened **while Claude is responding**, shows status icons inline, and accepts the `f` keypress to auto-fix detected issues. v2.1.178 refreshed the layout to a flat tree with clearer status icons and highlighted commands | run `/doctor` inside the REPL |
-| `claude mcp` | Configure MCP servers | See [MCP documentation](../05-mcp/) |
+| `claude mcp` | Configure MCP servers (incl. `login`/`logout` for auth, v2.1.186+) | See [MCP documentation](../05-mcp/) |
 | `claude mcp serve` | Run Claude Code as an MCP server | `claude mcp serve` |
 | `claude agents` | Open the **Agent View** (Research Preview, v2.1.139+) — multi-session manager listing every Claude Code session with its status. See [Agent View](#agent-view-claude-agents-v21139) below. | `claude agents` |
 | `claude auto-mode defaults` | Print auto mode default rules as JSON | `claude auto-mode defaults` |
@@ -841,6 +841,10 @@ The "ultrathink" keyword in prompts activates deep reasoning. The `/effort` menu
 | `CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE` | Set to `1` to enable background upgrades for Homebrew/WinGet installs (which normally do not auto-update) (v2.1.129+) |
 | `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` | Set to `1` to opt in to gateway `/v1/models` discovery when `ANTHROPIC_BASE_URL` is set. Without it, `/model` shows the built-in static list (v2.1.129+) |
 | `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to opt in to auto mode on Bedrock, Vertex, and Foundry for Opus 4.7/4.8 (v2.1.158+) |
+| `CLAUDE_CLIENT_PRESENCE_FILE` | Point at a marker file to suppress mobile push notifications while you're at the machine (v2.1.181+). Note: the name is `CLAUDE_CLIENT_PRESENCE_FILE`, not `CLAUDE_CODE_CLIENT_PRESENCE_FILE`. |
+| `CLAUDE_CODE_MAX_RETRIES` | Maximum number of API retry attempts. Capped at 15 as of v2.1.186. |
+| `CLAUDE_CODE_RETRY_WATCHDOG` | Retry control recommended for unattended sessions, as an alternative to raising `CLAUDE_CODE_MAX_RETRIES` (v2.1.186+). |
+| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Override the 5-minute idle abort for remote MCP tool calls that hang with no response (v2.1.187+). |
 | `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` | **Removed (no-op as of v2.1.160).** Previously pinned Fast Mode (`/fast`) to Opus 4.6. To use fast mode on Opus 4.6 now, run `/model claude-opus-4-6[1m]` then `/fast on`. |
 
 > **`ENABLE_TOOL_SEARCH` on Vertex AI (v2.1.119+)**: Tool search is **disabled by default on Google Cloud Vertex AI** deployments. Users who want the tool-search capability on Vertex must explicitly opt in with `export ENABLE_TOOL_SEARCH=true`. On direct Anthropic API it remains enabled by default.
@@ -853,6 +857,7 @@ These keys live in a `settings.json` file (`~/.claude/settings.json` for user sc
 
 | Key | Description |
 |-----|-------------|
+| `respondToBashCommands` | (v2.1.186) Auto-respond to the output of `!` bash commands. Default `true`. Set `false` for context-only (pre-v2.1.186) behavior. See [Advanced Features → Bash Mode](../09-advanced-features/README.md#bash-mode). |
 | `wheelScrollAccelerationEnabled` | (v2.1.174) Set to `false` to disable mouse-wheel scroll acceleration in the fullscreen renderer. Useful when fast wheel flicks overshoot. |
 | `footerLinksRegexes` | (v2.1.176) Array of regexes that render matched links as badges in the footer row. Configurable in user or managed settings. |
 | `language` | Sets Claude's preferred response language and voice-dictation language (e.g. `"french"`, `"japanese"`). As of **v2.1.176** it also pins the language used for auto-generated session titles. |
@@ -969,16 +974,16 @@ claude -p --output-format json "query"
 
 ---
 
-**Last Updated**: June 17, 2026
-**Claude Code Version**: 2.1.179
+**Last Updated**: June 24, 2026
+**Claude Code Version**: 2.1.187
 **Sources**:
 - https://code.claude.com/docs/en/cli-reference
 - https://code.claude.com/docs/en/changelog#2-1-174
 - https://code.claude.com/docs/en/changelog#2-1-176
 - https://code.claude.com/docs/en/changelog
 - https://code.claude.com/docs/en/settings
-- https://code.claude.com/docs/en/settings
-- https://code.claude.com/docs/en/changelog
+- https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- https://docs.anthropic.com/en/docs/claude-code/cli-reference
 - https://code.claude.com/docs/en/troubleshooting
 - https://code.claude.com/docs/en/slash-commands
 - https://code.claude.com/docs/en/model-config


### PR DESCRIPTION
## Summary

Syncs the tutorial docs from **v2.1.179 → v2.1.187** (the published versions in that range: v2.1.181/.183/.185/.186/.187). No P0/breaking changes in this delta; all edits are additive corrections and new-surface documentation. Footers on every touched file bumped to **2.1.187**.

Generated from `update-plan-2026-06-24.md` (docs-sync-claude-code).

## Changes by module

| File | Change |
|------|--------|
| `01-slash-commands/README.md` | Reclassify `/review <pr>` as a supported PR-review entry point — now runs the same engine as `/code-review medium` (v2.1.186); removed from the deprecated list |
| `09-advanced-features/README.md` | `!` bash output now auto-responds (v2.1.186, `respondToBashCommands`); `/config key=value` shorthand + `--help` (v2.1.181/.183) and menu key behavior; built-in intent-based auto-mode blocks for destructive git/IaC commands (v2.1.183); `sandbox.credentials` + `sandbox.allowAppleEvents` |
| `04-subagents/README.md` | `teammateMode: "iterm2"` display mode (v2.1.186) with `it2` CLI caveat |
| `02-memory/README.md` | `attribution.sessionUrl` setting (v2.1.183) |
| `05-mcp/README.md` | `claude mcp login` / `claude mcp logout` CLI auth, incl. `--no-browser` SSH mode (v2.1.186) |
| `10-cli/README.md` | `respondToBashCommands` setting; new env vars `CLAUDE_CLIENT_PRESENCE_FILE`, `CLAUDE_CODE_MAX_RETRIES` (now capped at 15), `CLAUDE_CODE_RETRY_WATCHDOG`, `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`; cross-link to `claude mcp login/logout` |

## Decisions made during execution

- **`/review` framing (P2)**: reclassified `/review <pr>` as a supported PR-review entry point (engine = `/code-review medium`), not deprecated.
- **Footer policy (P4)**: touched-only — only files edited this run were bumped to v2.1.187; untouched files keep their existing footers.
- **Task 2.5 (retry-stall wording)**: N/A — the old "No response from API"/10s-threshold string does not appear anywhere in the repo, so no edit was made (no invented content).

## Validation

- `pre-commit run --all-files` passes for all six edited files (markdown-lint, cross-references, mermaid-syntax, link-check, build-epub). The only pre-commit failures in the working tree come from untracked `update-plan-*.md` scaffolding files, which are not part of this PR.
- Footers verified consistent at `v2.1.187` with today's date; no stale version strings remain in edited files.

## Notes

- `Type: docs` — exempt from the `Closes #N` traceability requirement per `.gitissue.yml`.
