### PR TITLE
Add Vexilo field guide to Additional Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ Quick start:
 - [Skills Repository](https://github.com/luongnv89/skills) - Collection of ready-to-use skills
 - [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook)
 - [Boris Cherny's Claude Code Workflow](https://x.com/bcherny/status/2007179832300581177) - The creator of Claude Code shares his systematized workflow: parallel agents, shared CLAUDE.md, Plan mode, slash commands, subagents, and verification hooks for autonomous long-running sessions.
+- [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) - Visual interactive index of 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click "Teach Claude this handbook" feeds the whole index into a local Claude session in 30 seconds. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
 
 </details>
 


### PR DESCRIPTION
## Adds Vexilo · A field guide to Claude Code to the Additional Resources section

[Vexilo](https://vexilo.app/?lang=en) is a visual interactive index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click **"Teach Claude this handbook"** feeds the whole index into a local Claude session in 30 seconds.

### Why it fits
Your "Additional Resources" section already lists official docs, MCP spec, your own skills repo, and Boris Cherny's workflow. Vexilo fits as the **navigation layer** that ties them all together — a searchable index of every agent, command, and skill across the ecosystem.

### Complementary, not competitive
- Your claude-howto ships **installable primitives** (slash commands, agents, skills)
- Vexilo ships **the index of primitives** (so people know what to install and when)

### Entry details
- URL: https://vexilo.app/?lang=en
- Companion repo (MIT): https://github.com/lilhawk7077/claude-code-resources

### Checklist
- [x] Open and free
- [x] Actively maintained (v1.1.9, weekly updates)
- [x] Directly relevant to Claude Code
- [x] No duplicate of existing entry
- [x] Fits the "Additional Resources" section's purpose