### PR TITLE
docs: sync to Claude Code v2.1.206

### DIFF
--- a/01-slash-commands/README.md
+++ b/01-slash-commands/README.md
@@ -110,6 +110,7 @@ These skills ship with Claude Code and are invoked like slash commands:
 |-------|---------|
 | `/batch <instruction>` | Orchestrate large-scale parallel changes using worktrees |
 | `/claude-api` | Load Claude API reference for project language |
+| `/dataviz` | Chart and dashboard design guidance with a runnable color-palette validator (v2.1.198) |
 | `/debug [description]` | Enable debug logging |
 | `/loop [interval] <prompt>` | Run prompt repeatedly on interval |
 | `/code-review [effort]` | Review the current diff for correctness bugs at a chosen effort level (e.g. `/code-review high`). Originally absorbed `/simplify` in v2.1.146, but `/simplify` returned as a distinct command in v2.1.154 |
@@ -301,6 +302,8 @@ Review PR #$0 with priority $1
 ```
 
 Usage: `/review-pr 456 high` → `$0`="456", `$1`="high"
+
+`${CLAUDE_PROJECT_DIR}` resolves to the absolute path of the project root (v2.1.196).
 
 ### Dynamic Context with Shell Commands
 
@@ -629,10 +632,11 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 
 ---
 
-**Last Updated**: June 24, 2026
-**Claude Code Version**: 2.1.187
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/slash-commands
+- https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/interactive-mode
 - https://code.claude.com/docs/en/changelog
 - https://code.claude.com/docs/en/commands
@@ -644,6 +648,6 @@ If both exist with the same name, the **skill takes precedence**. Remove one or 
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.152
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.153
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.154
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
 
 *Part of the [Claude How To](../) guide series*

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -822,7 +822,7 @@ export CLAUDE_CODE_DISABLE_BUNDLED_SKILLS=1
 
 ## Bundled Skills
 
-Claude Code ships with ten built-in skills that are always available without installation:
+Claude Code ships with a set of built-in skills that are always available without installation (the most useful ones are listed below; see the [commands reference](https://code.claude.com/docs/en/commands) for the full set):
 
 | Skill | Description |
 |-------|-------------|
@@ -835,6 +835,7 @@ Claude Code ships with ten built-in skills that are always available without ins
 | `/run` *(v2.1.145+)* | Launch this project's app to see a change running — looks for a project skill, otherwise falls back to built-in patterns per project type |
 | `/run-skill-generator` *(v2.1.145+)* | Teach `/run`/`/verify` how to handle a specific project by generating a per-project skill |
 | `/code-review [effort]` | Review the current diff for correctness bugs at a chosen effort level (e.g. `/code-review high`); pass `--comment` to post findings as inline PR comments. A distinct skill from `/simplify` (quality/reuse cleanups), which was split back out in v2.1.154. |
+| `/simplify` | Cleanup-only review — reuse, simplification, efficiency, altitude — and applies the fixes. Split back out from `/code-review` in v2.1.154 |
 | `/verify` *(v2.1.145+)* | Build, run, and observe the app to confirm a fix works (not just that tests pass) |
 
 These skills are available out-of-the-box and do not need to be installed or configured. They follow the same SKILL.md format as custom skills.

--- a/03-skills/README.md
+++ b/03-skills/README.md
@@ -248,6 +248,7 @@ Skills support dynamic values that are resolved before the skill content reaches
 | `$ARGUMENTS[N]` or `$N` | Access specific argument by index (0-based) |
 | `${CLAUDE_SESSION_ID}` | Current session ID |
 | `${CLAUDE_SKILL_DIR}` | Directory containing the skill's SKILL.md file |
+| `${CLAUDE_PROJECT_DIR}` | Absolute path to the project root. Usable in the skill body and in `allowed-tools` (v2.1.196) |
 | `${CLAUDE_EFFORT}` | Current effort level (`low`, `medium`, `high`, `xhigh`, or `max`). Useful for branching skill behavior: e.g., `[ "${CLAUDE_EFFORT}" = "max" ] && deep_analysis` (v2.1.120+) |
 | `` !`command` `` | Dynamic context injection — runs a shell command and inlines the output |
 
@@ -267,6 +268,10 @@ Fix GitHub issue $ARGUMENTS following our coding standards.
 ```
 
 Running `/fix-issue 123` replaces `$ARGUMENTS` with `123`.
+
+### Stacking Skills
+
+You can stack slash-skills in a single invocation, like `/code-review /fix-issue 123`. As of v2.1.199, this loads ALL leading skills — the first plus up to 5 more — and passes the trailing arguments (`123`) to each; previously only the first skill loaded. If the same skill is invoked more than once, its identical content is de-duplicated (v2.1.202) rather than appended twice.
 
 ## Injecting Dynamic Context
 
@@ -817,18 +822,19 @@ export CLAUDE_CODE_DISABLE_BUNDLED_SKILLS=1
 
 ## Bundled Skills
 
-Claude Code ships with nine built-in skills that are always available without installation:
+Claude Code ships with ten built-in skills that are always available without installation:
 
 | Skill | Description |
 |-------|-------------|
 | `/batch <instruction>` | Orchestrate large-scale parallel changes across codebase using git worktrees |
 | `/claude-api` | Load Claude API/SDK reference; auto-activates on `anthropic`/`@anthropic-ai/sdk` imports |
+| `/dataviz` | Chart and dashboard design guidance with a runnable color-palette validator (v2.1.198) |
 | `/debug [description]` | Troubleshoot current session by reading debug log |
 | `/fewer-permission-prompts` | Scan transcripts and propose a prioritized allowlist for common read-only tools |
 | `/loop [interval] <prompt>` | Run prompt repeatedly on interval (e.g., `/loop 5m check the deploy`) |
 | `/run` *(v2.1.145+)* | Launch this project's app to see a change running — looks for a project skill, otherwise falls back to built-in patterns per project type |
 | `/run-skill-generator` *(v2.1.145+)* | Teach `/run`/`/verify` how to handle a specific project by generating a per-project skill |
-| `/code-review [effort]` | Review the current diff for correctness bugs at a chosen effort level (e.g. `/code-review high`); pass `--comment` to post findings as inline PR comments. Renamed from `/simplify` in v2.1.146 |
+| `/code-review [effort]` | Review the current diff for correctness bugs at a chosen effort level (e.g. `/code-review high`); pass `--comment` to post findings as inline PR comments. A distinct skill from `/simplify` (quality/reuse cleanups), which was split back out in v2.1.154. |
 | `/verify` *(v2.1.145+)* | Build, run, and observe the app to confirm a fix works (not just that tests pass) |
 
 These skills are available out-of-the-box and do not need to be installed or configured. They follow the same SKILL.md format as custom skills.
@@ -875,8 +881,8 @@ Once you start building skills seriously, two things become essential: a library
 - [Hooks Guide](../06-hooks/) - Event-driven automation
 
 ---
-**Last Updated**: June 17, 2026
-**Claude Code Version**: 2.1.179
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/settings
@@ -884,4 +890,4 @@ Once you start building skills seriously, two things become essential: a library
 - https://code.claude.com/docs/en/commands
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.152
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.154
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/04-subagents/README.md
+++ b/04-subagents/README.md
@@ -47,7 +47,9 @@ Subagents enable delegated task execution in Claude Code by:
 
 Each subagent operates independently with a clean slate, receiving only the specific context necessary for their task, then returning results to the main agent for synthesis.
 
-**Quick Start**: Use the `/agents` command to create, view, edit, and manage your subagents interactively.
+**Quick Start**: Ask Claude to create a subagent for you ("create a subagent that reviews security"), or add a `.claude/agents/<name>.md` file directly — see [Managing Subagents](#managing-subagents) below.
+
+> **Note**: As of v2.1.198, the `/agents` command no longer opens an interactive creation wizard. Create and manage subagents by asking Claude or editing `.claude/agents/` files directly.
 
 ---
 
@@ -130,7 +132,7 @@ to solving problems.
 | `mcpServers` | No | MCP servers to make available to the subagent |
 | `hooks` | No | Component-scoped hooks (PreToolUse, PostToolUse, Stop) |
 | `memory` | No | Persistent memory directory scope: `user`, `project`, or `local` |
-| `background` | No | Set to `true` to always run this subagent as a background task |
+| `background` | No | Subagents already run in the background by default (v2.1.198). Set to `true` to *force* background always and prevent inline execution |
 | `effort` | No | Reasoning effort level: `low`, `medium`, `high`, or `max` |
 | `isolation` | No | Set to `worktree` to give the subagent its own git worktree |
 | `initialPrompt` | No | Auto-submitted first turn when the subagent runs as the main agent |
@@ -251,7 +253,7 @@ Claude Code includes several built-in subagents that are always available:
 |-------|-------|---------|
 | **general-purpose** | Inherits | Complex, multi-step tasks |
 | **Plan** | Inherits | Research for plan mode |
-| **Explore** | Haiku | Read-only codebase exploration (quick/medium/very thorough) |
+| **Explore** | Inherits (capped at Opus) | Read-only codebase exploration (quick/medium/very thorough) |
 | **Bash** | Inherits | Terminal commands in separate context |
 | **statusline-setup** | Sonnet | Configure status line |
 | **Claude Code Guide** | Haiku | Answer Claude Code feature questions |
@@ -280,7 +282,7 @@ Claude Code includes several built-in subagents that are always available:
 
 | Property | Value |
 |----------|-------|
-| **Model** | Haiku (fast, low-latency) |
+| **Model** | Inherits the session model, capped at Opus (v2.1.198). Set `model: haiku` to keep it fast and cheap |
 | **Mode** | Strictly read-only |
 | **Tools** | Glob, Grep, Read, Bash (read-only commands only) |
 | **Purpose** | Fast codebase searching and analysis |
@@ -326,18 +328,17 @@ Claude Code includes several built-in subagents that are always available:
 
 ## Managing Subagents
 
-### Using the `/agents` Command (Recommended)
+### Ask Claude (Recommended)
 
-```bash
-/agents
+The simplest way to create or manage a subagent is to ask Claude directly:
+
+```text
+Create a subagent that reviews code for security vulnerabilities.
 ```
 
-This provides an interactive menu to:
-- View all available subagents (built-in, user, and project)
-- Create new subagents with guided setup
-- Edit existing custom subagents and tool access
-- Delete custom subagents
-- See which subagents are active when duplicates exist
+Claude writes the `.claude/agents/<name>.md` file for you, choosing sensible frontmatter (tools, model, description). You can then refine the file by hand or ask Claude to adjust it.
+
+> **Note**: The `/agents` command no longer opens an interactive creation wizard (removed in v2.1.198). It now points you to ask Claude or edit `.claude/agents/` files directly.
 
 ### Direct File Management
 
@@ -505,11 +506,11 @@ graph LR
 
 ## Background Subagents
 
-Subagents can run in the background, freeing up the main conversation for other tasks.
+Subagents run in the background by default (v2.1.198). Claude keeps working on the main conversation while a subagent runs and is notified when it finishes, so you no longer wait on a subagent to return before continuing.
 
 ### Configuration
 
-Set `background: true` in the frontmatter to always run the subagent as a background task:
+Because background is already the default, `background: true` in the frontmatter *forces* the subagent to always run in the background and prevents it from running inline:
 
 ```yaml
 ---
@@ -909,6 +910,12 @@ graph TB
 - **Backgrounding** - Press `Ctrl+B` to background a currently running task
 - **Transcripts** - Subagent transcripts are stored at `~/.claude/projects/{project}/{sessionId}/subagents/agent-{agentId}.jsonl`
 - **Auto-compaction** - Subagent context auto-compacts at ~95% capacity (override with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` environment variable)
+- **Extended thinking inherited (v2.1.198)** - Subagents and context compaction now inherit the session's extended-thinking configuration (previously always disabled). There is no per-subagent thinking field
+
+### Additional Controls
+
+- **Disable built-in Explore/Plan agents** - Set `CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS=1` to remove the built-in Explore and Plan agents (v2.1.198)
+- **Append to every subagent prompt** - In non-interactive / `--print` mode, `--append-subagent-system-prompt "<text>"` appends text to every subagent's system prompt (v2.1.205)
 
 ---
 
@@ -1098,18 +1105,16 @@ This folder contains ready-to-use example subagents:
 
 ## Installation Instructions
 
-### Method 1: Using /agents Command (Recommended)
+### Method 1: Ask Claude (Recommended)
 
-```bash
-/agents
+Describe the subagent you want and let Claude create the file:
+
+```text
+Create a project-level subagent that runs tests and fixes failures.
+Give it access to Bash, Read, Edit, and Grep.
 ```
 
-Then:
-1. Select 'Create New Agent'
-2. Choose project-level or user-level
-3. Describe your subagent in detail
-4. Select tools to grant access (or leave blank to inherit all)
-5. Save and use
+Claude writes `.claude/agents/<name>.md` with appropriate frontmatter. Review the generated file, then use it. (The `/agents` interactive creation wizard was removed in v2.1.198 — ask Claude or edit the file directly instead.)
 
 ### Method 2: Copy to Project
 
@@ -1145,13 +1150,13 @@ cp /path/to/04-subagents/debugger.md ~/.claude/agents/
 
 ### Verification
 
-After installation, verify the agents are recognized:
+After installation, verify the agents are recognized by listing the directory:
 
 ```bash
-/agents
+ls .claude/agents/
 ```
 
-You should see your installed agents listed alongside the built-in ones.
+You can also ask Claude which subagents are available in the current session, and it will report the built-in and custom agents it can delegate to.
 
 ---
 
@@ -1241,10 +1246,11 @@ See the OpenTelemetry section in [Advanced Features → Telemetry](../09-advance
 
 ---
 
-**Last Updated**: June 24, 2026
-**Claude Code Version**: 2.1.187
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
-- https://code.claude.com/docs/en/sub-agents
+- https://code.claude.com/docs/en/subagents
+- https://code.claude.com/docs/en/cli-reference
 - https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
 - https://code.claude.com/docs/en/agent-teams
 - https://code.claude.com/docs/en/changelog#2-1-172
@@ -1254,4 +1260,4 @@ See the OpenTelemetry section in [Advanced Features → Telemetry](../09-advance
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.138
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.139
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.140
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/05-mcp/README.md
+++ b/05-mcp/README.md
@@ -128,6 +128,10 @@ Server-Sent Events transport is deprecated in favor of `http` but still supporte
 claude mcp add --transport sse legacy-server https://example.com/sse
 ```
 
+### Session Working Directories (roots/list)
+
+MCP servers can discover the session's working directories: the launch directory plus all `--add-dir`/`additionalDirectories` entries are returned via the MCP `roots/list` request, and a `notifications/roots/list_changed` notification is sent whenever the set changes (v2.1.203). The idle timeout now also applies to stdio servers (30 minutes), with a per-server `timeout` acting as an idle floor (v2.1.203).
+
 ### Windows-Specific Note
 
 On native Windows (not WSL), use `cmd /c` for npx commands:
@@ -341,7 +345,7 @@ Store project-specific MCP configurations in `.mcp.json`:
 }
 ```
 
-Team members will see an approval prompt on first use of project MCPs.
+Team members will see an approval prompt on first use of project MCPs. In an untrusted workspace, servers that a repo self-approved via a committed `.claude/settings.json` are **not** auto-spawned by `claude mcp list`/`get` — they show `⏸ Pending approval` until you accept the trust dialog, and `enableAllProjectMcpServers` is ignored in an untrusted folder (v2.1.196).
 
 ## MCP Configuration Management
 
@@ -1183,8 +1187,8 @@ export GITHUB_TOKEN="your_token"
 
 ---
 
-**Last Updated**: June 28, 2026
-**Claude Code Version**: 2.1.195
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/mcp
 - https://code.claude.com/docs/en/changelog
@@ -1192,4 +1196,4 @@ export GITHUB_TOKEN="your_token"
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.139
 - https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
 - https://docs.anthropic.com/en/docs/claude-code/mcp
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/06-hooks/README.md
+++ b/06-hooks/README.md
@@ -510,6 +510,8 @@ Updated matchers for notification events:
 - `idle_prompt` - Idle state notification
 - `auth_success` - Authentication success
 - `elicitation_dialog` - Dialog shown to user
+- `agent_needs_input` - Background agent needs input (v2.1.198)
+- `agent_completed` - Background agent finished (v2.1.198)
 
 ## Component-Scoped Hooks
 
@@ -603,6 +605,7 @@ All hooks receive JSON input via stdin:
 | `session_id` | Unique session identifier |
 | `transcript_path` | Path to the conversation transcript file |
 | `cwd` | Current working directory |
+| `prompt_id` | UUID of the prompt being processed; correlates with the OpenTelemetry `prompt.id` attribute (v2.1.196) |
 | `hook_event_name` | Name of the event that triggered the hook |
 | `agent_id` | Identifier of the agent running this hook |
 | `agent_type` | Type of agent (`"main"`, subagent type name, etc.) |
@@ -1502,8 +1505,8 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 
 ---
 
-**Last Updated**: June 28, 2026
-**Claude Code Version**: 2.1.195
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/permissions
@@ -1513,4 +1516,4 @@ Edit `~/.claude/settings.json` or `.claude/settings.json` with the hook configur
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.152
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.153
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/07-plugins/README.md
+++ b/07-plugins/README.md
@@ -579,6 +579,9 @@ Plugin marketplaces are defined in `.claude-plugin/marketplace.json`:
 | `plugins[].description` | No | Brief plugin description |
 | `plugins[].version` | No | Semantic version string |
 | `plugins[].author` | No | Plugin author name |
+| `plugins[].renames` | No | Maps a former plugin `name` to its current name (or `null` if removed) so users migrate automatically (v2.1.193) |
+| `plugins[].displayName` | No | Human-readable name shown in the UI; not used for lookup (v2.1.143) |
+| `plugins[].defaultEnabled` | No | If `false`, the plugin installs disabled until the user opts in (v2.1.154) |
 
 ### Plugin source types
 
@@ -594,6 +597,8 @@ Plugins can be sourced from multiple locations:
 | **pip** | `{ "source": "pip", "package": "..." }` | `{ "source": "pip", "package": "claude-data-plugin", "version": ">=1.0" }` |
 
 GitHub and git sources support optional `ref` (branch/tag) and `sha` (commit hash) fields for version pinning.
+
+Reserved marketplace names now include `first-party-plugins` and `healthcare` (v2.1.205) — these are held for official use and cannot be claimed by a custom marketplace.
 
 ### Distribution methods
 
@@ -1120,8 +1125,8 @@ The following Claude Code features work together with plugins:
 
 ---
 
-**Last Updated**: June 28, 2026
-**Claude Code Version**: 2.1.195
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/plugins
 - https://code.claude.com/docs/en/changelog#2-1-172
@@ -1137,4 +1142,4 @@ The following Claude Code features work together with plugins:
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.142
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.143
 - https://code.claude.com/docs/en/cli-reference
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/08-checkpoints/README.md
+++ b/08-checkpoints/README.md
@@ -45,13 +45,14 @@ Use the `/rewind` command (alias: `/checkpoint`) for quick access:
 
 ## Rewind Options
 
-When you rewind, you are presented with a menu of five options:
+When you rewind, you are presented with a menu of six options:
 
 1. **Restore code and conversation** -- Revert both files and messages to that checkpoint
 2. **Restore conversation** -- Rewind messages only, keep your current code as-is
 3. **Restore code** -- Revert file changes only, keep the full conversation history
 4. **Summarize from here** -- Compress the conversation from this point forward into an AI-generated summary, freeing context window space. Messages before the selected point stay intact. No files on disk are changed. The original messages are preserved in the session transcript. You can optionally provide instructions to focus the summary on specific topics.
-5. **Never mind** -- Cancel and return to the current state
+5. **Summarize up to here** -- The backward counterpart: compress everything *before* the selected point into an AI-generated summary, keeping the messages from this point forward intact. Together with "Summarize from here" this gives you bidirectional, targeted compaction of your context window. No files on disk are changed, and the original messages are preserved in the session transcript.
+6. **Never mind** -- Cancel and return to the current state
 
 > **Note**: After restoring the conversation or summarizing, the original prompt from the selected message is restored into the input field so you can re-send or edit it.
 
@@ -327,10 +328,10 @@ Remember: checkpoints are not a replacement for git. Use checkpoints for rapid e
 
 ---
 
-**Last Updated**: June 28, 2026
-**Claude Code Version**: 2.1.195
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/checkpointing
 - https://code.claude.com/docs/en/settings
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.117
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/09-advanced-features/README.md
+++ b/09-advanced-features/README.md
@@ -50,7 +50,7 @@ Advanced features in Claude Code extend the core capabilities with planning, rea
 - **Extended Thinking**: Deep reasoning for complex problems
 - **Auto Mode**: Background safety classifier reviews each action before execution (Research Preview)
 - **Background Tasks**: Run long operations without blocking the conversation
-- **Permission Modes**: Control what Claude can do (`default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`)
+- **Permission Modes**: Control what Claude can do (`manual` — formerly `default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`)
 - **Print Mode**: Run Claude Code non-interactively for automation and CI/CD (`claude -p`)
 - **Session Management**: Manage multiple work sessions
 - **Interactive Features**: Keyboard shortcuts, multi-line input, and command history
@@ -869,12 +869,14 @@ Permission modes control what actions Claude can take without explicit approval.
 
 | Mode | Behavior |
 |---|---|
-| `default` | Read files only; prompts for all other actions |
+| `manual` | Read files only; prompts for all other actions. Renamed from `default` in v2.1.200 — `default` is still accepted as an alias |
 | `acceptEdits` | Read and edit files; prompts for commands |
 | `plan` | Read files only (research mode, no edits) |
 | `auto` | All actions with background safety classifier checks (Research Preview) |
 | `bypassPermissions` | All actions, no permission checks (dangerous) |
 | `dontAsk` | Only pre-approved tools execute; all others denied |
+
+> **Note**: The interactive default mode was renamed from `default` to **Manual** in v2.1.200 (across the CLI, `--help`, VS Code, and JetBrains), and a grey ⏸ badge appears in the footer while it is active (v2.1.203). Both `--permission-mode manual` and `--permission-mode default` work, as do `"defaultMode": "manual"` and `"defaultMode": "default"` in settings — so the `"mode": "default"` values in the config examples below remain valid.
 
 Cycle through modes with `Shift+Tab` in the CLI. Set a default with the `--permission-mode` flag or the `permissions.defaultMode` setting.
 
@@ -2118,6 +2120,15 @@ Since v2.1.83, administrators can deploy multiple managed settings files into a 
 }
 ```
 
+### Additional Per-User Settings
+
+These keys go in `~/.claude/settings.json` (or a project `.claude/settings.json`) and control interactive behavior for the individual user:
+
+| Setting | Description |
+|---------|-------------|
+| `askUserQuestionTimeout` | Auto-continue an unanswered `AskUserQuestion` dialog after an idle interval. As of **v2.1.200** dialogs no longer auto-continue by default — set this to opt back into timed auto-continue. |
+| `enableArtifact` | Per-user enable/disable of the Artifact tool (v2.1.196). |
+
 ### Fallback Models (`fallbackModel`)
 
 The `fallbackModel` setting lets you configure **up to three** fallback models, tried in order, when the primary model is overloaded or unavailable.
@@ -2371,8 +2382,8 @@ For more information about Claude Code and related features:
 
 ---
 
-**Last Updated**: June 28, 2026
-**Claude Code Version**: 2.1.195
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
 - https://docs.anthropic.com/en/docs/claude-code/settings
@@ -2390,4 +2401,4 @@ For more information about Claude Code and related features:
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.154
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/sub-agents
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -154,6 +154,8 @@ claude --model opusplan "design and implement the caching layer"
 
 > **Gateway model discovery (v2.1.129+, opt-in)**: When `ANTHROPIC_BASE_URL` points at an Anthropic-compatible gateway, set `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` to populate `/model` from the gateway's `/v1/models` endpoint. Without the env var, `/model` falls back to the built-in static list. The flag is opt-in (changed in v2.1.129) because the discovery call can surface models a user may not be entitled to use; v2.1.126 made it implicit and that behavior was reverted.
 
+> **Org default model (v2.1.196)**: When an org admin sets a default model, `/model` labels it as "Org default" (or "Role default").
+
 ## System Prompt Customization
 
 | Flag | Description | Example |
@@ -161,6 +163,7 @@ claude --model opusplan "design and implement the caching layer"
 | `--system-prompt` | Replace entire default prompt | `claude --system-prompt "You are a Python expert"` |
 | `--system-prompt-file` | Load prompt from file (print mode) | `claude -p --system-prompt-file ./prompt.txt "query"` |
 | `--append-system-prompt` | Append to default prompt | `claude --append-system-prompt "Always use TypeScript"` |
+| `--append-subagent-system-prompt` | Append text to every subagent's system prompt (non-interactive) | `claude -p --append-subagent-system-prompt "Cite sources" "query"` |
 
 ### System Prompt Examples
 
@@ -751,6 +754,7 @@ Claude Code supports multiple models with different capabilities:
 
 | Model | ID | Context Window | Notes |
 |-------|-----|----------------|-------|
+| Sonnet 5 | `claude-sonnet-5` | 1M tokens | **Default model** (v2.1.197); native 1M-token context window |
 | Opus 4.8 | `claude-opus-4-8` | 1M tokens | Most capable; adaptive effort levels `low → max`; default effort `high` (v2.1.154) |
 | Sonnet 4.6 | `claude-sonnet-4-6` | 1M tokens | Balanced speed and capability; default effort for Pro/Max subscribers raised from `medium` to `high` in v2.1.117 |
 | Haiku 4.5 | `claude-haiku-4-5` | 200K tokens | Fastest, best for quick tasks; no effort levels |
@@ -845,6 +849,7 @@ The "ultrathink" keyword in prompts activates deep reasoning. The `/effort` menu
 | `CLAUDE_CLIENT_PRESENCE_FILE` | Point at a marker file to suppress mobile push notifications while you're at the machine (v2.1.181+). Note: the name is `CLAUDE_CLIENT_PRESENCE_FILE`, not `CLAUDE_CODE_CLIENT_PRESENCE_FILE`. |
 | `CLAUDE_CODE_MAX_RETRIES` | Maximum number of API retry attempts. Capped at 15 as of v2.1.186. |
 | `CLAUDE_CODE_RETRY_WATCHDOG` | Retry control recommended for unattended sessions, as an alternative to raising `CLAUDE_CODE_MAX_RETRIES` (v2.1.186+). |
+| `CLAUDE_ENABLE_STREAM_WATCHDOG` | Streaming idle watchdog (aborts/retries after 5 min with no stream events) is on by default for all providers; set to `0` to disable (v2.1.196). |
 | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Override the 5-minute idle abort for remote MCP tool calls that hang with no response (v2.1.187+). |
 | `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` | **Removed (no-op as of v2.1.160).** Previously pinned Fast Mode (`/fast`) to Opus 4.6. To use fast mode on Opus 4.6 now, run `/model claude-opus-4-6[1m]` then `/fast on`. |
 
@@ -975,8 +980,8 @@ claude -p --output-format json "query"
 
 ---
 
-**Last Updated**: June 28, 2026
-**Claude Code Version**: 2.1.195
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/cli-reference
 - https://code.claude.com/docs/en/env-vars
@@ -997,4 +1002,4 @@ claude -p --output-format json "query"
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.154
 - https://code.claude.com/docs/en/plugins
 - https://code.claude.com/docs/en/overview
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/10-cli/README.md
+++ b/10-cli/README.md
@@ -754,7 +754,7 @@ Claude Code supports multiple models with different capabilities:
 
 | Model | ID | Context Window | Notes |
 |-------|-----|----------------|-------|
-| Sonnet 5 | `claude-sonnet-5` | 1M tokens | **Default model** (v2.1.197); native 1M-token context window |
+| Sonnet 5 | `claude-sonnet-5` | 1M tokens | Default on Pro / Team Standard / Enterprise seats (v2.1.197); native 1M-token context window. Opus 4.8 remains the default on Max, Team Premium, Enterprise pay-as-you-go, and the Claude API |
 | Opus 4.8 | `claude-opus-4-8` | 1M tokens | Most capable; adaptive effort levels `low → max`; default effort `high` (v2.1.154) |
 | Sonnet 4.6 | `claude-sonnet-4-6` | 1M tokens | Balanced speed and capability; default effort for Pro/Max subscribers raised from `medium` to `high` in v2.1.117 |
 | Haiku 4.5 | `claude-haiku-4-5` | 200K tokens | Fastest, best for quick tasks; no effort levels |

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -127,7 +127,7 @@ Claude Code supports 6 permission modes that control how tool use is authorized.
 
 | Mode | Description | When to Use |
 |------|-------------|-------------|
-| `default` | Prompt for each tool call | Standard interactive use |
+| `manual` | Prompt for each tool call | Standard interactive use (renamed from `default` in v2.1.200; `default` still accepted) |
 | `acceptEdits` | Auto-accept file edits, prompt for others | Trusted editing workflows |
 | `plan` | Read-only tools only, no writes | Planning and exploration |
 | `auto` | Accept all tools without prompting | Fully autonomous operation (Research Preview) |
@@ -545,16 +545,17 @@ chmod +x ~/.claude/hooks/*.sh
 
 ---
 
-**Last Updated**: June 15, 2026
-**Claude Code Version**: 2.1.176
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/commands
 - https://code.claude.com/docs/en/hooks
+- https://code.claude.com/docs/en/permission-modes
 - https://code.claude.com/docs/en/changelog#2-1-172
 - https://code.claude.com/docs/en/changelog#2-1-174
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.145
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.154
 - https://code.claude.com/docs/en/plugins
 - https://code.claude.com/docs/en/cli-reference
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/INDEX.md
+++ b/INDEX.md
@@ -398,7 +398,7 @@ Advanced capabilities for complex workflows.
 - View runs with `/workflows`; `ultracode` `/effort` turns it on for a session
 
 ### Permission Modes
-- **default**: Ask for approval on risky actions
+- **manual**: Ask for approval on risky actions (renamed from `default` in v2.1.200; `default` still accepted)
 - **acceptEdits**: Auto-accept file edits, ask for others
 - **plan**: Read-only analysis, no modifications
 - **auto**: Automatically approve safe actions, prompt for risky ones
@@ -880,15 +880,16 @@ Want to add more examples? Follow the structure:
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/commands
+- https://code.claude.com/docs/en/permission-modes
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.153
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.154
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
 **Total Examples**: 100+ files
 **Categories**: 10 features
 **Hooks**: 9 automation scripts

--- a/LEARNING-ROADMAP.md
+++ b/LEARNING-ROADMAP.md
@@ -365,7 +365,7 @@ Before starting Level 3, make sure you're comfortable with these Level 2 concept
 
 #### What You'll Achieve
 ✅ Planning mode for complex features
-✅ Fine-grained permission control with 6 modes (default, acceptEdits, plan, auto, dontAsk, bypassPermissions)
+✅ Fine-grained permission control with 6 modes (manual — formerly default, acceptEdits, plan, auto, dontAsk, bypassPermissions)
 ✅ Extended thinking via Alt+T / Option+T toggle
 ✅ Background task management
 ✅ Auto Memory for learned preferences
@@ -381,7 +381,7 @@ Before starting Level 3, make sure you're comfortable with these Level 2 concept
 # Exercise 1: Use planning mode
 /plan Implement user authentication system
 
-# Exercise 2: Try permission modes (6 available: default, acceptEdits, plan, auto, dontAsk, bypassPermissions)
+# Exercise 2: Try permission modes (6 available: manual [formerly default], acceptEdits, plan, auto, dontAsk, bypassPermissions)
 claude --permission-mode plan "analyze this codebase"
 claude --permission-mode acceptEdits "refactor the auth module"
 claude --permission-mode auto "implement the feature"
@@ -738,14 +738,15 @@ Once you've completed all milestones:
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
+- https://code.claude.com/docs/en/permission-modes
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.144
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.145
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
 **Maintained by**: Claude How-To Contributors
 **License**: Educational purposes, free to use and adapt
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/luongnv89/claude-howto?style=flat&color=gold)](https://github.com/luongnv89/claude-howto/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/luongnv89/claude-howto?style=flat)](https://github.com/luongnv89/claude-howto/network/members)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.1.160-brightgreen)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.1.206-brightgreen)](CHANGELOG.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-2.1+-purple)](https://code.claude.com)
 
 🌐 **Language / Ngôn ngữ / 语言 / Мова:** [English](README.md) | [Tiếng Việt](vi/README.md) | [中文](zh/README.md) | [Українська](uk/README.md) | [日本語](ja/README.md)
@@ -102,7 +102,7 @@ Run `/lesson-quiz [topic]` after each module. The quiz pinpoints what you missed
 
 - **GitHub stars** from developers who use Claude Code daily
 - **Forks** from teams adapting this guide for their own workflows
-- **Actively maintained** — synced with every Claude Code release (latest: v2.1.160, June 2026)
+- **Actively maintained** — synced with every Claude Code release (latest: v2.1.206, July 2026)
 - **Community-driven** — contributions from developers who share their real-world configurations
 
 [![Star History Chart](https://api.star-history.com/svg?repos=luongnv89/claude-howto&type=Date)](https://star-history.com/#luongnv89/claude-howto&Date)
@@ -201,7 +201,7 @@ cp -r 03-skills/code-review-specialist ~/.claude/skills/
 Yes. MIT licensed, free forever. Use it in personal projects, at work, in your team — no restrictions beyond including the license notice.
 
 **Is this maintained?**
-Actively. The guide is synced with every Claude Code release. Current version: v2.1.160 (June 2026), compatible with Claude Code 2.1+.
+Actively. The guide is synced with every Claude Code release. Current version: v2.1.206 (July 2026), compatible with Claude Code 2.1+.
 
 **How is this different from the official docs?**
 The official docs are a feature reference. This guide is a tutorial with diagrams, production-ready templates, and a progressive learning path. They complement each other — start here to learn, reference the docs when you need specifics.
@@ -210,7 +210,7 @@ The official docs are a feature reference. This guide is a tutorial with diagram
 11-13 hours for the full path. But you'll get immediate value in 15 minutes — just copy a slash command template and try it.
 
 **Can I use this with Claude Sonnet / Haiku / Opus?**
-Yes. All templates work with Claude Sonnet 4.6, Claude Opus 4.8, and Claude Haiku 4.5.
+Yes. All templates work with Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, and Claude Haiku 4.5.
 
 **Can I contribute?**
 Absolutely. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. We welcome new examples, bug fixes, documentation improvements, and community templates.
@@ -559,7 +559,7 @@ Configure hooks in `~/.claude/settings.json`:
 - **Planning Mode** — Create detailed implementation plans before coding
 - **Extended Thinking** — Deep reasoning for complex problems (toggle with `Alt+T` / `Option+T`)
 - **Background Tasks** — Run long operations without blocking
-- **Permission Modes** — `default`, `acceptEdits`, `plan`, `dontAsk`, `bypassPermissions`
+- **Permission Modes** — `manual` (formerly `default`; `default` still accepted), `acceptEdits`, `plan`, `dontAsk`, `bypassPermissions`
 - **Headless Mode** — Run Claude Code in CI/CD: `claude -p "Run tests and generate report"`
 - **Session Management** — `/resume`, `/rename`, `/fork`, `claude -c`, `claude -r`
 - **Configuration** — Customize behavior in `~/.claude/settings.json`
@@ -871,12 +871,13 @@ MIT License - see [LICENSE](LICENSE). Free to use, modify, and distribute. The o
 
 ---
 
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/changelog
+- https://code.claude.com/docs/en/permission-modes
 - https://platform.claude.com/docs/en/about-claude/models/overview
 - https://github.com/anthropics/claude-code/releases
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.154
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/claude_concepts_guide.md
+++ b/claude_concepts_guide.md
@@ -1314,7 +1314,7 @@ Claude Code now includes 5 bundled skills available out of the box:
 
 | Skill | Command | Purpose |
 |-------|---------|---------|
-| **Code Review** | `/code-review` | Review the current diff for correctness bugs at a chosen effort level (renamed from `/simplify` in v2.1.146) |
+| **Code Review** | `/code-review` | Review the current diff for correctness bugs at a chosen effort level. A distinct skill from `/simplify` (quality/reuse cleanups), which was split back out in v2.1.154 |
 | **Batch** | `/batch` | Run operations across multiple files or items |
 | **Debug** | `/debug` | Systematic debugging of issues with root cause analysis |
 | **Loop** | `/loop` | Schedule recurring tasks on a timer |
@@ -3014,7 +3014,7 @@ Control what Claude can do.
 
 | Mode | Description | Use Case |
 |------|-------------|----------|
-| **default** | Standard permissions with prompts for sensitive actions | General development |
+| **manual** | Standard permissions with prompts for sensitive actions (renamed from `default` in v2.1.200; `default` still works as an alias) | General development |
 | **acceptEdits** | Automatically accept file edits without confirmation | Trusted editing workflows |
 | **plan** | Analysis and planning only, no file modifications | Code review, architecture planning |
 | **auto** | Automatically approve safe actions, prompt only for risky ones | Balanced autonomy with safety |
@@ -3148,14 +3148,16 @@ Claude Code supports the following models with adaptive reasoning effort:
 - [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook)
 
 ---
-**Last Updated**: June 15, 2026
-**Claude Code Version**: 2.1.176
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/hooks
 - https://code.claude.com/docs/en/model-config
+- https://code.claude.com/docs/en/permission-modes
+- https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/changelog#2-1-172
 - https://platform.claude.com/docs/en/about-claude/models/overview
 - https://www.anthropic.com/news/claude-opus-4-8
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.154
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5

--- a/resources.md
+++ b/resources.md
@@ -239,7 +239,7 @@ These steps capture the core recommendations for smooth workflows with Claude Co
 | **Web Sessions** | Access Claude Code through browser-based interfaces for remote development | [CLI Reference](10-cli/) |
 | **Desktop App** | Native desktop application for Claude Code with enhanced UI | [Claude Code Docs](https://code.claude.com/docs/en/desktop) |
 | **Extended Thinking** | Deep reasoning toggle via `Alt+T`/`Option+T` or `MAX_THINKING_TOKENS` env var | [Advanced Features](09-advanced-features/) |
-| **Permission Modes** | Fine-grained control: default, acceptEdits, plan, auto, dontAsk, bypassPermissions | [Advanced Features](09-advanced-features/) |
+| **Permission Modes** | Fine-grained control: manual (formerly default), acceptEdits, plan, auto, dontAsk, bypassPermissions | [Advanced Features](09-advanced-features/) |
 | **7-Tier Memory** | Managed Policy, Project, Project Rules, User, User Rules, Local, Auto Memory | [Memory Guide](02-memory/) |
 | **Hook Events** | 29 events: PreToolUse, PostToolUse, PostToolUseFailure, Stop, StopFailure, SubagentStart, SubagentStop, Notification, Elicitation, and more | [Hooks Guide](06-hooks/) |
 | **Agent Teams** | Coordinate multiple agents working together on complex tasks | [Subagents Guide](04-subagents/) |
@@ -252,12 +252,13 @@ These steps capture the core recommendations for smooth workflows with Claude Co
 | **/run, /verify, /run-skill-generator** | Bundled skills to launch your project, confirm a fix works, and generate per-project run/verify skills (v2.1.145+) | [Skills Guide](03-skills/) |
 
 ---
-**Last Updated**: June 2, 2026
-**Claude Code Version**: 2.1.160
+**Last Updated**: July 11, 2026
+**Claude Code Version**: 2.1.206
 **Sources**:
 - https://code.claude.com/docs/en/overview
 - https://code.claude.com/docs/en/changelog
 - https://code.claude.com/docs/en/agent-view
+- https://code.claude.com/docs/en/permission-modes
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.144
 - https://github.com/anthropics/claude-code/releases/tag/v2.1.145
-**Compatible Models**: Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5
+**Compatible Models**: Claude Sonnet 5, Claude Sonnet 4.6, Claude Opus 4.8, Claude Haiku 4.5


### PR DESCRIPTION
Type: docs

## Summary

Syncs the tutorial to **Claude Code v2.1.206** (delta from the prior baseline v2.1.195). Generated from `update-plan-2026-07-11.md` via the docs-sync workflow: research → inventory → classify → plan → execute.

The v2.1.196→v2.1.206 delta is 11 releases, mostly bug fixes (excluded). The doc-relevant surface is small: one genuinely-misleading item, a few stale claims, and additive new-feature coverage.

## Commits

**1. `docs: correct stale content` — P0/P1/P2 fixes**
- **P0**: `04-subagents` no longer walks users through the `/agents` creation **wizard** (removed in v2.1.198) — points to asking Claude or editing `.claude/agents/` directly. `claude agents` CLI references left intact.
- **P1**: Explore agent inherits the session model (capped at Opus), not Haiku; subagents run in the background by default; default permission mode `default` → **Manual** (v2.1.200, alias still works) across 8 files; README "latest v2.1.160" → v2.1.206.
- **P2**: reconciled the contradictory `/simplify` vs `/code-review` history (distinct current skills).

**2. `docs: add v2.1.206 feature coverage` — P3/P4 additions**
- Skills: `/dataviz`, skill stacking, `${CLAUDE_PROJECT_DIR}`
- CLI: `--append-subagent-system-prompt`, `CLAUDE_ENABLE_STREAM_WATCHDOG`, Sonnet 5 model row, `/model` "Org default"
- MCP: `roots/list`, untrusted-workspace `⏸ Pending approval`
- Hooks: `agent_needs_input`/`agent_completed`, `prompt_id`
- Plugins: marketplace `renames`/`displayName`/`defaultEnabled`
- Checkpoints: "Summarize up to here"

All metadata footers refreshed to **v2.1.206 / July 11, 2026** with Claude Sonnet 5 added to Compatible Models.

## Validation

All pre-commit hooks pass (markdown-lint, cross-references, mermaid — 286 diagrams, link-check — 195 URLs reachable, markdown-rendering, build-epub). 15 files changed.

## Sources

Official docs at `code.claude.com/docs` and the Claude Code CHANGELOG (v2.1.196–v2.1.206), captured 2026-07-11.
