### PR TITLE
feat: add Chinese (zh) language support and fix Windows encoding issues

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp"],
+      "env": {}
+    }
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
       - id: vietnamese-cross-references
         name: vietnamese-cross-references
         language: system
-        entry: python scripts/check_cross_references.py --lang vi
+        entry: python scripts/check_cross_references.py
         pass_filenames: false
         files: ^vi/.*\.md$
 
@@ -142,3 +142,44 @@ repos:
         entry: uv run scripts/build_epub.py --lang vi
         pass_filenames: false
         files: ^(vi/.*\.md|scripts/build_epub\.py)$
+
+  # Chinese documentation checks
+  - repo: local
+    hooks:
+      - id: chinese-markdown-lint
+        name: chinese-markdown-lint
+        language: node
+        entry: markdownlint
+        args: ['--ignore', 'node_modules', '--ignore', '.venv', '--config', '.markdownlint.json']
+        files: ^zh/.*\.md$
+        additional_dependencies: ['markdownlint-cli']
+
+      - id: chinese-cross-references
+        name: chinese-cross-references
+        language: system
+        entry: python scripts/check_cross_references.py
+        pass_filenames: false
+        files: ^zh/.*\.md$
+
+      - id: chinese-mermaid
+        name: chinese-mermaid-syntax
+        language: system
+        entry: python scripts/check_mermaid.py
+        pass_filenames: false
+        files: ^zh/.*\.md$
+        verbose: true
+
+      - id: chinese-link-check
+        name: chinese-link-check
+        language: system
+        entry: python scripts/check_links.py
+        pass_filenames: false
+        files: ^zh/.*\.md$
+        verbose: true
+
+      - id: chinese-build-epub
+        name: chinese-build-epub
+        language: system
+        entry: uv run scripts/build_epub.py --lang zh
+        pass_filenames: false
+        files: ^(zh/.*\.md|scripts/build_epub\.py)$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Claude How To is a tutorial repository for Claude Code features. This is **documentation-as-code** — the primary output is markdown files organized into numbered learning modules, not an executable application.
 
-**Architecture**: Each module (01-10) covers a specific Claude Code feature with copy-paste templates, Mermaid diagrams, and examples. The build system validates documentation quality and generates an EPUB ebook.
+**Architecture**: Each module (01-10) covers a specific Claude Code feature with copy-paste templates, Mermaid diagrams, and examples. The build system validates documentation quality and generates an EPUB ebook. Translations exist under `zh/` (Chinese) and `vi/` (Vietnamese) with their own pre-commit hooks and EPUB builds.
 
 ## Common Commands
 
 ### Pre-commit Quality Checks
 
-All documentation must pass four quality checks before commits (these run automatically via pre-commit hooks):
+All documentation must pass five quality checks before commits (these run automatically via pre-commit hooks):
 
 ```bash
 # Install pre-commit hooks (runs on every commit)
@@ -22,12 +22,14 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-The four checks are:
+The five doc quality checks are:
 1. **markdown-lint** — Markdown structure and formatting via `markdownlint`
 2. **cross-references** — Internal links, anchors, code fence syntax (Python script)
 3. **mermaid-syntax** — Validates all Mermaid diagrams parse correctly (Python script)
 4. **link-check** — External URLs are reachable (Python script)
 5. **build-epub** — EPUB generates without errors (on `.md` changes)
+
+Additionally, pre-commit runs **shift-left quality gates** (ruff, bandit, mypy) on Python scripts so CI catches issues before they reach the pipeline.
 
 ### Development Environment Setup
 
@@ -108,6 +110,9 @@ uv run scripts/build_epub.py --verbose --output custom-name.epub --max-concurren
 │   ├── check_mermaid.py        # Validates Mermaid syntax
 │   └── tests/                  # Unit tests for scripts
 ├── .pre-commit-config.yaml    # Quality check definitions
+├── resources/               # Logos and images
+├── zh/                      # Chinese translation
+├── vi/                      # Vietnamese translation
 └── README.md               # Main guide (also module index)
 ```
 
@@ -140,7 +145,7 @@ Each numbered folder follows the pattern:
 
 2. **Scripts are utilities, not the product** — The Python scripts in `scripts/` support documentation quality and EPUB generation. The actual content is in the numbered module folders.
 
-3. **Pre-commit is the gatekeeper** — All four quality checks must pass before a PR is accepted. The CI pipeline runs these same checks as a second pass.
+3. **Pre-commit is the gatekeeper** — All five quality checks must pass before a PR is accepted. The CI pipeline runs these same checks as a second pass.
 
 4. **Mermaid rendering requires network** — The EPUB build calls Kroki.io API to render diagrams. Build failures here are typically network issues or invalid Mermaid syntax.
 

--- a/scripts/build_epub.py
+++ b/scripts/build_epub.py
@@ -113,6 +113,8 @@ class EPUBConfig:
     vi_subtitle: str = "Làm chủ Claude Code trong một cuối tuần"
     en_title: str = "Claude Code How-To Guide"
     en_subtitle: str = "Master Claude Code in a Weekend"
+    zh_title: str = "Claude Code 实用指南"
+    zh_subtitle: str = "周末精通 Claude Code"
 
     # Cover Settings
     cover_width: int = 600
@@ -1057,8 +1059,8 @@ def main() -> int:
         "--lang",
         type=str,
         default="en",
-        choices=["en", "vi"],
-        help="Language code: 'en' for English, 'vi' for Vietnamese (default: en)",
+        choices=["en", "vi", "zh"],
+        help="Language code: 'en' for English, 'vi' for Vietnamese, 'zh' for Chinese (default: en)",
     )
     parser.add_argument(
         "--puppeteer-config",
@@ -1079,6 +1081,11 @@ def main() -> int:
         output = args.output or (repo_root / "claude-howto-guide-vi.epub")
         title = EPUBConfig.vi_title
         language = "vi"
+    elif args.lang == "zh":
+        root = repo_root / "zh"
+        output = args.output or (repo_root / "claude-howto-guide-zh.epub")
+        title = EPUBConfig.zh_title
+        language = "zh"
     else:
         root = repo_root
         output = args.output or (repo_root / "claude-howto-guide.epub")

--- a/scripts/check_cross_references.py
+++ b/scripts/check_cross_references.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """Validate cross-references, anchors, and code fences in Markdown files."""
 
 import re
 import sys
 from pathlib import Path
+
+import io
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
 IGNORE_DIRS = {
     ".venv",

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """Check external URLs in Markdown files are reachable."""
 
+import io
 import re
 import sys
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
 IGNORE_DIRS = {
     ".venv",
@@ -88,7 +92,7 @@ def main(strict: bool = False) -> int:
     ]
 
     for file_path in md_files:
-        content = file_path.read_text()
+        content = file_path.read_text(encoding="utf-8")
         for raw_url in URL_RE.findall(content):
             # Strip trailing Markdown/punctuation characters the regex may over-capture
             # from link syntax like [text](https://url/) or **https://url)**

--- a/scripts/check_mermaid.py
+++ b/scripts/check_mermaid.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """Validate Mermaid diagram syntax in Markdown files using mmdc."""
 
+import io
 import json
 import os
 import re
@@ -8,6 +10,8 @@ import shutil
 import subprocess  # nosec B404
 import sys
 import tempfile
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 from pathlib import Path
 
 IGNORE_DIRS = {".venv", "node_modules", ".git", "blog-posts", ".agents"}
@@ -43,7 +47,7 @@ def main() -> int:
 
     try:
         for file_path in md_files:
-            content = file_path.read_text()
+            content = file_path.read_text(encoding="utf-8")
             blocks = re.findall(r"```mermaid\n(.*?)```", content, re.DOTALL)
             for i, block in enumerate(blocks):
                 with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
## Summary

Three commits adding Chinese documentation support and fixing Windows GBK encoding bugs in the quality-check scripts.

### Changes

**New feature — Chinese language support:**
- `build_epub.py`: `--lang zh` option with Chinese title/subtitle
- `CLAUDE.md`: updated to reflect five doc quality checks and translation directories
- `.mcp.json`: added chrome-devtools MCP server configuration

**Pre-commit hooks:**
- Added Chinese documentation pre-commit hooks mirroring the Vietnamese ones
- Fixed unsupported `--lang` argument in Vietnamese cross-refs hook

**Bug fix — Windows GBK encoding:**
- `check_cross_references.py`, `check_mermaid.py`, `check_links.py`:
  - Added `sys.stdout` UTF-8 wrapper to fix `UnicodeEncodeError` when printing emoji
  - Added `encoding="utf-8"` to `Path.read_text()` to fix `UnicodeDecodeError` on UTF-8 files

### Commits
- `6785d7a` feat: add Chinese (zh) language support
- `de89041` feat: add Chinese documentation pre-commit hooks
- `d920cd5` fix: add UTF-8 encoding for stdout and file reads

---
*Created from uongxzh/claude-howto fork*