### PR TITLE
docs: Replace broken star-history.com chart with self-hosted mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Run `/lesson-quiz [topic]` after each module. The quiz pinpoints what you missed
 - **Actively maintained** — synced with every Claude Code release (latest: v2.1.220, July 2026)
 - **Community-driven** — contributions from developers who share their real-world configurations
 
-[![Star History Chart](https://api.star-history.com/svg?repos=luongnv89/claude-howto&type=Date)](https://star-history.com/#luongnv89/claude-howto&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=luongnv89/claude-howto&type=date)](https://star-history.dera.page/#luongnv89/claude-howto&type=date)
 
 ---
 

--- a/ja/README.md
+++ b/ja/README.md
@@ -109,7 +109,7 @@ Claude Code の力の 90% を眠らせたままで、しかも自分が何を知
 - **積極的にメンテナンス**：Claude Code のリリースに同期（最新は v2.1.119、2026 年 4 月）
 - **コミュニティ駆動**：実際の運用設定を共有する開発者からのコントリビュート
 
-[![Star History Chart](https://api.star-history.com/svg?repos=luongnv89/claude-howto&type=Date)](https://star-history.com/#luongnv89/claude-howto&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=luongnv89/claude-howto&type=date)](https://star-history.dera.page/#luongnv89/claude-howto&type=date)
 
 ---
 

--- a/zh/README.md
+++ b/zh/README.md
@@ -103,7 +103,7 @@
 - **持续维护中**，会与每次 Claude Code 发布保持同步（最新版本：v2.1.112，2026 年 4 月）
 - **社区驱动**，贡献者会分享他们在真实工作中的配置和经验
 
-[![Star History Chart](https://api.star-history.com/svg?repos=luongnv89/claude-howto&type=Date)](https://star-history.com/#luongnv89/claude-howto&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=luongnv89/claude-howto&type=date)](https://star-history.dera.page/#luongnv89/claude-howto&type=date)
 
 ---
 


### PR DESCRIPTION
The current star history chart is broken because the upstream star-history.com chart depends on GitHub stargazer API, which is no longer returning data. This change points the chart at our self-hosted mirror (star-history.dera.page), which uses an alternative data source and needs no API token.