### PR TITLE
fix(lesson-quiz): align memory quiz answers with v2.1.220 README

### DIFF
--- a/.claude/skills/lesson-quiz/references/question-bank.md
+++ b/.claude/skills/lesson-quiz/references/question-bank.md
@@ -92,10 +92,10 @@
 
 ### Q1
 - **Category**: conceptual
-- **Question**: How many levels does the Claude Code memory hierarchy have, and what has the highest priority?
-- **Options**: A) 5 levels, User Memory is highest | B) 7 levels, Managed Policy is highest | C) 3 levels, Project Memory is highest | D) 7 levels, Auto Memory is highest
+- **Question**: How do CLAUDE.md memory files relate to each other, and what has the highest authority?
+- **Options**: A) Higher tiers override lower tiers entirely | B) They are concatenated into context; Managed Policy loads first and cannot be excluded | C) The most recently modified file wins | D) Project Memory has the highest priority
 - **Correct**: B
-- **Explanation**: The hierarchy has 7 levels: Managed Policy > Project Memory > Project Rules > User Memory > User Rules > Local Project Memory > Auto Memory. Managed Policy (set by admins) has the highest priority.
+- **Explanation**: CLAUDE.md files are concatenated into context rather than overriding each other — load order sets position in context, not precedence. Managed Policy (admin-managed) loads first and cannot be excluded by individual settings. Auto memory is a separate mechanism.
 - **Review**: Memory hierarchy section
 
 ### Q2
@@ -109,9 +109,9 @@
 ### Q3
 - **Category**: conceptual
 - **Question**: What is the maximum depth for `@path/to/file` imports in CLAUDE.md?
-- **Options**: A) 3 levels deep | B) 5 levels deep | C) 10 levels deep | D) Unlimited
+- **Options**: A) 3 levels deep | B) 4 levels deep | C) 10 levels deep | D) Unlimited
 - **Correct**: B
-- **Explanation**: The `@import` syntax supports recursive imports up to a maximum depth of 5 to prevent infinite loops.
+- **Explanation**: The `@path` import syntax supports recursive imports up to a maximum depth of 4 hops to prevent infinite loops.
 - **Review**: Import syntax section
 
 ### Q4
@@ -157,9 +157,9 @@
 ### Q9
 - **Category**: conceptual
 - **Question**: Can a lower-priority memory tier override rules from a higher-priority tier?
-- **Options**: A) Yes, the most recent rule always wins | B) No, higher tiers always take precedence | C) Yes, if the lower tier uses the `!important` flag | D) It depends on the rule type
+- **Options**: A) Yes, the most recent rule always wins | B) No — CLAUDE.md files are concatenated into context, not overridden; load order sets position, not precedence | C) Yes, if the lower tier uses the `!important` flag | D) It depends on the rule type
 - **Correct**: B
-- **Explanation**: Memory precedence flows downward from Managed Policy. Lower tiers (like Auto Memory) cannot override higher tiers (like Project Memory).
+- **Explanation**: CLAUDE.md files (user, project, local, rules) are concatenated into context rather than overriding each other — later files appear later in context, not "instead of" earlier ones. Only Managed Policy is special: it loads first and cannot be excluded by individual settings. Auto memory is a separate mechanism, not part of the concatenation order.
 - **Review**: Memory hierarchy section
 
 ### Q10


### PR DESCRIPTION
## Description

Lesson 02 question bank (`.claude/skills/lesson-quiz/references/question-bank.md`) contradicted `02-memory/README.md` in three places. Fixes the quiz so correct answers match the current (v2.1.220) documentation.

## Type of Change
- [x] Bug fix
- [x] Documentation improvement

## Related Issues
Closes #163

## Changes Made
- **Q1**: Reframed from "7-level strict override hierarchy" to the concatenation model — CLAUDE.md files are merged into context, not overridden; Managed Policy still loads first and cannot be excluded.
- **Q3**: `@import` max depth corrected from 5 levels to **4 hops** (README states 4 hops in four places).
- **Q9**: Rewrote answer from "higher tiers always override" to the concatenation model — load order sets position in context, not precedence; Managed Policy is the only special case.

## What to Review
- Answers match `02-memory/README.md` "Memory Hierarchy in Claude Code" and "Import Syntax" sections.
- Quiz still scores correctly after option changes (correct answer letter unchanged in all three questions).

## Files Changed
- `.claude/skills/lesson-quiz/references/question-bank.md`

## Testing
- [x] Verified answers against README v2.1.220 text (`:214`, `:225`, `:254`, `:406` for concatenation; `:186`, `:929`, `:957`, `:1163` for 4-hop depth)
- [ ] Ran pre-commit locally (pre-commit not installed in this environment — CI doc checks will run on this PR)

## Checklist
- [x] Follows project structure and conventions
- [x] Commit message follows conventional commit format
- [ ] No sensitive information included (keys, tokens, credentials)
- [x] No large files (>1MB) added

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, and it's documented below

## Additional Notes

The old answers taught a strict precedence model that v2.1.220 review (#155, #161) replaced with the concatenation model. If upstream semantics are actually strict-precedence, the README (not the quiz) should be updated instead — current evidence points to the quiz being stale.